### PR TITLE
feat(upgrades): Add Upgrade Examples for Cards

### DIFF
--- a/src/patternfly/demos/CardUpgradeExamples/card-upgrade-examples.hbs
+++ b/src/patternfly/demos/CardUpgradeExamples/card-upgrade-examples.hbs
@@ -1,0 +1,6 @@
+<div class="pf-d-card-upgrade-examples {{pf-d-card-upgrade-examples--modifier}}"
+  {{#if pf-d-upgrade-examples__id}}
+    id="{{pf-d-card-upgrade-examples__id}}"
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/demos/CardUpgradeExamples/docs/code.md
+++ b/src/patternfly/demos/CardUpgradeExamples/docs/code.md
@@ -1,0 +1,13 @@
+## Overview
+
+When converting PatternFly 3 components to PatternFly 4 components, you must also take into consideration the layouts and sizings that PatternFly 3 utilized from Bootstrap 3.
+
+## Usage
+
+| PatternFly 3 | Replaced By | PatternFly 4 |
+| -- | -- | -- |
+| `<div class='container-fluid container-cards-pf'>` |  | `<div class='pf-l-grid pf-m-gutters'>` |
+| `<div class='col-sm-3'>` |  | `<div class='pf-l-grid__item pf-m-3-col'>` |
+| `<div class='card-pf'>` |  | `<div class='pf-c-card'` |
+| `<div class='card-pf-heading'>` `<h2 class='card-pf-title'></h2>` |  | `<div class='pf-c-card__header'>` |
+| `<div class='card-pf-body'>` |  | `<div class='pf-c-card__body'>`|

--- a/src/patternfly/demos/CardUpgradeExamples/examples/card-upgrade-examples-example1.hbs
+++ b/src/patternfly/demos/CardUpgradeExamples/examples/card-upgrade-examples-example1.hbs
@@ -1,0 +1,36 @@
+{{#> card-upgrade-examples}}
+<div class="cards-pf">
+  <div class="container-fluid container-cards-pf">
+    <div class="row row-cards-pf">
+      <div class="col-sm-3">
+        <div class="card-pf">
+          <div class="card-pf-heading">
+            <h2 class="card-pf-title">
+              Card Title
+            </h2>
+          </div>
+          <div class="card-pf-body">
+            <p>
+              Card Contents
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-3">
+        <div class="card-pf">
+          <div class="card-pf-heading">
+            <h2 class="card-pf-title">
+              Card Title
+            </h2>
+          </div>
+          <div class="card-pf-body">
+            <p>
+              Card Contents
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{{/card-upgrade-examples}}

--- a/src/patternfly/demos/CardUpgradeExamples/examples/card-upgrade-examples-example2.hbs
+++ b/src/patternfly/demos/CardUpgradeExamples/examples/card-upgrade-examples-example2.hbs
@@ -1,0 +1,24 @@
+{{#> card-upgrade-examples}}
+<div class="pf-l-grid pf-m-gutters">
+  <div class="pf-l-grid__item pf-m-3-col">
+    <div class="pf-c-card">
+      <div class="pf-c-card__header">
+        Header
+      </div>
+      <div class="pf-c-card__body">
+        Body
+      </div>
+    </div>
+  </div>
+  <div class="pf-l-grid__item pf-m-3-col">
+    <div class="pf-c-card">
+      <div class="pf-c-card__header">
+        Header
+      </div>
+      <div class="pf-c-card__body">
+        Body
+      </div>
+    </div>
+  </div>
+</div>
+{{/card-upgrade-examples}}

--- a/src/patternfly/demos/CardUpgradeExamples/examples/index.js
+++ b/src/patternfly/demos/CardUpgradeExamples/examples/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Documentation from '@siteComponents/Documentation';
+import Example from '@siteComponents/Example';
+import docs from '../docs/code.md';
+import CardupgradeexamplesExample1 from './card-upgrade-examples-example1.hbs';
+import CardupgradeexamplesExample2 from './card-upgrade-examples-example2.hbs';
+import '../styles.scss';
+
+export const Docs = docs;
+
+export default () => {
+  const cardUpgradeExamplesExample1 = CardupgradeexamplesExample1();
+  const cardUpgradeExamplesExample2 = CardupgradeexamplesExample2();
+
+  return (
+    <Documentation docs={Docs}>
+      <Example heading="PatternFly 3 Cards">
+        {cardUpgradeExamplesExample1}
+      </Example>
+      <Example heading="PatternFly 4 Cards">
+        {cardUpgradeExamplesExample2}
+      </Example>
+    </Documentation>
+  );
+};

--- a/src/patternfly/demos/CardUpgradeExamples/styles.scss
+++ b/src/patternfly/demos/CardUpgradeExamples/styles.scss
@@ -1,0 +1,86 @@
+@import "../../patternfly-utilities";
+
+// Component variables follow this formula:
+// --pf-d-upgrade-examples__element--modifier--state--PropertyCamelCase
+
+// The value of component scoped variables is always defined by a global variable:
+:root {
+  // Example block variable
+  --pf-d-upgrade-examples--Color: var(--pf-global--Color--dark-100);
+
+  // Example element variable
+  --pf-d-upgrade-examples__title--FontSize: var(--pf-global--FontSize--xxl);
+
+  // Example modifier variable
+  --pf-d-upgrade-examples--m-danger--BackgroundColor: var(--pf-global--danger-color);
+}
+
+.pf-d-card-upgrade-examples {
+  color: var(--pf-d-upgrade-examples--Color);
+
+  .row.row-cards-pf {
+    display: flex;
+  }
+  .col-sm-3 {
+    width: 25%;
+    margin-right: 35px;
+  }
+  .container-fluid {
+    padding-right: 20px;
+    padding-left: 20px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+  .container-cards-pf {
+    margin-top: 0;
+  }
+  .row-cards-pf {
+    padding-right: 20px;
+    padding-left: 20px;
+    margin-right: -10px;
+    margin-left: -10px;
+    &:first-child {
+      padding-top: 20px;
+    }
+  }
+  .cards-pf {
+    background: #f5f5f5;
+    .row-cards-pf {
+      padding: 0 20px;
+      &:first-child {
+        padding-top: 20px;
+        padding-bottom: 20px;
+      }
+    }
+  }
+  .card-pf {
+    padding: 0 20px;
+    margin: 0 -10px 20px;
+    background: #fff;
+    border-top: 2px solid transparent;
+    box-shadow: 0 1px 1px rgba(3, 3, 3, .175);
+    &-heading {
+      padding: 0 20px 0;
+      margin: 0 -20px 20px;
+      border-bottom: 1px solid #d1d1d1;
+    }
+    &-title {
+      padding-bottom: 10px;
+      line-height: 1.4;
+    }
+    &-body {
+      padding: 0 0 20px;
+      margin: 20px 0 0;
+    }
+  }
+
+  // Element
+  &__title {
+    font-size: var(--pf-d-upgrade-examples__title--FontSize);
+  }
+
+  // Modifier
+  &.pf-m-danger {
+    background-color: var(--pf-d-upgrade-examples--m-danger--BackgroundColor);
+  }
+}


### PR DESCRIPTION
This PR adds an upgrade example for those looking to move from PatternFly 3 to PatternFly 4. This particular example demonstrates the differences between Cards in PF3 vs PF4.

related to https://github.com/patternfly/patternfly-next/issues/334