### PR TITLE
fix(borders): update borders for high contrast mode

### DIFF
--- a/src/patternfly/components/Button/styles.scss
+++ b/src/patternfly/components/Button/styles.scss
@@ -9,90 +9,89 @@
   --pf-c-button--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-button--FontSize: var(--pf-global--FontSize--md);
   --pf-c-button--BackgroundColor: transparent;
-  --pf-c-button--BoxShadowColor: var(--pf-global--primary-color);
-  --pf-c-button--BoxShadowSpread: var(--pf-global--BorderWidth--sm);
-  --pf-c-button--Color: var(--pf-global--primary-color);
+  --pf-c-button--Color: var(--pf-global--primary-color-100);
   --pf-c-button--BorderRadius: var(--pf-global--BorderRadius);
+  --pf-c-button--BorderColor: var(--pf-global--primary-color-100);
   --pf-c-button--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Hover state variables
   --pf-c-button--hover--Color: var(--pf-global--primary-color--200);
   --pf-c-button--hover--BackgroundColor: transparent;
-  --pf-c-button--hover--BoxShadowColor: var(--pf-global--primary-color--200);
-  --pf-c-button--hover--BoxShadowSpread: var(--pf-global--BorderWidth--md);
+  --pf-c-button--hover--BorderColor: var(--pf-global--primary-color--200);
+  --pf-c-button--hover--BorderWidth: var(--pf-global--BorderWidth--md);
 
   // Focus state variables
   --pf-c-button--focus--Color: var(--pf-global--primary-color--200);
   --pf-c-button--focus--BackgroundColor: transparent;
-  --pf-c-button--focus--BoxShadowColor: var(--pf-global--primary-color--200);
-  --pf-c-button--focus--BoxShadowSpread: var(--pf-global--BorderWidth--md);
+  --pf-c-button--focus--BorderColor: var(--pf-global--primary-color--200);
+  --pf-c-button--focus--BorderWidth: var(--pf-global--BorderWidth--md);
 
   // Active state variables
   --pf-c-button--active--Color: var(--pf-global--primary-color--200);
   --pf-c-button--active--BackgroundColor: transparent;
-  --pf-c-button--active--BoxShadowColor: var(--pf-global--primary-color--200);
-  --pf-c-button--active--BoxShadowSpread: var(--pf-global--BorderWidth--md);
+  --pf-c-button--active--BorderColor: var(--pf-global--primary-color--200);
+  --pf-c-button--active--BorderWidth: var(--pf-global--BorderWidth--md);
 
   // Disabled state variables
   --pf-c-button--m-disabled--Color: var(--pf-color-black-600);
   --pf-c-button--m-disabled--BackgroundColor: var(--pf-color-black-300);
-  --pf-c-button--m-disabled--BoxShadowColor: var(--pf-c-button--m-disabled--BackgroundColor);
-  --pf-c-button--m-disabled--BoxShadowSpread: var(--pf-global--BorderWidth--lg);
+  --pf-c-button--m-disabled--BorderColor: transparent;
+  --pf-c-button--m-disabled--BorderWidth: var(--pf-global--BorderWidth--lg);
 
   // Primary btn
   --pf-c-button--m-primary--BackgroundColor: var(--pf-global--primary-color--100);
-  --pf-c-button--m-primary--BoxShadowColor: var(--pf-global--primary-color--100);
+  --pf-c-button--m-primary--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-button--m-primary--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-primary--hover--BackgroundColor: var(--pf-global--primary-color--200);
-  --pf-c-button--m-primary--hover--BoxShadowColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-primary--hover--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-primary--hover--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-primary--focus--BackgroundColor: var(--pf-global--primary-color--200);
-  --pf-c-button--m-primary--focus--BoxShadowColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-primary--focus--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-primary--focus--Color: var(--pf-global--Color--light-100);
-  --pf-c-button--m-primary--active--BoxShadowColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-primary--active--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-primary--active--BackgroundColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-primary--active--Color: var(--pf-global--Color--light-100);
 
   // Secondary btn
   --pf-c-button--m-secondary--BackgroundColor: transparent;
