### PR TITLE
Unify split layout with conventions

### DIFF
--- a/src/pages/layouts/split/index.js
+++ b/src/pages/layouts/split/index.js
@@ -1,36 +1,17 @@
 import React from 'react'
 import Documentation from '@siteComponents/Documentation'
 import Example from '@siteComponents/Example'
-import Split, {Docs} from '@layouts/Split'
+import Split, {SplitSecondary, SplitPrimary, Docs} from '@layouts/Split'
+
 
 export default () => {
   return (
     <Documentation docs={Docs} className="is-layout-page">
-      <Example heading="Split Example - Default">
+      <Example heading="Split Example">
         <Split>
-          <div>
-            Secondary content area.
-          </div>
-          <div>
-            <p> Main Content Area. Expands to full-width of the container, minus the width of the secondary content area(s).</p>
-          </div>
-          <div>
-            Secondary content area.
-          </div>
-        </Split>
-      </Example>
-
-      <Example heading="Split Example - Explicit Content Areas">
-        <Split>
-          <div className="pf-l-split__main">
-            <p> Main Content Area. Expands to full-width of the container, minus the width of the secondary content area(s).</p>
-          </div>
-          <div className="pf-l-split__secondary">
-            Secondary content area.
-          </div>
-          <div className="pf-l-split__secondary">
-            Secondary content area.
-          </div>
+          <SplitSecondary></SplitSecondary>
+          <SplitPrimary></SplitPrimary>
+          <SplitSecondary></SplitSecondary>
         </Split>
       </Example>
     </Documentation>

--- a/src/pages/layouts/split/index.js
+++ b/src/pages/layouts/split/index.js
@@ -9,9 +9,15 @@ export default () => {
     <Documentation docs={Docs} className="is-layout-page">
       <Example heading="Split Example">
         <Split>
-          <SplitSecondary></SplitSecondary>
-          <SplitPrimary></SplitPrimary>
-          <SplitSecondary></SplitSecondary>
+          <SplitSecondary>
+            secondary content
+          </SplitSecondary>
+          <SplitPrimary>
+            primary content
+          </SplitPrimary>
+          <SplitSecondary>
+            secondary content
+          </SplitSecondary>
         </Split>
       </Example>
     </Documentation>

--- a/src/patternfly/layouts/Split/docs.md
+++ b/src/patternfly/layouts/Split/docs.md
@@ -4,14 +4,10 @@
 
 Split layouts are meant for use in positioning child elements horizontally, with one of the children being used as primary content area, and the other(s) being used as a secondary content area.
 
-## Notes
-
-- Splits may contain at most 1 main content area.
-- Splits may contain 1 or more secondary content areas, but it is recommended not to exceed 2.
-- Splits are designed to always display the children horizontally, regardless of the device or viewport.
-
 ## Usage
 
-- `.pf-l-split` **Applied to:** `<div>` |  **Outcome:** Established element as a split layout **Required:** Yes **Remarks:** None
-  - `.pf-l-split__main` **Applied to:** `<div>` |  **Outcome:** Explicitly sets a child element as the main content area  **Required:** No **Remarks:** If not applied, the main content area will be the second child.
-  - `.pf-l-split__secondary` **Applied to:** `<div>` | **Outcome:** Explicitly sets a child element as a secondary content area **Required:** No **Remarks:** If not applied, all children except the second child will be secondary content.
+| Class | Usage |
+| -- | -- |
+| `.pf-l-split` | **Outcome:** Initiates the split layout **Required:** Yes |
+| `.pf-l-split__primary` | **Outcome:** Specificies the primary child of the layout, which expands vertically when needed. **Required:** No **Remarks:** If the primary is not explicitly set, the layout will use the second child as the primary item.|
+| `.pf-l-split__secondary` | **Outcome:** Specificies a secondary child of the layout, which accommodates to it's content. **Required:** No **Remarks:** A split can have one or more secondary children. If secondary children are not explicitly set, the layout will use all children, except the second child.|

--- a/src/patternfly/layouts/Split/index.js
+++ b/src/patternfly/layouts/Split/index.js
@@ -4,6 +4,22 @@ import './styles.scss'
 
 export const Docs = docs
 
+export const SplitPrimary = ({children}) => {
+  return (
+    <div className="pf-l-split__primary">
+      {children}
+    </div>
+  )
+}
+
+export const SplitSecondary = ({children}) => {
+  return (
+    <div className="pf-l-split__secondary">
+      {children}
+    </div>
+  )
+}
+
 export default ({children, className = ''}) => {
   return (
     <div className={`pf-l-split ${className}`}>

--- a/src/patternfly/layouts/Split/styles.scss
+++ b/src/patternfly/layouts/Split/styles.scss
@@ -6,7 +6,7 @@
   margin: 0;
 
   > :nth-child(2),
-  > .pf-l-split__main {
+  > .pf-l-split__primary {
     flex: 1;
   }
   > .pf-l-split__secondary,


### PR DESCRIPTION
A Split layout is a layout the displays the children horizontally. One of the children is considered the primary and will expand to fill the container as needed.

resolve #75 