### PR TITLE
Move the Stack example content from the workspace css to the example

### DIFF
--- a/src/pages/layouts/stack/index.js
+++ b/src/pages/layouts/stack/index.js
@@ -9,10 +9,13 @@ export default () => {
       <Example heading="Stack Example">
         <Stack>
           <StackSecondary>
+            secondary content
           </StackSecondary>
           <StackPrimary>
+            primary content
           </StackPrimary>
           <StackSecondary>
+            secondary content
           </StackSecondary>
         </Stack>
       </Example>

--- a/src/workspace.scss
+++ b/src/workspace.scss
@@ -150,15 +150,6 @@
     border: 2px dashed #393f44;
     padding: 0.5rem;
   }
-  .pf-l-stack__primary::before {
-    content: "primary content";
-  }
-  .pf-l-stack__secondary::before {
-    content: "secondary content";
-  }
-  .pf-l-bullseye__item::before {
-    content: "content";
-  }
 
   .Preview__body {
     height: 300px;


### PR DESCRIPTION
There was a misunderstanding about where the example content should go. This moves the content from the workspace css, and back into the example.

Involves comment from here: https://github.com/patternfly/patternfly-next/pull/80