### PR TITLE
chore(site/layouts): Move layouts under src/site/layouts

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,68 +1,73 @@
-const path = require('path')
-const fs = require('fs-extra')
-const inflection = require('inflection')
-const StyleLintPlugin = require('stylelint-webpack-plugin')
-const WebpackNotifierPlugin = require('webpack-notifier')
+const path = require('path');
+const fs = require('fs-extra');
+const inflection = require('inflection');
+const StyleLintPlugin = require('stylelint-webpack-plugin');
+const WebpackNotifierPlugin = require('webpack-notifier');
+const glob = require('glob');
 
+const COMPONENTS_PATH = path.resolve(__dirname, './src/patternfly/components');
+const LAYOUTS_PATH = path.resolve(__dirname, './src/patternfly/layouts');
 
-const COMPONENTS_PATH = path.resolve(__dirname, './src/patternfly/components')
-const LAYOUTS_PATH = path.resolve(__dirname, './src/patternfly/layouts')
+const COMPONENT_PATHS = fs
+  .readdirSync(COMPONENTS_PATH)
+  .map(name => path.resolve(COMPONENTS_PATH, `./${name}`));
 
-const COMPONENT_PATHS = fs.readdirSync(
-  COMPONENTS_PATH
-).map(name => path.resolve(COMPONENTS_PATH, `./${name}`))
-
-const LAYOUT_PATHS = fs.readdirSync(
-  LAYOUTS_PATH
-).map(name => path.resolve(LAYOUTS_PATH, `./${name}`))
-
+const LAYOUT_PATHS = fs
+  .readdirSync(LAYOUTS_PATH)
+  .map(name => path.resolve(LAYOUTS_PATH, `./${name}`));
 
 exports.onCreateNode = ({ node, boundActionCreators }) => {
-  const { createNodeField } = boundActionCreators
-  const PAGES_BASE_DIR = path.resolve(__dirname, './src/site/pages')
-  const PATTERNS_BASE_DIR = path.resolve(__dirname, './src/patternfly/patterns')
-  const COMPONENTS_BASE_DIR = path.resolve(__dirname, './src/patternfly/components')
-  const LAYOUTS_BASE_DIR = path.resolve(__dirname, './src/patternfly/layouts')
-  const isMarkdown = (node.internal.type === 'MarkdownRemark')
+  const { createNodeField } = boundActionCreators;
+  const PAGES_BASE_DIR = path.resolve(__dirname, './src/site/pages');
+  const PATTERNS_BASE_DIR = path.resolve(
+    __dirname,
+    './src/patternfly/patterns'
+  );
+  const COMPONENTS_BASE_DIR = path.resolve(
+    __dirname,
+    './src/patternfly/components'
+  );
+  const LAYOUTS_BASE_DIR = path.resolve(__dirname, './src/patternfly/layouts');
+  const isMarkdown = node.internal.type === 'MarkdownRemark';
 
   if (isMarkdown) {
-    const isPage = (node.fileAbsolutePath.includes(PAGES_BASE_DIR))
-    const isPattern = (node.fileAbsolutePath.includes(PATTERNS_BASE_DIR))
-    const isComponent = (node.fileAbsolutePath.includes(COMPONENTS_BASE_DIR))
-    const isLayout = (node.fileAbsolutePath.includes(LAYOUTS_BASE_DIR))
+    const isPage = node.fileAbsolutePath.includes(PAGES_BASE_DIR);
+    const isPattern = node.fileAbsolutePath.includes(PATTERNS_BASE_DIR);
+    const isComponent = node.fileAbsolutePath.includes(COMPONENTS_BASE_DIR);
+    const isLayout = node.fileAbsolutePath.includes(LAYOUTS_BASE_DIR);
     if (isPage) {
-      let relativePath = path.relative(PAGES_BASE_DIR, node.fileAbsolutePath)
-      let pagePath = `/${relativePath}`.replace(/\.md$/, '')
-      createNodeField({ node, name: 'path', value: pagePath })
-      createNodeField({ node, name: 'type', value: 'page' })
-      createNodeField({ node, name: 'contentType', value: 'page' })
+      let relativePath = path.relative(PAGES_BASE_DIR, node.fileAbsolutePath);
+      let pagePath = `/${relativePath}`.replace(/\.md$/, '');
+      createNodeField({ node, name: 'path', value: pagePath });
+      createNodeField({ node, name: 'type', value: 'page' });
+      createNodeField({ node, name: 'contentType', value: 'page' });
     } else if (isComponent) {
-      let componentName = path.basename(path.dirname(node.fileAbsolutePath))
-      let componentSlug = inflection.dasherize(componentName)
-      let pagePath = `/components/${componentName}/docs`
-      createNodeField({ node, name: 'path', value: pagePath })
-      createNodeField({ node, name: 'type', value: 'documentation' })
-      createNodeField({ node, name: 'contentType', value: 'component' })
+      let componentName = path.basename(path.dirname(node.fileAbsolutePath));
+      let componentSlug = inflection.dasherize(componentName);
+      let pagePath = `/components/${componentName}/docs`;
+      createNodeField({ node, name: 'path', value: pagePath });
+      createNodeField({ node, name: 'type', value: 'documentation' });
+      createNodeField({ node, name: 'contentType', value: 'component' });
     } else if (isPattern) {
-      let patternName = path.basename(path.dirname(node.fileAbsolutePath))
-      let patternSlug = inflection.dasherize(patternName)
-      let pagePath = `/patterns/${patternName}/docs`
-      createNodeField({ node, name: 'path', value: pagePath })
-      createNodeField({ node, name: 'type', value: 'documentation' })
-      createNodeField({ node, name: 'contentType', value: 'pattern' })
-    }  else if (isLayout) {
-      let layoutName = path.basename(path.dirname(node.fileAbsolutePath))
-      let layoutSlug = inflection.dasherize(layoutName)
-      let pagePath = `/layouts/${layoutName}/docs`
-      createNodeField({ node, name: 'path', value: pagePath })
-      createNodeField({ node, name: 'type', value: 'documentation' })
-      createNodeField({ node, name: 'contentType', value: 'layout' })
+      let patternName = path.basename(path.dirname(node.fileAbsolutePath));
+      let patternSlug = inflection.dasherize(patternName);
+      let pagePath = `/patterns/${patternName}/docs`;
+      createNodeField({ node, name: 'path', value: pagePath });
+      createNodeField({ node, name: 'type', value: 'documentation' });
+      createNodeField({ node, name: 'contentType', value: 'pattern' });
+    } else if (isLayout) {
+      let layoutName = path.basename(path.dirname(node.fileAbsolutePath));
+      let layoutSlug = inflection.dasherize(layoutName);
+      let pagePath = `/layouts/${layoutName}/docs`;
+      createNodeField({ node, name: 'path', value: pagePath });
+      createNodeField({ node, name: 'type', value: 'documentation' });
+      createNodeField({ node, name: 'contentType', value: 'layout' });
     }
   }
-}
+};
 
 exports.createPages = ({ boundActionCreators, graphql }) => {
-  const { createPage } = boundActionCreators
+  const { createPage } = boundActionCreators;
 
   return graphql(`
     {
@@ -80,91 +85,117 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
     }
   `).then(result => {
     if (result.errors) {
-      return Promise.reject(result.errors)
+      return Promise.reject(result.errors);
     }
 
     return result.data.allMarkdownRemark.edges.forEach(({ node }) => {
       createPage({
         path: node.fields.path,
-        component: path.resolve(__dirname, `./src/site/templates/${node.fields.type}.js`),
+        component: path.resolve(
+          __dirname,
+          `./src/site/templates/${node.fields.type}.js`
+        ),
         context: {
           pagePath: node.fields.path,
           type: node.fields.type,
           contentType: node.fields.contentType
         }
-      })
-    })
-  })
-}
+      });
+    });
+  });
+};
+
+exports.createLayouts = ({
+  graphql,
+  store,
+  boundActionCreators: { createLayout, deleteLayout }
+}) => {
+  return new Promise(resolve => {
+    const layouts = glob(
+      path.resolve(__dirname, 'src/site/layouts/**.js'),
+      (err, matches) => {
+        matches.forEach(layoutFilePath => {
+          const id = path.parse(layoutFilePath).name;
+          deleteLayout(id);
+          createLayout({
+            id,
+            component: layoutFilePath
+          });
+        });
+        resolve();
+      }
+    );
+  });
+};
 
 exports.onCreatePage = async ({ page, boundActionCreators }) => {
-  const { createPage, createNodeField } = boundActionCreators
-  const CATEGORY_PAGE_REGEX = /^\/(components|patterns|layouts)\/$/
-  const CATEGORY_CHILD_PAGE_REGEX = /^\/(components|patterns|layouts)\/([A-Za-z0-9_-]+)/
-  const DEMO_PAGE_REGEX = /^\/(demos)\/([A-Za-z0-9_-]+)/
+  const { createPage, createNodeField } = boundActionCreators;
+  const CATEGORY_PAGE_REGEX = /^\/(components|patterns|layouts)\/$/;
+  const CATEGORY_CHILD_PAGE_REGEX = /^\/(components|patterns|layouts)\/([A-Za-z0-9_-]+)/;
+  const DEMO_PAGE_REGEX = /^\/(demos)\/([A-Za-z0-9_-]+)/;
   return new Promise((resolve, reject) => {
-    let isCategoryPage = page.path.match(CATEGORY_PAGE_REGEX)
-    let isCategoryChildPage = page.path.match(CATEGORY_CHILD_PAGE_REGEX)
-    let isDemoPage = page.path.match(DEMO_PAGE_REGEX)
+    let isCategoryPage = page.path.match(CATEGORY_PAGE_REGEX);
+    let isCategoryChildPage = page.path.match(CATEGORY_CHILD_PAGE_REGEX);
+    let isDemoPage = page.path.match(DEMO_PAGE_REGEX);
 
-    page.context.type = 'page'
-    page.context.category = 'page'
-    page.context.slug = ''
-    page.context.name = ''
-    page.context.title = ''
+    page.context.type = 'page';
+    page.context.category = 'page';
+    page.context.slug = '';
+    page.context.name = '';
+    page.context.title = '';
 
     if (isCategoryPage) {
-      page.context.type = 'category'
-      page.context.category = page.path.match(CATEGORY_PAGE_REGEX)[1]
+      page.context.type = 'category';
+      page.context.category = page.path.match(CATEGORY_PAGE_REGEX)[1];
     } else if (isCategoryChildPage) {
-      let pageCategory = page.path.match(CATEGORY_CHILD_PAGE_REGEX)[1]
-      let pageSlug = page.path.match(CATEGORY_CHILD_PAGE_REGEX)[2]
-      let pageName = pageSlug.replace('-', ' ')
-      let pageTitle = inflection.titleize(pageName)
-      page.context.type = inflection.singularize(pageCategory)
-      page.context.category = pageCategory
-      page.context.slug = pageSlug
-      page.context.name = pageName
-      page.context.title = pageTitle
+      let pageCategory = page.path.match(CATEGORY_CHILD_PAGE_REGEX)[1];
+      let pageSlug = page.path.match(CATEGORY_CHILD_PAGE_REGEX)[2];
+      let pageName = pageSlug.replace('-', ' ');
+      let pageTitle = inflection.titleize(pageName);
+      page.context.type = inflection.singularize(pageCategory);
+      page.context.category = pageCategory;
+      page.context.slug = pageSlug;
+      page.context.name = pageName;
+      page.context.title = pageTitle;
     } else if (isDemoPage) {
-      let pageCategory = page.path.match(DEMO_PAGE_REGEX)[1]
-      let pageSlug = page.path.match(DEMO_PAGE_REGEX)[2]
-      let pageName = pageSlug.replace('-', ' ')
-      let pageTitle = inflection.titleize(pageName)
-      page.context.type = inflection.singularize(pageCategory)
-      page.context.category = pageCategory
-      page.context.slug = pageSlug
-      page.context.name = pageName
-      page.context.title = pageTitle
+      let pageCategory = page.path.match(DEMO_PAGE_REGEX)[1];
+      let pageSlug = page.path.match(DEMO_PAGE_REGEX)[2];
+      let pageName = pageSlug.replace('-', ' ');
+      let pageTitle = inflection.titleize(pageName);
+      page.context.type = inflection.singularize(pageCategory);
+      page.context.category = pageCategory;
+      page.context.slug = pageSlug;
+      page.context.name = pageName;
+      page.context.title = pageTitle;
 
-      page.layout = 'demo'
+      page.layout = 'demo';
     }
 
-    createPage(page)
+    createPage(page);
 
-    resolve()
-  })
-}
+    resolve();
+  });
+};
 
 exports.modifyWebpackConfig = ({ config, stage }) => {
   config.loader('markdown-loader', function(current) {
-    current.test = /\.md$/
-    current.loader = 'html-loader!markdown-loader'
-    return current
-  })
+    current.test = /\.md$/;
+    current.loader = 'html-loader!markdown-loader';
+    return current;
+  });
   config.loader('html-loader', function(current) {
-    current.test = /\.html$/
-    current.loader = 'html-loader'
-    return current
-  })
+    current.test = /\.html$/;
+    current.loader = 'html-loader';
+    return current;
+  });
   config.loader('handlebars-loader', function(current) {
-    current.test = /\.hbs$/
-    current.loader = 'handlebars-loader'
+    current.test = /\.hbs$/;
+    current.loader = 'handlebars-loader';
     current.query = {
-      partialDirs: COMPONENT_PATHS.concat(LAYOUT_PATHS),
-    }
-    return current
-  })
+      partialDirs: COMPONENT_PATHS.concat(LAYOUT_PATHS)
+    };
+    return current;
+  });
 
   config.merge({
     resolve: {
@@ -188,6 +219,6 @@ exports.modifyWebpackConfig = ({ config, stage }) => {
         skipFirstNotification: true
       })
     ]
-  })
-  return config
-}
+  });
+  return config;
+};

