### PR TITLE
refactor(component generator): address some erros in the component generator and bring output closer inline with contribution guidelines

### DIFF
--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/docs/code.md
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/docs/code.md
@@ -15,5 +15,5 @@ For example for buttons: Always add a modifier class to add color to the button.
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.class-name-here` | `<tags-here>` |  Outcome and remarks |
+| `.class-name-here` | `<tags-here>` |  Outcome and remarks. |
 | Example: `.btn` | `<button>` |  Initiates a button. Always use it with a modifier class. |

--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/__nameDasherized__-example1.hbs
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/__nameDasherized__-example1.hbs
@@ -1,0 +1,3 @@
+{{moduleHbOpen}}
+  Example 1 Content
+{{moduleHbClose}}

--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/__nameDasherized__-example2.hbs
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/__nameDasherized__-example2.hbs
@@ -1,0 +1,3 @@
+{{moduleHbOpen}}
+  Example 2 Content
+{{moduleHbClose}}

--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/example1.hbs
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/example1.hbs
@@ -1,1 +1,0 @@
-{{moduleHbOpen}}Example 1 Content{{moduleHbClose}}

--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/example2.hbs
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/example2.hbs
@@ -1,1 +1,0 @@
-{{moduleHbOpen}}Example 2 Content{{moduleHbClose}}

--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/index.js
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/index.js
@@ -2,20 +2,20 @@ import React from 'react';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
 import docs from '../docs/code.md';
-import Example1 from './example1.hbs';
-import Example2 from './example2.hbs';
+import {{moduleName}}Example1 from './{{nameDasherized}}-example1.hbs';
+import {{moduleName}}Example2 from './{{nameDasherized}}-example2.hbs';
 import '../styles.scss';
 
 export const Docs = docs;
 
 export default () => {
-  const example1 = Example1();
-  const example2 = Example2();
+  const {{name}}Example1 = {{moduleName}}Example1();
+  const {{name}}Example2 = {{moduleName}}Example2();
 
   return (
     <Documentation docs={Docs}>
-      <Example heading="{{moduleName}} Example 1">{example1}</Example>
-      <Example heading="{{moduleName}} Example 2">{example2}</Example>
+      <Example heading="{{moduleName}} Example 1">{ {{name}}Example1 }</Example>
+      <Example heading="{{moduleName}} Example 2">{ {{name}}Example2 }</Example>
     </Documentation>
   );
 };

--- a/build/blueprints/component/files/src/patternfly/components/__moduleName__/styles.scss
+++ b/build/blueprints/component/files/src/patternfly/components/__moduleName__/styles.scss
@@ -6,26 +6,25 @@
 // The value of component scoped variables is always defined by a global variable:
 :root {
   // Example block variable
-  --{{bemName}}--Color: var(--pf-global--dark--Color);
+  --{{bemName}}--Color: var(--pf-global--Color--dark-100);
 
   // Example element variable
-  --{{bemName}}_title--FontSize: var($pf-global--FontSize--xxl);
+  --{{bemName}}__title--FontSize: var(--pf-global--FontSize--xxl);
 
   // Example modifier variable
   --{{bemName}}--m-danger--BackgroundColor: var(--pf-global--danger-color);
 }
 
 .{{bemName}} {
-  color: var(--{{bemName}}--Color, #292e34);
+  color: var(--{{bemName}}--Color);
 
   // Element
-  &_title {
-    font-size: var(--{{bemName}}_title--FontSize, 2rem);
+  &__title {
+    font-size: var(--{{bemName}}__title--FontSize);
   }
 
   // Modifier
-  &.is-danger {
-    background-color: var(--{{bemName}}--m-danger--BackgroundColor, #c00);
+  &.pf-m-danger {
+    background-color: var(--{{bemName}}--m-danger--BackgroundColor);
   }
 }
-

--- a/build/patternfly-cli/pf.js
+++ b/build/patternfly-cli/pf.js
@@ -56,8 +56,8 @@ program
       bemName: `${prefix}${bemEntity}`,
       moduleName,
       partialBlock: '{{> @partial-block}}',
-      moduleHbOpen: `{{#> ${moduleName}}}`,
-      moduleHbClose: `{{/${moduleName}}}`,
+      moduleHbOpen: `{{#> ${name}}}`,
+      moduleHbClose: `{{/${name}}}`,
       args: blueprintArgs
     };
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/271

@dgutride can you advise re: removing spaces from the output in [index.js](https://github.com/michael-coker/patternfly-next/blob/component-generator-updates/build/blueprints/component/files/src/patternfly/components/__moduleName__/examples/index.js) - in the `return()` block, the spaces in `{ {{name}}Example1 }` and `{ {{name}}Example2 }`?