-  --pf-c-button--m-secondary--BoxShadowColor: var(--pf-global--primary-color--100);
+  --pf-c-button--m-secondary--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-button--m-secondary--Color: var(--pf-global--primary-color--100);
   --pf-c-button--m-secondary--hover--BackgroundColor: transparent;
-  --pf-c-button--m-secondary--hover--BoxShadowColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-secondary--hover--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-secondary--hover--Color: var(--pf-global--primary-color--200);
   --pf-c-button--m-secondary--focus--BackgroundColor: transparent;
-  --pf-c-button--m-secondary--focus--BoxShadowColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-secondary--focus--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-secondary--focus--Color: var(--pf-global--primary-color--200);
   --pf-c-button--m-secondary--active--BackgroundColor: transparent;
-  --pf-c-button--m-secondary--active--BoxShadowColor: var(--pf-global--primary-color--200);
+  --pf-c-button--m-secondary--active--BorderColor: var(--pf-global--primary-color--200);
   --pf-c-button--m-secondary--active--Color: var(--pf-global--primary-color--200);
 
   // Tertiary btn
   --pf-c-button--m-tertiary--BackgroundColor: transparent;
-  --pf-c-button--m-tertiary--BoxShadowColor: var(--pf-global--secondary-color--100);
+  --pf-c-button--m-tertiary--BorderColor: var(--pf-global--secondary-color--100);
   --pf-c-button--m-tertiary--Color: var(--pf-color-black-900);
   --pf-c-button--m-tertiary--hover--BackgroundColor: transparent;
-  --pf-c-button--m-tertiary--hover--BoxShadowColor: var(--pf-global--secondary-color--100);
+  --pf-c-button--m-tertiary--hover--BorderColor: var(--pf-global--secondary-color--100);
   --pf-c-button--m-tertiary--hover--Color: var(--pf-color-black-900);
   --pf-c-button--m-tertiary--focus--BackgroundColor: transparent;
-  --pf-c-button--m-tertiary--focus--BoxShadowColor: var(--pf-global--secondary-color--100);
+  --pf-c-button--m-tertiary--focus--BorderColor: var(--pf-global--secondary-color--100);
   --pf-c-button--m-tertiary--focus--Color: var(--pf-color-black-900);
   --pf-c-button--m-tertiary--active--BackgroundColor: transparent;
-  --pf-c-button--m-tertiary--active--BoxShadowColor: var(--pf-global--secondary-color--100);
+  --pf-c-button--m-tertiary--active--BorderColor: var(--pf-global--secondary-color--100);
   --pf-c-button--m-tertiary--active--Color: var(--pf-color-black-900);
 
   // danger btn
   --pf-c-button--m-danger--BackgroundColor: var(--pf-global--danger-color--100);
-  --pf-c-button--m-danger--BoxShadowColor: var(--pf-global--danger-color--100);
+  --pf-c-button--m-danger--BorderColor: var(--pf-global--danger-color--100);
   --pf-c-button--m-danger--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-danger--hover--BackgroundColor: var(--pf-global--danger-color--200);
-  --pf-c-button--m-danger--hover--BoxShadowColor: var(--pf-c-button--m-danger--hover--BackgroundColor);
+  --pf-c-button--m-danger--hover--BorderColor: var(--pf-c-button--m-danger--hover--BackgroundColor);
   --pf-c-button--m-danger--hover--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-danger--focus--BackgroundColor: var(--pf-global--danger-color--200);
-  --pf-c-button--m-danger--focus--BoxShadowColor: var(--pf-c-button--m-danger--hover--BackgroundColor);
+  --pf-c-button--m-danger--focus--BorderColor: var(--pf-c-button--m-danger--hover--BackgroundColor);
   --pf-c-button--m-danger--focus--Color: var(--pf-global--Color--light-100);
   --pf-c-button--m-danger--active--BackgroundColor: var(--pf-global--danger-color--200);