--- a/plugins/gatsby-plugin-page-creator/gatsby-node.js
+++ b/plugins/gatsby-plugin-page-creator/gatsby-node.js
@@ -15,63 +15,75 @@ const validatePath = require(`./validate-path`);
 // algorithm is glob /pages directory for js/jsx/cjsx files *not*
 // underscored. Then create url w/ our path algorithm *unless* user
 // takes control of that page component in gatsby-node.
-exports.createPagesStatefully = async ({ store, boundActionCreators, reporter }, pluginOptions, doneCb) => {
-    const { createPage, deletePage } = boundActionCreators;
-    const program = store.getState().program;
-    const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`);
+exports.createPagesStatefully = async (
+  { store, boundActionCreators, reporter },
+  pluginOptions,
+  doneCb
+) => {
+  const { createPage, deletePage } = boundActionCreators;
+  const program = store.getState().program;
+  const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`);
 
-    if (!(pluginOptions && pluginOptions.path)) {
-        reporter.panic(`
+  if (!(pluginOptions && pluginOptions.path)) {
+    reporter.panic(`
       "path" is a required option for gatsby-plugin-page-creator
       See docs here - https://www.gatsbyjs.org/packages/gatsby-plugin-page-creator/
       `);
-    }
+  }
 
-    // Validate that the path exists.
-    if (!fs.existsSync(pluginOptions.path)) {
-        reporter.panic(`
+  // Validate that the path exists.
+  if (!fs.existsSync(pluginOptions.path)) {
+    reporter.panic(`
       The path passed to gatsby-plugin-page-creator does not exist on your file system:
       ${pluginOptions.path}
       Please pick a path to an existing directory.
       `);
-    }
+  }
 
-    const pagesDirectory = systemPath.posix.join(pluginOptions.path);
-    const pagesGlob = `${pagesDirectory}/**/*.{${exts}}`;
+  const pagesDirectory = systemPath.posix.join(pluginOptions.path);
+  const pagesGlob = `${pagesDirectory}/**/*.{${exts}}`;
 
-    // Get initial list of files.
-    let files = await glob(pagesGlob);
-    files.forEach(file => _createPage(file, pagesDirectory, createPage));
+  // Get initial list of files.
+  let files = await glob(pagesGlob);
+  files.forEach(file => _createPage(file, pagesDirectory, createPage));
 
-    // Listen for new component pages to be added or removed.
-    chokidar.watch(pagesGlob).on(`add`, path => {
-        if (!_.includes(files, path)) {
-            _createPage(path, pagesDirectory, createPage);
-            files.push(path);
-        }
-    }).on(`unlink`, path => {
-        // Delete the page for the now deleted component.
-        store.getState().pages.filter(p => p.component === path).forEach(page => {
-            deletePage({
-                path: createPath(pagesDirectory, path),
-                component: path
-            });
-            files = files.filter(f => f !== path);
+  // Listen for new component pages to be added or removed.
+  chokidar
+    .watch(pagesGlob)
+    .on(`add`, path => {
+      if (!_.includes(files, path)) {
+        _createPage(path, pagesDirectory, createPage);
+        files.push(path);
+      }
+    })
+    .on(`unlink`, path => {
+      // Delete the page for the now deleted component.
+      store
+        .getState()
+        .pages.filter(p => p.component === path)
+        .forEach(page => {
+          deletePage({
+            path: createPath(pagesDirectory, path),
+            component: path
+          });
+          files = files.filter(f => f !== path);
         });
-    }).on(`ready`, () => doneCb());
+    })
+    .on(`ready`, () => doneCb());
 };
 const _createPage = (filePath, pagesDirectory, createPage) => {
-    // Filter out special components that shouldn't be made into
-    // pages.
-    if (!validatePath(systemPath.posix.relative(pagesDirectory, filePath))) {
-        return;
-    }
+  // Filter out special components that shouldn't be made into
+  // pages.
+  if (!validatePath(systemPath.posix.relative(pagesDirectory, filePath))) {
+    return;
+  }
 
-    // Create page object
-    const page = {
-        path: createPath(pagesDirectory, filePath),
-        component: filePath
-
-        // Add page
-    };createPage(page);
+  // Create page object
+  const page = {
+    path: createPath(pagesDirectory, filePath),
+    component: filePath,
+    layout: 'index'
+  };
+  // Add page
+  createPage(page);
 };

--- a/src/layouts/demo.js
+++ b/src/layouts/demo.js
@@ -1,9 +1,0 @@
-import React from 'react'
-
-export default ({ children }) => {
-  return (
-    <div>
-      {children()}
-    </div>
-  )
-}

--- a/src/site/layouts/demo.js
+++ b/src/site/layouts/demo.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default ({ children }) => {
+  return <div>{children()}</div>;
+};

--- a/src/site/layouts/index.js
+++ b/src/site/layouts/index.js
@@ -1,27 +1,29 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
-import Link from 'gatsby-link'
-import Navigation from '@siteComponents/Navigation'
+import React from 'react';
+import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
+import Link from 'gatsby-link';
+import Navigation from '@siteComponents/Navigation';
 
-import 'prismjs/themes/prism-coy.css'
-import '../patternfly/patternfly.scss'
-import '../site/workspace.scss'
+import 'prismjs/themes/prism-coy.css';
+import '../../patternfly/patternfly.scss';
+import '../workspace.scss';
 
 export default ({ children, data }) => {
   let allPages = data.allSitePage.edges.reduce((accum, edge) => {
-    let type = edge.node.context.type || 'page'
+    let type = edge.node.context.type || 'page';
 
     if (!accum[type]) {
-      accum[type] = []
+      accum[type] = [];
     }
 
-    if (edge.node.context.name == null ) {
-      let bestGuessName = edge.node.path.match(/\/([A-Za-z0-9_-]+)$/g)[0].substring(1)
-      bestGuessName = bestGuessName.replace(/-/g, ' ')
+    if (edge.node.context.name == null) {
+      let bestGuessName = edge.node.path
+        .match(/\/([A-Za-z0-9_-]+)$/g)[0]
+        .substring(1);
+      bestGuessName = bestGuessName.replace(/-/g, ' ');
 
-      if(bestGuessName !== 'docs') {
-        edge.node.context.name = bestGuessName
+      if (bestGuessName !== 'docs') {
+        edge.node.context.name = bestGuessName;
       }
     }
 
@@ -29,21 +31,21 @@ export default ({ children, data }) => {
       path: edge.node.path,
       text: edge.node.context.name,
       className: `is-${type}`
-    })
-    return accum
-  }, {})
+    });
+    return accum;
+  }, {});
 
   return (
     <div className="layout">
       <Helmet>
         <title>PF Next</title>
-        <script defer src="//use.fontawesome.com/releases/v5.0.8/js/all.js"></script>
+        <script defer src="//use.fontawesome.com/releases/v5.0.8/js/all.js" />
       </Helmet>
       <header className="layout__header">
         <h1>
           <Link to="/">PF Next</Link>
         </h1>
-        <Navigation links={allPages.page} isHorizontal={true}/>
+        <Navigation links={allPages.page} isHorizontal={true} />
       </header>
       <main className="layout__main">
         <div className="layout__sidebar">
@@ -64,20 +66,16 @@ export default ({ children, data }) => {
             <Navigation links={allPages.demo} />
           </div>
         </div>
-        <div className="layout__content">
-          {children()}
-        </div>
+        <div className="layout__content">{children()}</div>
       </main>
-      <footer className="layout__footer"></footer>
+      <footer className="layout__footer" />
     </div>
-  )
-}
+  );
+};
 
 export const indexPageQuery = graphql`
-  query IndexPageQuery {
-    allSitePage(
-      filter: { path: { regex: "/^((?!(404)).)*$/" } }
-    ) {
+  query IndexOtherPageQuery {
+    allSitePage(filter: { path: { regex: "/^((?!(404)).)*$/" } }) {
       edges {
         node {
           path
@@ -92,4 +90,4 @@ export const indexPageQuery = graphql`
       }
     }
   }
-`
+`;


### PR DESCRIPTION
Use gatsby's `createLayouts` hook to create layouts under site/layouts.  Added a default layout for the page creator plugin we are using. Otherwise, it defaults to the old path.

Extension of https://github.com/patternfly/patternfly-next/pull/138