### PR TITLE
Fix issue with components not adding to distributed sass file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('build-modules', function () {
     .pipe(gulp.dest('./dist'))
 })
 
-gulp.task('copy-source', function () {
-  return gulp.src('./src/patternfly/**/*.scss')
+gulp.task('copy-source', ['build-tmp'], function () {
+  return gulp.src('./tmp/**/*.scss')
     .pipe(gulp.dest('./dist'))
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@patternfly/patternfly-next",
   "description": "Assets, source, tooling, and content for PatternFly Next",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Cliff Pyles",
   "dependencies": {},
   "keywords": [],


### PR DESCRIPTION
The distribution build wasn't adding components and layouts to the sass file. This was caused by an incorrect path being used in the 'copy-source' task in the gulpfile.