-  --pf-c-button--m-danger--active--BoxShadowColor: var(--pf-c-button--m-danger--hover--BackgroundColor);
+  --pf-c-button--m-danger--active--BorderColor: var(--pf-c-button--m-danger--hover--BackgroundColor);
   --pf-c-button--m-danger--active--Color: var(--pf-global--Color--light-100);
 
   // Link btn
@@ -114,6 +113,7 @@
   --pf-c-button--m-action--active--Color: var(--pf-global--Color--dark-100);
   --pf-c-button--item--MarginRight: var(--pf-global--spacer--xs);
 
+  position: relative;
   display: inline-block;
   padding: var(--pf-c-button--PaddingTop) var(--pf-c-button--PaddingRight) var(--pf-c-button--PaddingBottom) var(--pf-c-button--PaddingLeft);
   font-size: var(--pf-c-button--FontSize);
@@ -123,9 +123,20 @@
   text-align: center;
   white-space: nowrap;
   background-color: var(--pf-c-button--BackgroundColor);
-  border: var(--pf-c-button--BorderWidth) solid transparent;
+  border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
-  box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--BoxShadowColor);
+
+  &::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    content: "";
+    border: var(--pf-c-button--BorderWidth) solid;
+    border-color: var(--pf-c-button--BorderColor);
+    border-radius: var(--pf-c-button--BorderRadius);
+  }
 
   // Add spacing to icon if it appears at the beginning of button
   > *:first-child {
@@ -136,21 +147,30 @@
   &.pf-m-hover {
     color: var(--pf-c-button--hover--Color);
     background-color: var(--pf-c-button--hover--BackgroundColor);
-    box-shadow: inset 0 0 0 var(--pf-c-button--hover--BoxShadowSpread) var(--pf-c-button--hover--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--hover--BorderColor);
+      border-width: var(--pf-c-button--hover--BorderWidth);
+    }
   }
 
   &:active,
   &.pf-m-active {
     color: var(--pf-c-button--active--Color);
     background-color: var(--pf-c-button--active--BackgroundColor);
-    box-shadow: inset 0 0 0 var(--pf-c-button--active--BoxShadowSpread) var(--pf-c-button--active--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--active--BorderColor);
+      border-width: var(--pf-c-button--focus--BorderWidth);
+    }
   }
 
   &:focus,
   &.pf-m-focus {
     color: var(--pf-c-button--focus--Color);
     background-color: var(--pf-c-button--focus--BackgroundColor);
-    box-shadow: inset 0 0 0 var(--pf-c-button--focus--BoxShadowSpread) var(--pf-c-button--focus--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--focus--BorderColor);
+      border-width: var(--pf-c-button--focus--BorderWidth);
+    }
   }
 
   &.pf-m-block {
@@ -162,28 +182,35 @@
   &.pf-m-primary {
     color: var(--pf-c-button--m-primary--Color);
     background-color: var(--pf-c-button--m-primary--BackgroundColor);
-    border: var(--pf-c-button--BorderWidth) solid transparent;
-    box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-primary--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--m-primary--BorderColor);
+    }
 
     &:hover,
     &.pf-m-hover {
       color: var(--pf-c-button--m-primary--hover--Color);
       background-color: var(--pf-c-button--m-primary--hover--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--hover--BoxShadowSpread) var(--pf-c-button--m-primary--hover--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-primary--hover--BorderColor);
+      }
     }
 
     &:active,
     &.pf-m-active {
       color: var(--pf-c-button--m-primary--active--Color);
       background-color: var(--pf-c-button--m-primary--active--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--active--BoxShadowSpread) var(--pf-c-button--m-primary--active--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-primary--active--BorderColor);
+      }
     }
 
     &:focus,
     &.pf-m-focus {
       color: var(--pf-c-button--m-primary--focus--Color);
       background-color: var(--pf-c-button--m-primary--focus--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--focus--BoxShadowSpread) var(--pf-c-button--m-primary--focus--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-primary--focus--BorderColor);
+      }
     }
   }
 
