### PR TITLE
Add documentation for using PatternFly Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # PatternFly Next
 
-## Setup
+## Install
 
-**PatternFly Next requires Node v8.0.0 or greater**
+- run `npm install @patternfly/patternfly-next`
+
+When you install PatternFly Next, the package includes:
+
+- a single file for the entire compiled library: `node_modules/@patternfly/patternfly-next/dist/patternfly.css`
+- individual files with each component compiled separately: `node_modules/@patternfly/patternfly-next/dist/<ComponentName>/styles.css`
+- a single file for the entire library's source (SASS): `node_modules/@patternfly/patternfly-next/dist/patternfly.scss`
+- individual files for each component's source (SASS): `node_modules/@patternfly/patternfly-next/dist/<ComponentName>/styles.scss`
+
+Any of the files above are meant for use in consuming the library. The recommended
+consumption approach will vary from project to project.
+
+## Development
+
+**PatternFly Next Development requires Node v8.0.0 or greater**
+
+To setup the PatternFly Next development environment:
 
 - clone the project
 - run `npm install` from the project root
@@ -10,20 +26,25 @@
 - run `npm run dev`
 - open your browser to `http://localhost:8000`
 
-## Create a new component
+### Create a new component
 
 - run `pf generate component <name>`
 
 *To view visit http://localhost:8000/components/<name>*
 
-## Create a new pattern
+### Create a new pattern
 
 - run `pf generate pattern <name>`
 
 *To view visit http://localhost:8000/patterns/<name>*
 
-## Create a new demo
+### Create a new demo
 
 - run `pf generate demo <name>`
 
 *To view visit http://localhost:8000/demos/<name>*
+
+## FAQ
+
+[How do I use CSS variables (custom properties) to customize
+the library?](https://pf-next.com/guidelines#variables)

--- a/src/pages/guidelines.md
+++ b/src/pages/guidelines.md
@@ -6,10 +6,6 @@ Every line of code should appear to be written by a single person, no matter the
 
 This set of rules generate some constraints and conventions. If you run into instances where a convention isn’t obvious or a solution could be handled in a few different ways, contact the PatternFly community, have a conversation about how to handle it and update this guidelines when needed.
 
-## Table of content
-
-Place TOC here
-
 ## Separation of UI structure concerns
 
 PatternFly is made out of isolated and modular structures that fall into 3 categories:
@@ -52,7 +48,7 @@ As a general rule create extension to an element with BEM modifiers if it’s a 
 
 Repetition is better than the wrong abstraction.
 
-## Variarbles
+## Variables
 
 PatternFly follows a two-layer theming system where **global variables** always inform **component variables**. Each one of those layers follow a set of very specific rules.
 


### PR DESCRIPTION
This adds documentation on how install PatternFly Next, and it includes a link to the documentation on how to customize with css variables.