### PR TITLE
Change path property in context to pagePath

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -75,7 +75,7 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
         path: node.fields.path,
         component: path.resolve(__dirname, `./src/templates/${node.fields.type}.js`),
         context: {
-          path: node.fields.path,
+          pagePath: node.fields.path,
           type: node.fields.type,
           contentType: node.fields.contentType
         }

--- a/src/templates/documentation.js
+++ b/src/templates/documentation.js
@@ -10,8 +10,8 @@ export default ({data}) => {
 }
 
 export const GetDocumentationContent = graphql`
-  query GetDocumentationContentByPath($path: String!) {
-    markdownRemark(fields: { path: { eq: $path } }) {
+  query GetDocumentationContentByPath($pagePath: String!) {
+    markdownRemark(fields: { path: { eq: $pagePath } }) {
       html
       fields {
         path

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -20,8 +20,8 @@ export default ({ data }) => {
 
 
 export const GetPageContent = graphql`
-  query GetPageContentByPath($path: String!) {
-    markdownRemark(fields: { path: { eq: $path } }) {
+  query GetPageContentByPath($pagePath: String!) {
+    markdownRemark(fields: { path: { eq: $pagePath } }) {
       html
       fields {
         path


### PR DESCRIPTION
When a developer runs `npm run dev` to launch the dev environment, the console is cluttered with warnings. This was caused by a conflicting property that was being used in the config.

To resolve the conflict, the `path` context property was changed to `pagePath`

Issue: https://github.com/patternfly/patternfly-next/issues/64