@@ -191,28 +218,33 @@
   &.pf-m-secondary {
     color: var(--pf-c-button--m-secondary--Color);
     background-color: var(--pf-c-button--m-secondary--BackgroundColor);
-    border: var(--pf-c-button--BorderWidth) solid transparent;
-    box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-secondary--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--m-secondary--BorderColor);
+    }
 
     &:hover,
     &.pf-m-hover {
       color: var(--pf-c-button--m-secondary--hover--Color);
       background-color: var(--pf-c-button--m-secondary--hover--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--hover--BoxShadowSpread) var(--pf-c-button--m-secondary--hover--BoxShadowColor);
+      border-color: var(--pf-c-button--m-secondary--hover--BorderColor);
     }
 
     &:active,
     &.pf-m-active {
       color: var(--pf-c-button--m-secondary--active--Color);
       background-color: var(--pf-c-button--m-secondary--active--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--active--BoxShadowSpread) var(--pf-c-button--m-secondary--active--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-secondary--active--BorderColor);
+      }
     }
 
     &:focus,
     &.pf-m-focus {
       color: var(--pf-c-button--m-secondary--focus--Color);
       background-color: var(--pf-c-button--m-secondary--focus--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--focus--BoxShadowSpread) var(--pf-c-button--m-secondary--focus--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-secondary--focus--BorderColor);
+      }
     }
   }
 
@@ -220,28 +252,36 @@
   &.pf-m-tertiary {
     color: var(--pf-c-button--m-tertiary--Color);
     background-color: var(--pf-c-button--m-tertiary--BackgroundColor);
-    border: var(--pf-c-button--BorderWidth) solid transparent;
-    box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-tertiary--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--m-tertiary--BorderColor);
+    }
 
     &:hover,
     &.pf-m-hover {
       color: var(--pf-c-button--m-tertiary--hover--Color);
       background-color: var(--pf-c-button--m-tertiary--hover--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--hover--BoxShadowSpread) var(--pf-c-button--m-tertiary--hover--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-tertiary--hover--BorderColor);
+      }
     }
 
     &:active,
     &.pf-m-active {
       color: var(--pf-c-button--m-tertiary--active--Color);
       background-color: var(--pf-c-button--m-tertiary--active--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--active--BoxShadowSpread) var(--pf-c-button--m-tertiary--active--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-tertiary--active--BorderColor);
+        border-width: var(--pf-c-button--m-tertiary--active--BorderWidth);
+      }
     }
 
     &:focus,
     &.pf-m-focus {
       color: var(--pf-c-button--m-tertiary--focus--Color);
       background-color: var(--pf-c-button--m-tertiary--focus--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--focus--BoxShadowSpread) var(--pf-c-button--m-tertiary--focus--BoxShadowColor);
+      &::after {
+        border-color: var(--pf-c-button--m-tertiary--focus--BorderColor);
+      }
     }
   }
 
@@ -249,28 +289,29 @@
   &.pf-m-danger {
     color: var(--pf-c-button--m-danger--Color);
     background-color: var(--pf-c-button--m-danger--BackgroundColor);
-    border: var(--pf-c-button--BorderWidth) solid transparent;
-    box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-danger--BoxShadowColor);
+    &::after {
+      border-color: var(--pf-c-button--m-danger--BorderColor);
+    }
 
     &:hover,
     &.pf-m-hover {
       color: var(--pf-c-button--m-danger--hover--Color);
       background-color: var(--pf-c-button--m-danger--hover--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--hover--BoxShadowSpread) var(--pf-c-button--m-danger--hover--BoxShadowColor);
+      border-color: var(--pf-c-button--m-danger--hover--BorderColor);
     }
 
     &:active,
     &.pf-m-active {
       color: var(--pf-c-button--m-danger--active--Color);
       background-color: var(--pf-c-button--m-danger--active--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--active--BoxShadowSpread) var(--pf-c-button--m-danger--active--BoxShadowColor);
+      border-color: var(--pf-c-button--m-danger--active--BorderColor);
     }
 
     &:focus,
     &.pf-m-focus {
       color: var(--pf-c-button--m-danger--focus--Color);
       background-color: var(--pf-c-button--m-danger--focus--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-button--focus--BoxShadowSpread) var(--pf-c-button--m-danger--focus--BoxShadowColor);
+      border-color: var(--pf-c-button--m-danger--focus--BorderColor);
     }
   }
 
