### PR TITLE
accessibility guide updates

### DIFF
--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -89,7 +89,40 @@ These are guidelines that we have defined for PatternFly.
 
 ## Techniques
 
-The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#contents)   provide examples on how to meet accessibility guidelines. Additionally, as we discover techniques for specific interaction patterns, we'll document them here so that we can be consistent in our approach.
+The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#contents) provide examples on how to meet accessibility guidelines. Any techniques that are adopted as standard within PatternFly for handling specific patterns are included below.
+
+### Labels and Accessible Names
+
+- #### Form Fields
+  - Use explicit linking between `label` and form input elements (e.g. `input`, `textarea`, or `select`) when both elements are present. Aside from providing an accessible name to screen readers, this method also increases the clickable area of the form element by making the label clickable, too. [H44](https://www.w3.org/TR/WCAG20-TECHS/H44.html)
+  - When a `label` element cannot accompany a form input element, then provide the name using `aria-label` [ARIA14](https://www.w3.org/TR/WCAG20-TECHS/H65.html)
+- #### Landmark Roles
+  - Screen reader users can navigate to sections of a page when landmark roles are used. Whenever a landmark role is used more than once, provide a name using `aria-label` to provide context for that landmark [ARIA6](https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html)
+- #### Icons
+  Icons can either be decorative or semantic. Icons are **decorative** if you can remove an icon without affecting the information that is presented on the page. Icons are **semantic** when they provide information that otherwise isn't present, such as indicating status, indicating type of alert message, or replacing text as button labels. When an icon is semantic, the meaning must be provided in alternative ways to the user. The following guidelines should be followed when using icons within PatternFly components.
+  - Add `aria-hidden="true"` for all icons, either to the icon element or a parent element of the icon. This renders the icon as something that assistive devices can ignore.
+  - Additionally, for **semantic** icons:
+      - Add a label for the icon in tooltip text that displays on hover, and also on focus for focusable elements.
+      - For interactive elements like `<a>` and `<button>` where an icon is used as the label instead of text, provide the label on the interactive element using `aria-label`. For example:
+      ```html
+      <button class="..." aria-label="Close Dialog">
+        <i class="..." aria-hidden="true"></i>
+      </button>
+      ```
+      - For non-interactive icons, include `sr-only` text near the icon. Depending on the component, the `sr-only` text might not be a direct sibling to the icon element. For example, in the Alert component, the icon label text adjacent to the message:
+      ```html
+      <div class="pf-c-alert pf-m-success" aria-label="Success Notification">
+        <div aria-hidden="true" class="pf-c-alert__icon">
+          <i class="fas fa-check-circle"></i>
+        </div>
+        <div class="pf-c-alert__body">
+          <h4 class="pf-c-alert__title">
+            <span class="sr-only">Success: </span> Success notification title
+          </h4>
+        </div>
+      </div>
+      ```
+
 
 ## Testing
 To keep testing simple and easy to complete, we ask that contributors complete the following three types of tests to try to catch most of the accessibility issues that may be present:

--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -47,17 +47,24 @@ Our goal is to meet [level AA in the Web Content Accessibility Guidelines 2.1](h
 
 If you use PatternFly, or contribute to PatternFly as a designer or developer, these are the items that are expected to be covered in PatternFly:
 
-| Guideline  | Link  |  |  |  |
-| --- | --- | --- | --- | --- |
-| Semantic html structures are used to accurately communicate purpose and relationship of UI elements | [WCAG 1.3.1](https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships) | `design` | `html` | `css` |
-| Color is not the only method of communication. Providing meaning through color is supplementary to providing meaning with text | [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/quickref/#use-of-color) | `design` | `html` | `css` |
-| Colors used provide sufficient contrast | [WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum) and [1.4.11](https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast) |  |  | `css` |
-| Font sizes can scale and the contents are functional and readable when the content sizes are doubled | [WCAG&nbsp;1.4.4](https://www.w3.org/WAI/WCAG21/quickref/#resize-text) |  |  | `css` |
-| All functionality is keyboard accessible | [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/quickref/#keyboard) and [2.1.2](https://www.w3.org/WAI/WCAG21/quickref/#no-keyboard-trap) |  | `html` |  |
-| Order of elements in the HTML and in the layout follow a logical order | [WCAG 1.3.2](https://www.w3.org/WAI/WCAG21/quickref/#meaningful-sequence) and [2.4.3](https://www.w3.org/WAI/WCAG21/quickref/#focus-order) | `design` | `html` | `css` |
-| Elements with focus are clearly visible | [WCAG 2.4.7](https://www.w3.org/WAI/WCAG21/quickref/#focus-visible) |  |  | `css` |
-| An accessible name is provided for all elements | [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/quickref/#name-role-value) | `design` | `html` |  |
-| The target area for clickable elements is large enough and not overlapping | [Accessible Styles for Responsive Design, Google Web Fundamentals](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design) |  |  | `css` |
+| Guideline  | Link  |  |  |  |  |
+| --- | --- | --- | --- | --- | --- |
+| Semantic html structures are used to accurately communicate purpose and relationship of UI elements | [WCAG 1.3.1](https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships) | `design` | `html` | `css` |  |
+| Color is not the only method of communication. Providing meaning through color is supplementary to providing meaning with text | [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/quickref/#use-of-color) | `design` | `html` | `css` |  |
+| Colors used provide sufficient contrast | [WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum) and [1.4.11](https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast) |  |  | `css` |  |
+| Font sizes can scale up to 200% without loss of content or functionality, and up to 400% without needing to scroll in more than one direction.  | [WCAG&nbsp;1.4.4](https://www.w3.org/WAI/WCAG21/quickref/#resize-text) and [1.4.10](https://www.w3.org/WAI/WCAG21/quickref/#reflow) |  |  | `css` |  |
+| Styles that affect text spacing (line height, space between paragraphs, letter spacing, and word spacing) can be increased without loss of content or functionality | [WCAG 1.4.12](https://www.w3.org/WAI/WCAG21/quickref/#text-spacing) |  |  | `css` |  |
+| Contents that appear on hover and focus are dismissable, hoverable, and persistent | [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/quickref/#content-on-hover-or-focus) |  | `html` | `css` | `js` |
+| All functionality is keyboard accessible | [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/quickref/#keyboard) and [2.1.2](https://www.w3.org/WAI/WCAG21/quickref/#no-keyboard-trap) |  | `html` |  |  |
+| Order of elements in the HTML and in the layout follow a logical order | [WCAG 1.3.2](https://www.w3.org/WAI/WCAG21/quickref/#meaningful-sequence) and [2.4.3](https://www.w3.org/WAI/WCAG21/quickref/#focus-order) | `design` | `html` | `css` |  |
+| Elements with focus are clearly visible | [WCAG 2.4.7](https://www.w3.org/WAI/WCAG21/quickref/#focus-visible) |  |  | `css` |  |
+| Flashing content | [WCAG 2.3.1](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=231#three-flashes-or-below-threshold) |  |  | `css` |  |
+| Functionality that uses complex gestures can also be operated with a single pointer without a path based gesture | [WCAG 2.5.1](https://www.w3.org/WAI/WCAG21/quickref/#pointer-gestures) | `design` |  |  |  |
+| Pointer events can be cancelled  | [WCAG 2.5.2](https://www.w3.org/WAI/WCAG21/quickref/#pointer-cancellation) | | | | `js` |
+| Visible labels of UI components are either the same as the accessible name or used in the beginning of the accessible name | [WCAG 2.5.3](https://www.w3.org/WAI/WCAG21/quickref/#label-in-name) |  | `html` |  |  |
+| The target area for clickable elements is at least 44 by 44 [CSS pixels](https://www.w3.org/TR/WCAG21/#dfn-css-pixels) | [WCAG 2.5.5 (AAA)](https://www.w3.org/WAI/WCAG21/quickref/#target-size) |  |  | `css` |  |
+| An accessible name is provided for all elements | [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/quickref/#name-role-value) | `design` | `html` |  |  |
+| Status messages can be programmatically determined through role or properties | [WCAG 4.1.3](https://www.w3.org/WAI/WCAG21/quickref/#status-messages) |  | `html` |  |  |
 
 ### What Products Should Address
 
@@ -84,8 +91,12 @@ These are guidelines that we have defined for PatternFly.
 
 #### Experience Parity
   - There should be parity between the screen reader contents and visibly rendered contents (refer to the [first Note for aria-hidden](https://www.w3.org/TR/wai-aria/#aria-hidden)).
-  - There should be parity among all input types: touch, mouse, and keyboard. Don’t toggle states on hover. Don’t optimize the experience for one input type at the expense of another.
-  - There should be parity between hover and focus events. Any information that’s available on hover for the mouse user should be available on focus for the keyboard-only user, and also available to the screen reader user.
+  - There should be parity among all input types: touch, mouse, and keyboard.
+      - Don’t optimize the experience for one input type at the expense of another.
+      - Contents that a user can interact with using a mouse are also accessible using touch or keyboard.
+      - Don’t show interactive elements on hover. Interactive elements that can display in a popup must display on click/touch/Enter events.
+  - There should be parity between hover and focus events.
+      - Any information that’s available on hover for the mouse user should be available on focus for the keyboard-only user, and also available to the screen reader user using `aria-describedby` (refer to [Tooltips & Toggletips example from Inclusive Components](https://inclusive-components.design/tooltips-toggletips/)).
 
 ## Techniques
 
@@ -95,9 +106,13 @@ The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#conte
 
 - #### Form Fields
   - Use explicit linking between `label` and form input elements (e.g. `input`, `textarea`, or `select`) when both elements are present. Aside from providing an accessible name to screen readers, this method also increases the clickable area of the form element by making the label clickable, too. [H44](https://www.w3.org/TR/WCAG20-TECHS/H44.html)
-  - When a `label` element cannot accompany a form input element, then provide the name using `aria-label` [ARIA14](https://www.w3.org/TR/WCAG20-TECHS/H65.html)
+  - When a `label` element cannot accompany a form input element:
+      - Provide the name using `aria-label`. [ARIA14](https://www.w3.org/TR/WCAG20-TECHS/H65.html)
+      - In a single-field form, the submit button label can serve as the field label for sighted users [G167](https://www.w3.org/TR/WCAG20-TECHS/general.html#G167)
+      
 - #### Landmark Roles
-  - Screen reader users can navigate to sections of a page when landmark roles are used. Whenever a landmark role is used more than once, provide a name using `aria-label` to provide context for that landmark [ARIA6](https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html)
+  - Screen reader users can navigate to sections of a page when [landmark roles](https://www.w3.org/TR/wai-aria-1.1/#landmark_roles) are used. Whenever a landmark role is used more than once, provide a name using `aria-label` or `aria-labelledby` to provide context for that landmark. [ARIA6](https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html) [ARIA16](https://www.w3.org/TR/WCAG20-TECHS/ARIA16.html)
+  - While [`toolbar`](https://www.w3.org/TR/wai-aria-1.1/#toolbar) is not a landmark role, the same rule applies to this role.
 - #### Icons
   Icons can either be decorative or semantic. Icons are **decorative** if you can remove an icon without affecting the information that is presented on the page. Icons are **semantic** when they provide information that otherwise isn't present, such as indicating status, indicating type of alert message, or replacing text as button labels. When an icon is semantic, the meaning must be provided in alternative ways to the user. The following guidelines should be followed when using icons within PatternFly components.
   - Add `aria-hidden="true"` for all icons, either to the icon element or a parent element of the icon. This renders the icon as something that assistive devices can ignore.
@@ -109,7 +124,7 @@ The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#conte
         <i class="..." aria-hidden="true"></i>
       </button>
       ```
-      - For non-interactive icons, include `sr-only` text near the icon. Depending on the component, the `sr-only` text might not be a direct sibling to the icon element. For example, in the Alert component, the icon label text adjacent to the message:
+      - For non-interactive icons, include `sr-only` text near the icon. Depending on the component, the `sr-only` text might not be a direct sibling to the icon element. For example, in the Alert component, the icon label text is adjacent to the message. This way, when `role="alert"` is added to `.pf-c-alert__body` for dynamically displayed alerts, the type of message is announced along with the message text.
       ```html
       <div class="pf-c-alert pf-m-success" aria-label="Success Notification">
         <div aria-hidden="true" class="pf-c-alert__icon">
@@ -125,7 +140,8 @@ The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#conte
 
 
 ## Testing
-To keep testing simple and easy to complete, we ask that contributors complete the following three types of tests to try to catch most of the accessibility issues that may be present:
+To keep testing simple and easy to complete, we ask that contributors complete the following tests to try to catch most of the accessibility issues that may be present:
 - Test keyboard accessibility
-- Disable styles to test the information architecture and presence of adequate text labels
-- Test with any screen reader available in your operating system.
+- Use the [WAVE browser extension from WebAIM](https://wave.webaim.org/extension/) to disable styles, then test the information architecture and presence of adequate text labels.
+- Test with any screen reader available in your operating system
+- Check color contrast

--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -7,7 +7,7 @@ The goal of software accessibility is to remove barriers and create inclusive pr
 Since accessibility is best achieved when considered early in the design and development process, we ask everyone who contributes to or consumes PatternFly to understand accessibility needs and how they can be met. The following guide provides techniques and suggestions to help you design, develop, and test UIs to ensure that everyone has a good user experience.
 
 - [Understanding Users’ Needs](#understanding-users-needs)
-- [Level of Support](#level-of-support)
+- [Designing and Developing for Accessibility](#designing-and-developing-for-accessibility)
 - [Checklists](#checklists)
   - [What PatternFly Should Address](#what-patternfly-should-address)
   - [What Products Should Address](#what-products-should-address)
@@ -37,7 +37,7 @@ Users with poor motor control can use a range of devices to access contents. Use
 
 Users who have difficulty processing information benefit from well-written content. Information should clear, concise, and easy to scan. Consider visual hierarchy, chunk content into short, related sections, and avoid long paragraphs.
 
-## Level of Support
+## Designing and Developing for Accessibility
 
 Our goal is to meet [level AA in the Web Content Accessibility Guidelines 2.1](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa). To help you get started, the following sections break some of these down by area of focus.
 

--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -7,13 +7,13 @@ The goal of software accessibility is to remove barriers and create inclusive pr
 Since accessibility is best achieved when considered early in the design and development process, we ask everyone who contributes to or consumes PatternFly to understand accessibility needs and how they can be met. The following guide provides techniques and suggestions to help you design, develop, and test UIs to ensure that everyone has a good user experience.
 
 - [Understanding Users’ Needs](#understanding-users-needs)
+- [Level of Support](#level-of-support)
 - [Checklists](#checklists)
-  - [Design and Development Guidelines](#design-and-development-guidelines)
-      - [What PatternFly Designers and Developers Should Address](#what-patternfly-designers-and-developers-should-address)
-      - [What Product Developers and Designers Should Address](#what-product-developers-and-designers-should-address)
-  - [Testing](#testing)
-  - [Screen Reader Support](#screen-reader-support)
-- [Methods](#methods)
+  - [What PatternFly Should Address](#what-patternfly-should-address)
+  - [What Products Should Address](#what-products-should-address)
+- [Guidelines and References](#guidelines-and-references)
+- [Techniques](#techniques)
+- [Testing](#testing)
 
 ## Understanding Users’ Needs
 
@@ -37,49 +37,62 @@ Users with poor motor control can use a range of devices to access contents. Use
 
 Users who have difficulty processing information benefit from well-written content. Information should clear, concise, and easy to scan. Consider visual hierarchy, chunk content into short, related sections, and avoid long paragraphs.
 
-## Checklists
-### Design and Development Guidelines
-The following are guidelines that we strive to adopt:
-- The [A11Y Project Checklist](https://a11yproject.com/checklist) is a helpful checklist to start with if you’re new to accessibility.
-- Our goal is to meet [level AA in the Web Content Accessibility Guidelines](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize&levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl). While these guidelines can seem like a lot, the following sections capture some of these.
+## Level of Support
 
-#### What PatternFly Designers and Developers Should Address
+Our goal is to meet [level AA in the Web Content Accessibility Guidelines 2.1](https://www.w3.org/WAI/WCAG21/quickref/?currentsidebar=%23col_customize&levels=aaa). To help you get started, the following sections break some of these down by area of focus.
+
+## Checklists
+
+### What PatternFly Should Address
 
 If you use PatternFly, or contribute to PatternFly as a designer or developer, these are the items that are expected to be covered in PatternFly:
 
-- Experience parity
+| Guideline  | Link  |  |  |  |
+| --- | --- | --- | --- | --- |
+| Semantic html structures are used to accurately communicate purpose and relationship of UI elements | [WCAG 1.3.1](https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships) | `design` | `html` | `css` |
+| Color is not the only method of communication. Providing meaning through color is supplementary to providing meaning with text | [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/quickref/#use-of-color) | `design` | `html` | `css` |
+| Colors used provide sufficient contrast | [WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum) and [1.4.11](https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast) |  |  | `css` |
+| Font sizes can scale and the contents are functional and readable when the content sizes are doubled | [WCAG&nbsp;1.4.4](https://www.w3.org/WAI/WCAG21/quickref/#resize-text) |  |  | `css` |
+| All functionality is keyboard accessible | [WCAG 2.1.1](https://www.w3.org/WAI/WCAG21/quickref/#keyboard) and [2.1.2](https://www.w3.org/WAI/WCAG21/quickref/#no-keyboard-trap) |  | `html` |  |
+| Order of elements in the HTML and in the layout follow a logical order | [WCAG 1.3.2](https://www.w3.org/WAI/WCAG21/quickref/#meaningful-sequence) and [2.4.3](https://www.w3.org/WAI/WCAG21/quickref/#focus-order) | `design` | `html` | `css` |
+| Elements with focus are clearly visible | [WCAG 2.4.7](https://www.w3.org/WAI/WCAG21/quickref/#focus-visible) |  |  | `css` |
+| An accessible name is provided for all elements | [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/quickref/#name-role-value) | `design` | `html` |  |
+| The target area for clickable elements is large enough and not overlapping | [Accessible Styles for Responsive Design, Google Web Fundamentals](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design) |  |  | `css` |
+
+### What Products Should Address
+
+If you consume PatternFly in your product, these are the items that are outside the scope of PatternFly, and should be addressed by the product developers and designers:
+
+
+| Guideline  | Link  |  |  |
+| --- | --- | --- | --- |
+| Skip to Main links | [WCAG 2.4.1](https://www.w3.org/WAI/WCAG21/quickref/#bypass-blocks) |  | `development` |
+| Page Titles | [WCAG 2.4.2](https://www.w3.org/WAI/WCAG21/quickref/#page-titled) |  | `development` |
+| Links — If more than one link has the same label, it should also have the same url. Screen reader users can access the list of links that are on a page, which pulls the links out of context. If you have links with different URLs but the same label, then add additional text to provide context to the screen reader user. | [WCAG&nbsp;2.4.4](https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-in-context) | `design`  | `development` |
+| Landmarks — Use landmark roles to clearly identify regions that communicate page structure. If more than one landmark role occurs in the page, use aria-label to differentiate the landmark elements | [ARIA11](https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html) | `design`  | `development` |
+| Headings — Heading text should be descriptive. Correct heading levels should be used to communicate the outline of the page. | [WCAG 2.4.10](https://www.w3.org/WAI/WCAG21/quickref/#section-headings) and [H42](https://www.w3.org/TR/WCAG20-TECHS/H42.html) | `design`  | `development` |
+| Contents — Should be meaningful, clear, and concise |  | `design` |  |
+
+## Guidelines and References
+
+- [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
+- [WebAIM's WCAG 2.0 Checklist](https://webaim.org/standards/wcag/checklist)
+- [A11Y Project Checklist](https://a11yproject.com/checklist)
+
+### PatternFly Guidelines
+These are guidelines that we have defined for PatternFly.
+
+#### Experience Parity
   - There should be parity between the screen reader contents and visibly rendered contents (refer to the [first Note for aria-hidden](https://www.w3.org/TR/wai-aria/#aria-hidden)).
   - There should be parity among all input types: touch, mouse, and keyboard. Don’t toggle states on hover. Don’t optimize the experience for one input type at the expense of another.
-  - There should be parity between hover and focus events. Any information that’s available on hover should be available on focus, too.
-- Semantic html structures are used to accurately communicate purpose and relationship of UI elements ([WCAG 1.3.1](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize&showtechniques=131#qr-content-structure-separation-programmatic)).  *[design, html, css]*
-- Color is not the only method of communication. Providing meaning through color is supplementary to providing meaning with text ([WCAG 1.4.1](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-visual-audio-contrast-without-color)).  *[design, html, css]*
-- Colors used provide sufficient contrast ([WCAG 1.4.3](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-visual-audio-contrast-contrast)).  *[css]*
-- Font sizes can scale and the contents are functional and readable when the content sizes are doubled ([WCAG 1.4.4](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-visual-audio-contrast-scale)).  *[css]*
-- All functionality is keyboard accessible ([WCAG 2.1.1 and 2.1.2](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#keyboard-operation)).  *[html]*
-- Order of elements in the HTML and in the layout follow a logical order ([WCAG 1.3.2](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-content-structure-separation-sequence) and [WCAG 2.4.3](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-navigation-mechanisms-focus-order)). *[design, html, css]*
-- Elements with focus are clearly visible ([WCAG 2.4.7](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-navigation-mechanisms-focus-visible)). *[css]*
-- An accessible name is provided for all elements ([WCAG 4.1.2](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize&showtechniques=412#qr-ensure-compat-rsv)). *[design, html]*
-- The target area for clickable elements is large enough and not overlapping ([Accessible Styles for Responsive Design, Google Web Fundamentals](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design)). *[css]*
+  - There should be parity between hover and focus events. Any information that’s available on hover for the mouse user should be available on focus for the keyboard-only user, and also available to the screen reader user.
 
-#### What Product Developers and Designers Should Address
+## Techniques
 
-- Skip to Main links ([WCAG 2.4.1](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-navigation-mechanisms-skip))
-- Page Titles ([WCAG 2.4.2](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-navigation-mechanisms-title))
-- Links ([WCAG 2.4.4](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-navigation-mechanisms-refs)) — If more than one link has the same label, it should also have the same url. Screen reader users can access the list of links that are on a page, which pulls the links out of context. If you have links with different URLs but the same label, then add additional text to provide context to the screen reader user.
-- Landmarks ([ARIA11](https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html)) — Use landmark roles to communicate page structure. If more than one landmark role occurs in the page, use aria-label to differentiate the landmark elements
-- Headings ([WCAG 2.4.10](https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=%23col_customize#qr-navigation-mechanisms-headings) and [H42](https://www.w3.org/TR/WCAG20-TECHS/H42.html)) — Heading text should be descriptive. Correct heading levels should be used to communicate the outline of the page.
-- Contents — Should be meaningful, clear, and concise
+The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#contents)   provide examples on how to meet accessibility guidelines. Additionally, as we discover techniques for specific interaction patterns, we'll document them here so that we can be consistent in our approach.
 
-
-### Testing
+## Testing
 To keep testing simple and easy to complete, we ask that contributors complete the following three types of tests to try to catch most of the accessibility issues that may be present:
 - Test keyboard accessibility
 - Disable styles to test the information architecture and presence of adequate text labels
 - Test with any screen reader available in your operating system.
-
-### Screen Reader Support
-*Screen reader support is to be determined.*
-
-## Methods
-
-The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#contents)   provide methods on how to meet accessibility guidelines. Additionally, as we discover techniques for specific interaction patterns, we'll document them here so that we can be consistent in our approach.

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -68,7 +68,10 @@
   h1 {
     margin-bottom: .5em;
   }
-  h2, h3, h4, h5, h6 {
+  h2 {
+    margin: 2em 0 .5em 0;
+  }
+  h3, h4, h5, h6 {
     margin: 1em 0 .5em 0;
   }
   p {
@@ -95,6 +98,22 @@
   }
   li + li {
     margin-top: .5rem;
+  }
+  table {
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+  table, td, th, tr {
+    padding: .5em;
+    vertical-align: top;
+    border-bottom: 1px solid #ccc;
+  }
+  td > code {
+    padding: .25em .75em;
+    color: #004368;
+    white-space: nowrap;
+    background-color: #def3ff;
+    border-radius: .5em;
   }
 }
 


### PR DESCRIPTION
The following changes have been included:
* restructured the outline — the new structure makes it easier for us to add our own PF guidelines and techniques, while still including a concise checklist to guidelines that we follow (which are mostly WCAG, but can include other guidelines that are documented that we want to adopt)
* changed the checklist from a bulleted list to a table
* updated links from WCAG 2.0 resources to WCAG 2.1 resources
* added styles for table, and modified the heading level 2 styles for more separation between content sections.
* Included WCAG added for 2.1
* Included link to WAVE webAIM tool for disabling styles (in Test section)
* Included extra step in Test section to check color contrast
* Included example techniques for defining accessible names for form fields, icons, and landmarks