### PR TITLE
updates spacer variables

### DIFF
--- a/src/patternfly/components/Alert/styles.scss
+++ b/src/patternfly/components/Alert/styles.scss
@@ -1,10 +1,10 @@
 @import "../../patternfly-utilities";
 :root {
-  --pf-c-alert--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-alert--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-alert--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-alert--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-alert--MarginBottom: var(--pf-global--spacer--md);
+  --pf-c-alert--PaddingTop: var(--pf-global--spacer--xxs);
+  --pf-c-alert--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-alert--PaddingBottom: var(--pf-global--spacer--xxs);
+  --pf-c-alert--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-alert--MarginBottom: var(--pf-global--spacer--xs);
   --pf-c-alert--BorderWidth: var(--pf-global--BorderWidth);
   --pf-c-alert__link--FontWeight: var(--pf-global--bold--FontWeight);
   //success alert

--- a/src/patternfly/components/Button/styles.scss
+++ b/src/patternfly/components/Button/styles.scss
@@ -2,10 +2,10 @@
 
 // stylelint-disable
 :root {
-  --pf-c-button--PaddingTop: var(--pf-global--spacer--xs);
-  --pf-c-button--PaddingRight: var(--pf-global--spacer--xxl);
-  --pf-c-button--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-button--PaddingLeft: var(--pf-global--spacer--xxl);
+  --pf-c-button--PaddingTop: var(--pf-global--spacer--xxs);
+  --pf-c-button--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-button--PaddingBottom: var(--pf-global--spacer--xxs);
+  --pf-c-button--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-button--LineHeight: var(--pf-global--sm--LineHeight);
   --pf-c-button--FontWeight: var(--pf-global--semi-bold--FontWeight);
   --pf-c-button--BorderWidth: var(--pf-global--BorderWidth);

--- a/src/patternfly/utilities/bs-variables.scss
+++ b/src/patternfly/utilities/bs-variables.scss
@@ -73,7 +73,7 @@ $grid-breakpoints: (
 //
 // Set the number of columns and specify the width of the gutters.
 
-$grid-gutter-width:           $pf-global--spacer--xxxl !default;
+$grid-gutter-width:           $pf-global--spacer--md !default;
 
 
 // Components

--- a/src/patternfly/utilities/variables.scss
+++ b/src/patternfly/utilities/variables.scss
@@ -78,15 +78,13 @@ $pf-global--left--BoxShadow:   -.2rem 0 .5rem -.2rem rgba($pf-color-black-1000, 
 $pf-global--font-path: "/assets/fonts" !default;
 
 // Spacers
-$pf-global--spacer--xxxs:   pf-size-prem(2px) !default;
-$pf-global--spacer--xxs:    pf-size-prem(4px) !default;
-$pf-global--spacer--xs:     pf-size-prem(8px) !default;
-$pf-global--spacer--sm:     pf-size-prem(12px) !default;
-$pf-global--spacer--md:     pf-size-prem(16px) !default;
-$pf-global--spacer--lg:     pf-size-prem(20px) !default;
-$pf-global--spacer--xl:     pf-size-prem(24px) !default;
-$pf-global--spacer--xxl:    pf-size-prem(28px) !default;
-$pf-global--spacer--xxxl:   pf-size-prem(32px) !default;
+$pf-global--spacer--xxxs:   pf-size-prem(4px) !default;
+$pf-global--spacer--xxs:    pf-size-prem(8px) !default;
+$pf-global--spacer--xs:     pf-size-prem(16px) !default;
+$pf-global--spacer--sm:     pf-size-prem(24px) !default;
+$pf-global--spacer--md:     pf-size-prem(32px) !default;
+$pf-global--spacer--lg:     pf-size-prem(48px) !default;
+$pf-global--spacer--xl:     pf-size-prem(64px) !default;
 
 
 // Grid breakpoints
@@ -193,8 +191,6 @@ $pf-global--lg--LineHeight:         1.8 !default;
   --pf-global--spacer--md:     $pf-global--spacer--md;
   --pf-global--spacer--lg:     $pf-global--spacer--lg;
   --pf-global--spacer--xl:     $pf-global--spacer--xl;
-  --pf-global--spacer--xxl:    $pf-global--spacer--xxl;
-  --pf-global--spacer--xxxl:   $pf-global--spacer--xxxl;
 
   // Grid breakpoints
   --pf-global--breakpoint--xs: $pf-global--breakpoint--xs;


### PR DESCRIPTION
This updates the spacer variables according to [this](https://github.com/patternfly/patternfly-next/issues/59)

I've removed the xxl and xxxl because they are no longer defined. Because of this I've updated the `.bs-variables.scss` to use the new `$pf-global--spacer--md` spacer for the gutter, which fixed a build error.

In the same `.bs-variables.scss` file there are a bunch of other spacers being used but I did not update this. @andresgalante let me know if you'd like me to go in and do that.

I've also updated the alert and button spacers to more closely match the new values. The button spacers match what is called for in the design but the alerts have to be finalized so this may need to be revisited. 