@@ -288,6 +329,9 @@
     &.pf-m-focus {
       background-color: transparent;
       box-shadow: none;
+    }
+    &::after {
+      border: 0;
     }
   }
 
@@ -347,6 +391,8 @@
     color: var(--pf-c-button--m-disabled--Color);
     pointer-events: none;
     background-color: var(--pf-c-button--m-disabled--BackgroundColor);
-    box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-disabled--BoxShadowColor);
+    &::after {
+      border: var(--pf-c-button--BorderWidth) solid var(--pf-c-button--m-disabled--BorderColor);
+    }
   }
 }

--- a/src/patternfly/components/Button/styles.scss
+++ b/src/patternfly/components/Button/styles.scss
@@ -13,6 +13,7 @@
   --pf-c-button--BoxShadowSpread: var(--pf-global--BorderWidth--sm);
   --pf-c-button--Color: var(--pf-global--primary-color);
   --pf-c-button--BorderRadius: var(--pf-global--BorderRadius);
+  --pf-c-button--BorderWidth: var(--pf-global--BorderWidth--sm);
 
   // Hover state variables
   --pf-c-button--hover--Color: var(--pf-global--primary-color--200);
@@ -122,7 +123,7 @@
   text-align: center;
   white-space: nowrap;
   background-color: var(--pf-c-button--BackgroundColor);
-  border: 0;
+  border: var(--pf-c-button--BorderWidth) solid transparent;
   border-radius: var(--pf-c-button--BorderRadius);
   box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--BoxShadowColor);
 
@@ -161,6 +162,7 @@
   &.pf-m-primary {
     color: var(--pf-c-button--m-primary--Color);
     background-color: var(--pf-c-button--m-primary--BackgroundColor);
+    border: var(--pf-c-button--BorderWidth) solid transparent;
     box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-primary--BoxShadowColor);
 
     &:hover,
@@ -189,6 +191,7 @@
   &.pf-m-secondary {
     color: var(--pf-c-button--m-secondary--Color);
     background-color: var(--pf-c-button--m-secondary--BackgroundColor);
+    border: var(--pf-c-button--BorderWidth) solid transparent;
     box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-secondary--BoxShadowColor);
 
     &:hover,
@@ -217,6 +220,7 @@
   &.pf-m-tertiary {
     color: var(--pf-c-button--m-tertiary--Color);
     background-color: var(--pf-c-button--m-tertiary--BackgroundColor);
+    border: var(--pf-c-button--BorderWidth) solid transparent;
     box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-tertiary--BoxShadowColor);
 
     &:hover,
