### PR TITLE
fix(button): Adds aria-label to pf-m-action buttons

### DIFF
--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -8,6 +8,7 @@ Always add a modifier class to add color to the button.
 | -- | -- | -- |
 | `disabled="disabled"` | `.pf-c-button` | Indicates the disabled state of the `button` to assistive technologies. |
 | `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. |
+| `aria-label="[button label text]"` | `.pf-m-action` | Provides an accessible name for the button when an icon is used instead of text. |
 
 
 ## Usage

--- a/src/patternfly/components/Button/examples/buttonTypes.hbs
+++ b/src/patternfly/components/Button/examples/buttonTypes.hbs
@@ -14,6 +14,6 @@
     <i class="fas fa-plus-circle"></i> 
     Link button
 {{/button}}
-{{#> button btnClass="pf-m-action"}}
-    <i class="fas fa-times"></i> 
+{{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Remove\" "}}
+    <i class="fas fa-times"></i>
 {{/button}}

--- a/src/patternfly/demos/Modal/examples/modal-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-example.hbs
@@ -11,8 +11,8 @@
             {{/ split-item }}
             {{#> split-item classModifier="pf-m-secondary" }}
               {{!-- Once there is a link button, this should be one and alignment may need to be adjusted --}}
-              {{#> button btnClass="pf-m-action"}}
-                <i class="fas fa-times"></i>  
+              {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Close Dialog\" "}}
+                <i class="fas fa-times"></i>
               {{/ button}}
             {{/ split-item }}
           {{/ split }}

--- a/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
@@ -12,8 +12,8 @@
               {{/ split-item }}
               {{#> split-item classModifier="pf-m-secondary" }}
                 {{!-- Once there is a link button, this should be one and alignment may need to be adjusted --}}
-                {{#> button btnClass="pf-m-action"}}
-                  <i class="fas fa-times"></i>  
+                {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Close Dialog\" "}}
+                  <i class="fas fa-times"></i>
                 {{/ button}}
               {{/ split-item }}
             {{/ split }}

--- a/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
@@ -11,7 +11,7 @@
             {{/ split-item }}
             {{#> split-item classModifier="pf-m-secondary" }}
               {{!-- Once there is a link button, this should be one and alignment may need to be adjusted --}}
-              {{#> button btnClass="pf-m-action"}}
+              {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Close Dialog\" "}}
                 <i class="fas fa-times"></i>
               {{/ button}}
             {{/ split-item }}

--- a/src/patternfly/demos/SimpleFormDemo/examples/simple-form-demo-example.hbs
+++ b/src/patternfly/demos/SimpleFormDemo/examples/simple-form-demo-example.hbs
@@ -58,7 +58,7 @@
                 <option value="Source secret 3">
                 <option value="Source secret 4">
               {{/form-datalist}}
-              {{#> button btnClass="pf-m-action" aria-labelled-by="Remove"}}
+              {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Remove\" "}}
                 <i class="fas fa-times"></i>
               {{/button}}
             {{/form-control}}
@@ -174,7 +174,7 @@
                   {{#> form-label for="variable_value" hidden="true"}}Environment variable value{{/form-label}}
                   {{#> form-control}}
                     {{#> form-input id="variable_value" type="text" name="app_variable_value" placeholder="value"}}{{/form-input}}
-                    {{#> button btnClass="pf-m-action" aria-labelled-by="Remove"}}
+                    {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Remove\" "}}
                       <i class="fas fa-times"></i>
                     {{/button}}
                   {{/form-control}}


### PR DESCRIPTION
Adds `aria-label` attribute to the accessibility documentation for Button, and includes this attribute wherever the button with `pf-m-action` modifier class is used (i.e. the class used when using icons instead of text as the button label). 

Closes #320 