### PR TITLE
Replace empty design.md with template

### DIFF
--- a/build/blueprints/template/files/src/patternfly/__typeDirectory__/__namePascalized__/docs/design.md
+++ b/build/blueprints/template/files/src/patternfly/__typeDirectory__/__namePascalized__/docs/design.md
@@ -1,1 +1,34 @@
-## design md file
+# Component Name
+_Include a short (1-2 sentence) description of the component here and fill out the following sections as needed_
+
+## Usage
+_(Required)
+Inform readers about when and how this component or pattern should be used, including any variations or related best practices._
+* What problem does this solve?
+* When to use
+* When not to use
+* Alternative solutions
+* How to use it in context (in my design)
+    * Layout or sizing considerations
+    * Using with other components or patterns
+    * Examples
+
+## Behavior
+_(Optional)
+You can include behavioral specifications to help readers understand any complex aspects of behavior that might not be obvious from the implementation examples.
+This will aid readers in understanding aspects of behavior that may not be
+obvious from looking at implementation examples._
+* Include mockups (can be low or mid-fi) with enumerated callouts to describe intended interactions.
+* Mockups can be low or mid-fi.
+
+## Styling
+_(Optional)
+If there are styling considerations that may not be obvious from looking at the implementation examples, they should be explained here._
+
+## Content
+_(optional)
+Provide content standards and writing suggestions for this component or pattern to help designers and developers deliver consistent and thoughtful content. You can include guidelines, messaging standards, or similar best practices specific to this component or pattern.This will extend
+   any general terminology and wording best practices to provide component specific guidance._
+* Editorial guidelines for labeling and message text
+* Length restrictions and/or what to do if text overflows
+* Localization considerations


### PR DESCRIPTION
Replacing the placeholder design.md file in the Blueprints folder with the template that we will use for design documents.

Closes #248 