### PR TITLE
feat(Backdrop): Implements backdrop (#255)

### DIFF
--- a/src/patternfly/components/Backdrop/backdrop.hbs
+++ b/src/patternfly/components/Backdrop/backdrop.hbs
@@ -1,0 +1,3 @@
+<div class="pf-c-backdrop {{ pf-c-backdrop--modifier }}">
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Backdrop/docs/code.md
+++ b/src/patternfly/components/Backdrop/docs/code.md
@@ -1,0 +1,9 @@
+## Overview
+
+This component puts a backdrop over the entire viewport.
+
+## Usage
+
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-c-backdrop` | `<div>` |  A backdrop is added over the viewport |

--- a/src/patternfly/components/Backdrop/docs/design.md
+++ b/src/patternfly/components/Backdrop/docs/design.md
@@ -1,0 +1,1 @@
+## design md file

--- a/src/patternfly/components/Backdrop/examples/backdrop-example.hbs
+++ b/src/patternfly/components/Backdrop/examples/backdrop-example.hbs
@@ -1,0 +1,2 @@
+{{#> backdrop}}
+{{/backdrop}}

--- a/src/patternfly/components/Backdrop/examples/index.js
+++ b/src/patternfly/components/Backdrop/examples/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Documentation from '@siteComponents/Documentation';
+import Example from '@siteComponents/Example';
+import docs from '../docs/code.md';
+import BackdropExample from './backdrop-example.hbs';
+import '../styles.scss';
+
+export const Docs = docs;
+
+export default () => {
+  const backdropExample = BackdropExample();
+
+  return (
+    <Documentation docs={Docs}>
+      <Example heading="Backdrop Example">{backdropExample}</Example>
+    </Documentation>
+  );
+};

--- a/src/patternfly/components/Backdrop/styles.scss
+++ b/src/patternfly/components/Backdrop/styles.scss
@@ -2,7 +2,8 @@
 
 :root {
   --pf-c-backdrop--ZIndex: var(--pf-global--ZIndex--xl);
-  --pf-c-backdrop--Color: rgba(0, 0, 0, .5);
+  // The color of the backdrop is pure black but at 42% transparency.
+  --pf-c-backdrop--Color: rgba(0, 0, 0, .42);
   --pf-c-backdrop--BackdropFilter: blur(10px);
 }
 
@@ -15,7 +16,9 @@
   height: 100%;
   background-color: var(--pf-c-backdrop--Color);
   // Vendor prefix needed for Safari, but it is not getting added in the autoprefixer right now
-  //-webkit-backdrop-filter: var(--pf-c-backdrop--BackdropFilter);
+  // Stylelint is disabled for one line so that the prefixed line can be included here
+  /* stylelint-disable-next-line */
+  -webkit-backdrop-filter: var(--pf-c-backdrop--BackdropFilter);
   backdrop-filter: var(--pf-c-backdrop--BackdropFilter);
 }
 

--- a/src/patternfly/components/Backdrop/styles.scss
+++ b/src/patternfly/components/Backdrop/styles.scss
@@ -1,0 +1,21 @@
+@import "../../patternfly-utilities";
+
+:root {
+  --pf-c-backdrop--ZIndex: var(--pf-global--ZIndex--xl);
+  --pf-c-backdrop--Color: rgba(0, 0, 0, .5);
+  --pf-c-backdrop--BackdropFilter: blur(10px);
+}
+
+.pf-c-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--pf-c-backdrop--ZIndex);
+  width: 100%;
+  height: 100%;
+  background-color: var(--pf-c-backdrop--Color);
+  // Vendor prefix needed for Safari, but it is not getting added in the autoprefixer right now
+  //-webkit-backdrop-filter: var(--pf-c-backdrop--BackdropFilter);
+  backdrop-filter: var(--pf-c-backdrop--BackdropFilter);
+}
+


### PR DESCRIPTION
Implements the backdrop that will darken and blur the background behind a modal. 
This uses `backdrop-filter`, which has very limited support in browsers. It will gracefully degrade to a dark backdrop without the blur.