@@ -245,6 +249,7 @@
   &.pf-m-danger {
     color: var(--pf-c-button--m-danger--Color);
     background-color: var(--pf-c-button--m-danger--BackgroundColor);
+    border: var(--pf-c-button--BorderWidth) solid transparent;
     box-shadow: inset 0 0 0 var(--pf-c-button--BoxShadowSpread) var(--pf-c-button--m-danger--BoxShadowColor);
 
     &:hover,

--- a/src/patternfly/components/Dropdown/styles.scss
+++ b/src/patternfly/components/Dropdown/styles.scss
@@ -25,7 +25,7 @@
   // Menu
   --pf-c-dropdown__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
   --pf-c-dropdown__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-dropdown__menu--BoxShadow: var(--pf-global--BoxShadow--sm);
+  --pf-c-dropdown__menu--BorderColor: var(--pf-global--BorderColor);
   --pf-c-dropdown__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--ZIndex: var(--pf-global--ZIndex--xs);
@@ -56,16 +56,16 @@
     line-height: var(--pf-c-dropdown__toggle--LineHeight);
     color: var(--pf-c-dropdown__toggle--Color);
     background-color: var(--pf-c-dropdown__toggle--BackgroundColor);
-    border: var(--pf-c-dropdown__toggle--BorderWidth) solid transparent;
-    box-shadow: inset 0 0 0 var(--pf-c-dropdown__toggle--BorderWidth) var(--pf-c-dropdown__toggle--BorderColor);
+    border: var(--pf-c-dropdown__toggle--BorderWidth) solid var(--pf-c-dropdown__toggle--BorderColor);
 
     &:hover {
-      box-shadow: inset 0 0 0 var(--pf-c-dropdown__toggle--hover--BorderWidth) var(--pf-c-dropdown__toggle--hover--BorderColor);
+      border-color: var(--pf-c-dropdown__toggle--hover--BorderColor);
     }
 
     &:active,
     .pf-m-expanded > & {
-      box-shadow: inset 0 0 0 var(--pf-c-dropdown__toggle--m-expanded--BorderWidth) var(--pf-c-dropdown__toggle--m-expanded--BorderColor);
+      border-color: var(--pf-c-dropdown__toggle--m-expanded--BorderColor);
+      border-width: var(--pf-c-dropdown__toggle--m-expanded--BorderWidth);
     }
 
     .pf-m-ghost > & {
@@ -108,7 +108,6 @@
     padding-bottom: var(--pf-c-dropdown__menu--PaddingBottom);
     background: var(--pf-c-dropdown__menu--BackgroundColor);
     border: var(--pf-c-dropdown__menu--BorderWidth) solid transparent;
-    box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
     .pf-m-right-aligned > & {
       right: 0;

--- a/src/patternfly/components/Dropdown/styles.scss
+++ b/src/patternfly/components/Dropdown/styles.scss
@@ -24,6 +24,7 @@
 
   // Menu
   --pf-c-dropdown__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-200);
+  --pf-c-dropdown__menu--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-dropdown__menu--BoxShadow: var(--pf-global--BoxShadow--sm);
   --pf-c-dropdown__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--PaddingBottom: var(--pf-global--spacer--sm);
@@ -55,7 +56,7 @@
     line-height: var(--pf-c-dropdown__toggle--LineHeight);
     color: var(--pf-c-dropdown__toggle--Color);
     background-color: var(--pf-c-dropdown__toggle--BackgroundColor);
-    border: none;
+    border: var(--pf-c-dropdown__toggle--BorderWidth) solid transparent;
     box-shadow: inset 0 0 0 var(--pf-c-dropdown__toggle--BorderWidth) var(--pf-c-dropdown__toggle--BorderColor);
 
     &:hover {
@@ -106,6 +107,7 @@
     padding-top: var(--pf-c-dropdown__menu--PaddingTop);
     padding-bottom: var(--pf-c-dropdown__menu--PaddingBottom);
     background: var(--pf-c-dropdown__menu--BackgroundColor);
+    border: var(--pf-c-dropdown__menu--BorderWidth) solid transparent;
     box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
     .pf-m-right-aligned > & {

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -52,7 +52,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
   --pf-c-form__input--hover--BorderSize:          var(--pf-global--BorderWidth--md);
   --pf-c-form__input--focus--BorderSize:          var(--pf-global--BorderWidth--md);
   --pf-c-form__input--disabled--BorderSize:       var(--pf-global--BorderWidth--sm);
-  --pf-c-form__input--BoxShadowColor:             var(--pf-global--BorderColor--dark);
+  --pf-c-form__input--BorderColor:             var(--pf-global--BorderColor--dark);
   --pf-c-form__input--hover--BorderColor:         var(--pf-global--BorderColor--dark);
   --pf-c-form__input--focus--BorderColor:         var(--pf-global--BorderColor--active);
   --pf-c-form__input--disabled--BorderColor:      var(--pf-global--BorderColor--disabled);
@@ -173,7 +173,9 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     /* stylelint-enable */
 
     .pf-c-button {
-      border-radius: 0;
+      &::after {
+        border-radius: 0;
+      }
     }
 
     .pf-c-dropdown {
@@ -227,10 +229,9 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     line-height: var(--pf-c-form__input--LineHeight);
     color: var(--pf-c-form__input--Color);
     background-color: var(--pf-c-form__input--BackgroundColor);
-    border: var(--pf-c-form__input--BorderSize) solid transparent;
+    border: var(--pf-c-form__input--BorderSize) solid var(--pf-c-form__input--BorderColor);
     border-radius: 0;
     outline: 0;
-    box-shadow: inset 0 0 0 var(--pf-c-form__input--BorderSize) var(--pf-c-form__input--BoxShadowColor);
 
     &::placeholder {
       color: var(--pf-c-form__input--placeholder--Color);
@@ -239,13 +240,13 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     // Hover
     &.pf-m-hover,
     &:hover {
-      box-shadow: inset 0 0 0 var(--pf-c-form__input--hover--BorderSize) var(--pf-c-form__input--hover--BorderColor);
+      border-color: var(--pf-c-form__input--hover--BorderColor);
     }
 
     // Focus
     &.pf-m-focus,
     &:focus {
-      box-shadow: inset 0 0 0 var(--pf-c-form__input--focus--BorderSize) var(--pf-c-form__input--focus--BorderColor);
+      border-color: var(--pf-c-form__input--focus--BorderColor);
     }
 
     // Disabled
@@ -253,7 +254,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     &:disabled {
       color: var(--pf-c-form__input--disabled--Color);
       background-color: var(--pf-c-form__input--disabled--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-form__input--disabled--BorderSize) var(--pf-c-form__input--disabled--BorderColor);
+      border-color: var(--pf-c-form__input--disabled--BorderColor);
     }
   }
 
@@ -264,7 +265,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
       padding-right: var(--pf-c-form__input--m-error--PaddingRight);
       color: var(--pf-c-form--m-error--Color);
       background-color: var(--pf-c-form__input__m-error--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-form__input--m-error--BorderSize) var(--pf-c-form__input--m-error--BorderColor);
+      border-color: var(--pf-c-form__input--m-error--BorderColor);
       @include pf-bg-svg($pf-c-form__select--m-error-svg--Coordinates, $pf-c-form__select--m-error-svg--Color, $pf-c-form__select--m-error-svg--Width, $pf-c-form__select--m-error-svg--Height, $pf-c-form__select--m-error-svg--Viewbox);
     }
 
@@ -294,7 +295,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     &:disabled {
       color: var(--pf-c-form__input--disabled--Color);
       background-color: var(--pf-c-form__input--disabled--BackgroundColor);
-      box-shadow: inset 0 0 0 var(--pf-c-form__input--disabled--BorderSize) var(--pf-c-form__input--disabled--BorderColor);
+      border-color: var(--pf-c-form__input--disabled--BorderColor);
       @include pf-bg-svg($pf-c-form__select--chevron-svg--Coordinates, $pf-c-form__select--chevron-svg--disabled--Color, $pf-c-form__select--chevron-svg--Width, $pf-c-form__select--chevron-svg--Height);
     }
 

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -52,7 +52,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
   --pf-c-form__input--hover--BorderSize:          var(--pf-global--BorderWidth--md);
   --pf-c-form__input--focus--BorderSize:          var(--pf-global--BorderWidth--md);
   --pf-c-form__input--disabled--BorderSize:       var(--pf-global--BorderWidth--sm);
-  --pf-c-form__input--BorderColor:                var(--pf-global--BorderColor--dark);
+  --pf-c-form__input--BoxShadowColor:             var(--pf-global--BorderColor--dark);
   --pf-c-form__input--hover--BorderColor:         var(--pf-global--BorderColor--dark);
   --pf-c-form__input--focus--BorderColor:         var(--pf-global--BorderColor--active);
   --pf-c-form__input--disabled--BorderColor:      var(--pf-global--BorderColor--disabled);
@@ -85,7 +85,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
   // Select
   --pf-c-form__select--PaddingRight: calc(#{$pf-global--spacer--sm} + #{$pf-global--spacer--md} + #{var(--pf-c-form__input--FontSize)});
 
-  // Checkbox 
+  // Checkbox
   --pf-c-form__checkbox--MarginRight: var(--pf-global--spacer--md);
 
   // Group
@@ -135,7 +135,7 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     }
   }
 
-  // Group - label and control container 
+  // Group - label and control container
   // Note: Fieldset and legend are replaced groups. In order to have fieldset elements layout like a group, fieldset contents must be wrapped in __group.
   &__group,
   .pf-m-subsection-title {
@@ -227,10 +227,10 @@ $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
     line-height: var(--pf-c-form__input--LineHeight);
     color: var(--pf-c-form__input--Color);
     background-color: var(--pf-c-form__input--BackgroundColor);
-    border: 0;
+    border: var(--pf-c-form__input--BorderSize) solid transparent;
     border-radius: 0;
     outline: 0;
-    box-shadow: inset 0 0 0 var(--pf-c-form__input--BorderSize) var(--pf-c-form__input--BorderColor);
+    box-shadow: inset 0 0 0 var(--pf-c-form__input--BorderSize) var(--pf-c-form__input--BoxShadowColor);
 
     &::placeholder {
       color: var(--pf-c-form__input--placeholder--Color);

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -3,6 +3,7 @@
 .pf-c-modal-box {
   // Component variables
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-modal-box--BorderColor: transparent;
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xxl);
@@ -42,7 +43,7 @@
   min-height: var(--pf-c-modal-box--MinHeight);
   max-height: var(--pf-c-modal-box--MaxHeight);
   background-color: var(--pf-c-modal-box--BackgroundColor);
-  border: var(--pf-c-modal-box--BorderSize) solid transparent;
+  border: var(--pf-c-modal-box--BorderSize) solid var(--pf-c-modal-box--BorderColor);
   box-shadow: var(--pf-c-modal-box--BoxShadow);
 
   &.pf-m-lg {

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -3,6 +3,7 @@
 .pf-c-modal-box {
   // Component variables
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xxl);
   // MaxWidth is based on optimal line length for reading
@@ -31,7 +32,7 @@
   --pf-c-modal-box__footer--PaddingBottom: var(--pf-global--spacer--xl);
   --pf-c-modal-box__footer--PaddingLeft: var(--pf-global--spacer--xl);
 
-  // This component always needs to be light  
+  // This component always needs to be light
   @extend %pf-t-light;
 
   z-index: var(--pf-c-modal-box--ZIndex);
@@ -41,6 +42,7 @@
   min-height: var(--pf-c-modal-box--MinHeight);
   max-height: var(--pf-c-modal-box--MaxHeight);
   background-color: var(--pf-c-modal-box--BackgroundColor);
+  border: var(--pf-c-modal-box--BorderSize) solid transparent;
   box-shadow: var(--pf-c-modal-box--BoxShadow);
 
   &.pf-m-lg {


### PR DESCRIPTION
Update the borders for buttons and input fields to appear in high contrast mode on Edge in Windows 10.

<img width="711" alt="screen shot 2018-06-14 at 9 34 39 am" src="https://user-images.githubusercontent.com/4032718/41415275-363dbd0a-6fb6-11e8-86e2-fa5775d86d95.png">

fixes https://github.com/patternfly/patternfly-next/issues/286