### PR TITLE
fix(title): fixes leftover -is in title to be -m

### DIFF
--- a/src/patternfly/components/Title/styles.scss
+++ b/src/patternfly/components/Title/styles.scss
@@ -43,7 +43,7 @@
 }
 .pf-c-title {
 
-  &.pf-is {
+  &.pf-m {
 
     &-xxxxl {
       font-size: var(--pf-c-title--m-xxxxl--FontSize);


### PR DESCRIPTION
One leftover `pf-is` in the title styles fixed to be `pf-m`