### PR TITLE
Add close button, add title, update documentation, space footer buttons

### DIFF
--- a/src/patternfly/components/Backdrop/backdrop.hbs
+++ b/src/patternfly/components/Backdrop/backdrop.hbs
@@ -1,3 +1,3 @@
-<div class="pf-c-backdrop {{ pf-c-backdrop--modifier }}">
+<div class="pf-c-backdrop{{#if pf-c-backdrop--modifier}} {{pf-c-backdrop--modifier}}{{/if}}">
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -1,7 +1,10 @@
 <button class="pf-c-button {{ btnClass }}" 
   {{#if btnAttributes}}
     {{{ btnAttributes }}} 
-  {{/if}} 
+  {{/if}}
+  {{#if aria-label}}
+    aria-label="{{aria-label}}"
+  {{/if}}
   >
 
   {{#if @partial-block}}

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -1,10 +1,7 @@
 <button class="pf-c-button {{ btnClass }}" 
   {{#if btnAttributes}}
     {{{ btnAttributes }}} 
-  {{/if}}
-  {{#if aria-label}}
-    aria-label="{{aria-label}}"
-  {{/if}}
+  {{/if}} 
   >
 
   {{#if @partial-block}}

--- a/src/patternfly/components/ModalBox/docs/code.md
+++ b/src/patternfly/components/ModalBox/docs/code.md
@@ -1,6 +1,6 @@
 ## Overview
 
-A modal box is a generic rectangular container that can be used to build modals.  A modal box can have three optional sections: header, body, and footer. 
+A modal box is a generic rectangular container that can be used to build modals. A modal box can have three sections: header, body, and footer. Header or body is required, but not both.
 
 ## Accessibility
 
@@ -10,13 +10,16 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `aria-labeledby="TitleID"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required** |
 | `aria-describedby="ContentID"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|
+| `aria-label="Close Dialog"` | `.pf-c-modal-box__close` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
 
 ## Usage
 
 | Class                | Applied     | Outcome                                                                                                                                                                              |
 | -------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.pf-c-modal-box`          | `<div>`     | Creates a box containing content                                                                                                                                                     |
-| `.pf-c-modal-box__header`          | `<div>`     | Creates the header of a box.                                                                                                                                                     |
-| `.pf-c-modal-box__body`          | `<div>`     | Creates the body of a box.  ** Required.**                                                                                                                                                   |
-| `.pf-c-modal-box__footer`          | `<div>`     | Creates the footer of a box.                                                                                                                                                     |
-| `.pf-m-lg`          | `.pf-c-modal-box`     | Creates a wide version of the modal.                                                                                                                                                     |
+| `.pf-c-modal-box` |               `<div>` |           Initiates a modal box. **Required** |
+| `.pf-c-modal-box__header` |       `<div>` |           Initiates a modal box header. A modal box header is **required** if there is no modal box body. |
+| `.pf-c-modal-box__header-title` | `<div>` |           Initiates a modal box header title. |
+| `.pf-c-modal-box__body` |         `<div>` |           Initiates a modal box body. A modal box body is **required** if there is no modal box header. |
+| `.pf-c-modal-box__footer` |       `<div>` |           Initiates a modal box footer. |
+| `.pf-c-modal-box__button-close` |        `<button>` |        Initiates a modal box close button. The close button can be nested as the first item in the header or body. **Required** |
+| `.pf-m-lg` |                      `.pf-c-modal-box` | Modifies for a modal box width. |

--- a/src/patternfly/components/ModalBox/docs/code.md
+++ b/src/patternfly/components/ModalBox/docs/code.md
@@ -10,7 +10,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `aria-labeledby="TitleID"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required** |
 | `aria-describedby="ContentID"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|
-| `aria-label="Close Dialog"` | `.pf-c-modal-box__close` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
+| `aria-label="Close Dialog"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
 
 ## Usage
 
@@ -21,5 +21,5 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `.pf-c-modal-box__header-title` | `<div>` |           Initiates a modal box header title. |
 | `.pf-c-modal-box__body` |         `<div>` |           Initiates a modal box body. A modal box body is **required** if there is no modal box header. |
 | `.pf-c-modal-box__footer` |       `<div>` |           Initiates a modal box footer. |
-| `.pf-c-modal-box__button-close` |        `<button>` |        Initiates a modal box close button. The close button can be nested as the first item in the header or body. **Required** |
+| `.pf-c-modal-box__close` |        `<button>` |        Initiates a modal box close button container. The close container can be nested as the first item in the header or body. **Required** |
 | `.pf-m-lg` |                      `.pf-c-modal-box` | Modifies for a modal box width. |

--- a/src/patternfly/components/ModalBox/docs/code.md
+++ b/src/patternfly/components/ModalBox/docs/code.md
@@ -1,14 +1,15 @@
 ## Overview
 
-A modal box is a generic rectangular container that can be used to build modals. A modal box can have three sections: header, body, and footer. Header or body is required. If no `pf-c-modal-box__header-title` is used, alternative text with a corresponding `id` must be provided for the modal `aria-labeledby` value.
+A modal box is a generic rectangular container that can be used to build modals. A modal box can have three sections: header, body, and footer. Header or body is required. If no `pf-c-modal-box__header-title` is used, `aria-label="[title of modal]"` must be provided for `.pf-c-modal-box`.
 
 ## Accessibility
 
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
 | `role="dialog"` | `.pf-c-modal-box` | Identifies the element that serves as the modal container. **Required**|
-| `aria-labeledby="TitleID"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required** |
-| `aria-describedby="ContentID"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
+| `aria-labeledby="[id value of .pf-c-modal-box__header-title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-modal-box__header-title is present** |
+| `aria-label="[title of modal]"` | `.pf-c-modal-box` | Gives the modal an accessible name. **Required when .pf-c-modal-box__header-title is _not_ present** |
+| `aria-describedby="[id value of applicable content]"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|
 | `aria-label="Close Dialog"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
 
@@ -17,9 +18,9 @@ A modal box is a generic rectangular container that can be used to build modals.
 | Class                | Applied     | Outcome                                                                                                                                                                              |
 | -------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `.pf-c-modal-box` |               `<div>` |           Initiates a modal box. **Required** |
-| `.pf-c-modal-box__header` |       `<div>` |           Initiates a modal box header. A modal box header is **required** if there is no modal box body. |
-| `.pf-c-modal-box__header-title` | `<div>` |           Initiates a modal box header title. |
+| `.pf-c-modal-box__header` |       `<header>` |           Initiates a modal box header. A modal box header is **required** if there is no modal box body. |
+| `.pf-c-modal-box__header-title` | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>` |           Initiates a modal box header title. |
 | `.pf-c-modal-box__body` |         `<div>` |           Initiates a modal box body. A modal box body is **required** if there is no modal box header. |
-| `.pf-c-modal-box__footer` |       `<div>` |           Initiates a modal box footer. |
+| `.pf-c-modal-box__footer` |       `<footer>` |           Initiates a modal box footer. |
 | `.pf-c-modal-box__close` |        `<button>` |        Initiates a modal box close button container. The close container can be nested as the first item in the header or body. **Required** |
 | `.pf-m-lg` |                      `.pf-c-modal-box` | Modifies for a modal box width. |

--- a/src/patternfly/components/ModalBox/docs/code.md
+++ b/src/patternfly/components/ModalBox/docs/code.md
@@ -1,6 +1,6 @@
 ## Overview
 
-A modal box is a generic rectangular container that can be used to build modals. A modal box can have three sections: header, body, and footer. Header or body is required, but not both.
+A modal box is a generic rectangular container that can be used to build modals. A modal box can have three sections: header, body, and footer. Header or body is required. If no `pf-c-modal-box__header-title` is used, alternative text with a corresponding `id` must be provided for the modal `aria-labeledby` value.
 
 ## Accessibility
 

--- a/src/patternfly/components/ModalBox/examples/index.js
+++ b/src/patternfly/components/ModalBox/examples/index.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
+import ModalBoxBasicExampleRaw from '!raw!./modal-box-basic-example.hbs';
+import ModalBoxLgExampleRaw from '!raw!./modal-box-lg-example.hbs';
+import ModalBoxNoHeaderExampleRaw from '!raw!./modal-box-no-header-example.hbs';
 import docs from '../docs/code.md';
 import ModalBoxBasicExample from './modal-box-basic-example.hbs';
 import ModalBoxLgExample from './modal-box-lg-example.hbs';
+import ModalBoxNoHeaderExample from './modal-box-no-header-example.hbs';
 import '../styles.scss';
 
 export const Docs = docs;
@@ -11,11 +15,28 @@ export const Docs = docs;
 export default () => {
   const modalBoxBasicExample = ModalBoxBasicExample();
   const modalBoxLgExample = ModalBoxLgExample();
+  const modalBoxNoHeaderExample = ModalBoxNoHeaderExample();
 
   return (
     <Documentation docs={Docs}>
-      <Example heading="ModalBox Basic Example">{modalBoxBasicExample}</Example>
-      <Example heading="ModalBox Large Example">{modalBoxLgExample}</Example>
+      <Example
+        heading="ModalBox Basic Example"
+        handlebars={ModalBoxBasicExampleRaw}
+      >
+        {modalBoxBasicExample}
+      </Example>
+      <Example
+        heading="ModalBox Large Example"
+        handlebars={ModalBoxLgExampleRaw}
+      >
+        {modalBoxLgExample}
+      </Example>
+      <Example
+        heading="ModalBox No Header Example"
+        handlebars={ModalBoxNoHeaderExampleRaw}
+      >
+        {modalBoxNoHeaderExample}
+      </Example>
     </Documentation>
   );
 };

--- a/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
@@ -1,11 +1,15 @@
-{{#> modal-box pf-c-modal-box-modifier="" }}
-  {{#> modal-box-header pf-c-modal-box__header-modifier="" }}
-    Modal Header
+{{#> modal-box aria-labelledby="modal-title"}}
+  {{#> modal-box-header}}
+    {{#> modal-box-button-close id="modal-close"}}
+    {{/modal-box-button-close}}          
+    {{#> modal-box-header-title id="modal-title"}}
+      Modal Header
+    {{/modal-box-header-title}}
   {{/modal-box-header}}
-  {{#> modal-box-body pf-c-modal-box__content-modifier="" }}
+  {{#> modal-box-body}}
     Modal Body
   {{/modal-box-body}}
-  {{#> modal-box-footer pf-c-modal-box__footer-modifier="" }}
+  {{#> modal-box-footer}}
     Modal Footer
   {{/modal-box-footer}}
 {{/modal-box}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
@@ -1,7 +1,10 @@
 {{#> modal-box aria-labelledby="modal-title"}}
   {{#> modal-box-header}}
-    {{#> modal-box-button-close id="modal-close"}}
-    {{/modal-box-button-close}}          
+    {{#> modal-box-close}}
+      {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-close"}}
+        <i class="fas fa-times"></i>
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header-title id="modal-title"}}
       Modal Header
     {{/modal-box-header-title}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
@@ -1,11 +1,11 @@
-{{#> modal-box aria-labelledby="modal-title"}}
+{{#> modal-box modal-box--attributes='aria-labelledby="modal-title"'}}
   {{#> modal-box-header}}
     {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-close"}}
+      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog" id="modal-close"'}}
         <i class="fas fa-times"></i>
       {{/button}}
     {{/modal-box-close}}
-    {{#> modal-box-header-title id="modal-title"}}
+    {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-title"'}}
       Modal Header
     {{/modal-box-header-title}}
   {{/modal-box-header}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
@@ -1,16 +1,16 @@
-{{#> modal-box modal-box--attributes='aria-labelledby="modal-title"'}}
+{{#> modal-box modal-box--attributes='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
+  {{#> modal-box-close}}
+    {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
+      <i class="fas fa-times"></i>
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
-    {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
-        <i class="fas fa-times"></i>
-      {{/button}}
-    {{/modal-box-close}}
     {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-title"'}}
       Modal Header
     {{/modal-box-header-title}}
   {{/modal-box-header}}
-  {{#> modal-box-body}}
-    Modal Body
+  {{#> modal-box-body modal-box-body--attributes='id="modal-description"'}}
+    To support screen reader user awareness of the dialog text, the dialog text is wrapped in a div that is referenced by aria-describedby.
   {{/modal-box-body}}
   {{#> modal-box-footer}}
     Modal Footer

--- a/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
@@ -1,7 +1,7 @@
 {{#> modal-box modal-box--attributes='aria-labelledby="modal-title"'}}
   {{#> modal-box-header}}
     {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog" id="modal-close"'}}
+      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
         <i class="fas fa-times"></i>
       {{/button}}
     {{/modal-box-close}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
@@ -1,7 +1,7 @@
 {{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title"'}}
   {{#> modal-box-header}}
     {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog" id="modal-close"'}}
+      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
         <i class="fas fa-times"></i>
       {{/button}}
     {{/modal-box-close}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
@@ -1,11 +1,15 @@
-{{#> modal-box pf-c-modal-box--modifier="pf-m-lg" }}
-  {{#> modal-box-header pf-c-modal-box__header--modifier="" }}
-    Modal Header
+{{#> modal-box modal-box--modifier="pf-m-lg" aria-labelledby="modal-lg-title"}}
+  {{#> modal-box-header}}
+    {{#> modal-box-button-close id="modal-lg-close"}}
+    {{/modal-box-button-close}}          
+    {{#> modal-box-header-title id="modal-lg-title"}}
+      Modal Header
+    {{/modal-box-header-title}}
   {{/modal-box-header}}
-  {{#> modal-box-body pf-c-modal-box__content--modifier="" }}
+  {{#> modal-box-body}}
     Modal Body
   {{/modal-box-body}}
-  {{#> modal-box-footer pf-c-modal-box__footer--modifier="" }}
+  {{#> modal-box-footer}}
     Modal Footer
   {{/modal-box-footer}}
 {{/modal-box}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
@@ -1,11 +1,11 @@
-{{#> modal-box modal-box--modifier="pf-m-lg" aria-labelledby="modal-lg-title"}}
+{{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title"'}}
   {{#> modal-box-header}}
     {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-close"}}
+      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog" id="modal-close"'}}
         <i class="fas fa-times"></i>
       {{/button}}
     {{/modal-box-close}}
-    {{#> modal-box-header-title id="modal-lg-title"}}
+    {{#> modal-box-header-title  modal-box-header-title--type="h2" modal-box-header-title--attributes='id="modal-lg-title"'}}
       Modal Header
     {{/modal-box-header-title}}
   {{/modal-box-header}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
@@ -1,16 +1,19 @@
-{{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title"'}}
+{{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
+  {{#> modal-box-close}}
+    {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
+      <i class="fas fa-times"></i>
+    {{/button}}
+  {{/modal-box-close}}
   {{#> modal-box-header}}
-    {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
-        <i class="fas fa-times"></i>
-      {{/button}}
-    {{/modal-box-close}}
     {{#> modal-box-header-title  modal-box-header-title--type="h2" modal-box-header-title--attributes='id="modal-lg-title"'}}
       Modal Header
     {{/modal-box-header-title}}
   {{/modal-box-header}}
-  {{#> modal-box-body}}
-    Modal Body
+  {{#> modal-box-body modal-box-body--attributes='id="modal-lg-description"'}}
+    Static text describing modal purpose. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat.
   {{/modal-box-body}}
   {{#> modal-box-footer}}
     Modal Footer

--- a/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
@@ -1,7 +1,10 @@
 {{#> modal-box modal-box--modifier="pf-m-lg" aria-labelledby="modal-lg-title"}}
   {{#> modal-box-header}}
-    {{#> modal-box-button-close id="modal-lg-close"}}
-    {{/modal-box-button-close}}          
+    {{#> modal-box-close}}
+      {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-close"}}
+        <i class="fas fa-times"></i>
+      {{/button}}
+    {{/modal-box-close}}
     {{#> modal-box-header-title id="modal-lg-title"}}
       Modal Header
     {{/modal-box-header-title}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
@@ -1,7 +1,7 @@
 {{#> modal-box modal-box--attributes='aria-labelledby="modal-title"'}}
   {{#> modal-box-body}}
     {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog" id="modal-close"'}}
+      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
         <i class="fas fa-times"></i>
       {{/button}}
     {{/modal-box-close}}  

--- a/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
@@ -1,0 +1,21 @@
+{{#> modal-box modal-box--attributes='aria-labelledby="modal-title"'}}
+  {{#> modal-box-body}}
+    {{#> modal-box-close}}
+      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog" id="modal-close"'}}
+        <i class="fas fa-times"></i>
+      {{/button}}
+    {{/modal-box-close}}  
+    <p>
+      <span id="modal-title">Lorem ipsum dolor sit</span> amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  {{/modal-box-body}}
+  {{#> modal-box-footer}}
+    Modal Footer
+  {{/modal-box-footer}}
+{{/modal-box}}
+

--- a/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
@@ -1,18 +1,11 @@
-{{#> modal-box modal-box--attributes='aria-labelledby="modal-title"'}}
+{{#> modal-box modal-box--attributes='aria-label="Example of a modal without a header" aria-describedby="modal-no-header-description"'}}
+  {{#> modal-box-close}}
+    {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
+      <i class="fas fa-times"></i>
+    {{/button}}
+  {{/modal-box-close}}  
   {{#> modal-box-body}}
-    {{#> modal-box-close}}
-      {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
-        <i class="fas fa-times"></i>
-      {{/button}}
-    {{/modal-box-close}}  
-    <p>
-      <span id="modal-title">Lorem ipsum dolor sit</span> amet, consectetur adipisicing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-    </p>
+    <span id="modal-no-header-description">When static text describing the modal is available, it can be wrapped with an ID referring to the modal's aria-describedby value. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   {{/modal-box-body}}
   {{#> modal-box-footer}}
     Modal Footer

--- a/src/patternfly/components/ModalBox/modal-box-body.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-body.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-modal-box__body{{#if modal-box-body--modifier}} {{modal-box-body--modifier}}{{/if}}"
-  {{#if id}}
-    id="{{id}}"
+<div class="pf-c-modal-box__body{{#if modal-box-body--modifiers}} {{modal-box-body--modifiers}}{{/if}}"
+  {{#if modal-box-body--attributes}}
+    {{{modal-box-body--attributes}}}
   {{/if}}
 >
   {{> @partial-block}}

--- a/src/patternfly/components/ModalBox/modal-box-body.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-body.hbs
@@ -1,3 +1,7 @@
-<div class="pf-c-modal-box__body {{ pf-c-modal-box__body--modifier }}">
+<div class="pf-c-modal-box__body{{#if modal-box-body--modifier}} {{modal-box-body--modifier}}{{/if}}"
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+>
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/ModalBox/modal-box-button-close.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-button-close.hbs
@@ -1,7 +1,0 @@
-<button class="pf-c-modal-box__button-close{{#if modal-box-button-close--modifier}} {{modal-box-button-close--modifier}}{{/if}}" aria-label="Close Dialog"
-  {{#if id}}
-    id="{{id}}"
-  {{/if}}
->  
-  <i class="fas fa-times"></i>
-</button>

--- a/src/patternfly/components/ModalBox/modal-box-button-close.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-button-close.hbs
@@ -1,0 +1,7 @@
+<button class="pf-c-modal-box__button-close{{#if modal-box-button-close--modifier}} {{modal-box-button-close--modifier}}{{/if}}" aria-label="Close Dialog"
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+>  
+  <i class="fas fa-times"></i>
+</button>

--- a/src/patternfly/components/ModalBox/modal-box-close.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-close.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-modal-box__close{{#if modal-box-close--modifier}} {{modal-box-close--modifier}}{{/if}}"
-  {{#if id}}
-    id="{{id}}"
+<div class="pf-c-modal-box__close{{#if modal-box-close--modifiers}} {{modal-box-close--modifiers}}{{/if}}"
+  {{#if modal-box-close--attributes}}
+    {{{modal-box-close--attributes}}}
   {{/if}}
 >
   {{> @partial-block}}

--- a/src/patternfly/components/ModalBox/modal-box-close.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-close.hbs
@@ -1,0 +1,7 @@
+<div class="pf-c-modal-box__close{{#if modal-box-close--modifier}} {{modal-box-close--modifier}}{{/if}}"
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/ModalBox/modal-box-footer.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-footer.hbs
@@ -1,3 +1,7 @@
-<div class="pf-c-modal-box__footer {{ pf-c-modal-box__footer--modifier }}">
+<div class="pf-c-modal-box__footer{{#if modal-box-footer--modifier}} {{modal-box-footer--modifier}}{{/if}}"
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+>
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/ModalBox/modal-box-footer.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-footer.hbs
@@ -1,7 +1,7 @@
-<div class="pf-c-modal-box__footer{{#if modal-box-footer--modifier}} {{modal-box-footer--modifier}}{{/if}}"
+<footer class="pf-c-modal-box__footer{{#if modal-box-footer--modifier}} {{modal-box-footer--modifier}}{{/if}}"
   {{#if modal-box-footer--attributes}}
     {{{modal-box-footer--attributes}}}
   {{/if}}
 >
   {{> @partial-block}}
-</div>
+</footer>

--- a/src/patternfly/components/ModalBox/modal-box-footer.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-footer.hbs
@@ -1,6 +1,6 @@
 <div class="pf-c-modal-box__footer{{#if modal-box-footer--modifier}} {{modal-box-footer--modifier}}{{/if}}"
-  {{#if id}}
-    id="{{id}}"
+  {{#if modal-box-footer--attributes}}
+    {{{modal-box-footer--attributes}}}
   {{/if}}
 >
   {{> @partial-block}}

--- a/src/patternfly/components/ModalBox/modal-box-header-title.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header-title.hbs
@@ -1,7 +1,7 @@
-<h4 class="pf-c-modal-box__header-title{{#if modal-box-header-title--modifier}} {{modal-box-header-title--modifier}}{{/if}}" 
-  {{#if id}}
-    id="{{id}}"
+<{{#if modal-box-header-title--type}}{{modal-box-header-title--type}}{{else}}h1{{/if}} class="pf-c-modal-box__header-title{{#if modal-box-header-title--modifiers}} {{modal-box-header-title--modifiers}}{{/if}}" 
+  {{#if modal-box-header-title--attributes}}
+    {{{modal-box-header-title--attributes}}}
   {{/if}}
 >
   {{> @partial-block}}
-</h4>
+</{{#if modal-box-header-title--type}}{{modal-box-header-title--type}}{{else}}h1{{/if}}>

--- a/src/patternfly/components/ModalBox/modal-box-header-title.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header-title.hbs
@@ -1,0 +1,7 @@
+<h4 class="pf-c-modal-box__header-title{{#if modal-box-header-title--modifier}} {{modal-box-header-title--modifier}}{{/if}}" 
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+>
+  {{> @partial-block}}
+</h4>

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,7 +1,7 @@
-<div class="pf-c-modal-box__header{{#if modal-box-header--modifiers}} {{modal-box-header--modifiers}}{{/if}}" 
+<header class="pf-c-modal-box__header{{#if modal-box-header--modifiers}} {{modal-box-header--modifiers}}{{/if}}" 
   {{#if modal-box-header--attributes}}
     {{{modal-box-header--attributes}}}
   {{/if}}
 >  
   {{> @partial-block}}
-</div>
+</header>

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,3 +1,7 @@
-<div class="pf-c-modal-box__header {{ pf-c-modal-box__header--modifier }}">
+<div class="pf-c-modal-box__header{{#if modal-box-header--modifier}} {{modal-box-header--modifier}}{{/if}}" 
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+>  
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/ModalBox/modal-box-header.hbs
+++ b/src/patternfly/components/ModalBox/modal-box-header.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-modal-box__header{{#if modal-box-header--modifier}} {{modal-box-header--modifier}}{{/if}}" 
-  {{#if id}}
-    id="{{id}}"
+<div class="pf-c-modal-box__header{{#if modal-box-header--modifiers}} {{modal-box-header--modifiers}}{{/if}}" 
+  {{#if modal-box-header--attributes}}
+    {{{modal-box-header--attributes}}}
   {{/if}}
 >  
   {{> @partial-block}}

--- a/src/patternfly/components/ModalBox/modal-box.hbs
+++ b/src/patternfly/components/ModalBox/modal-box.hbs
@@ -1,17 +1,9 @@
-<div class="pf-c-modal-box{{#if modal-box--modifier}} {{modal-box--modifier}}{{/if}}"
+<div class="pf-c-modal-box{{#if modal-box--modifiers}} {{modal-box--modifiers}}{{/if}}"
   role="dialog" 
   aria-modal="true"
-  {{#if id}}
-    id="{{id}}"
-  {{/if}}
-  {{#if aria-labelledby}}
-    aria-labelledby="{{aria-labelledby}}"
-  {{else}}
-    [Missing required aria-labelledby value]
-  {{/if}}
-  {{#if aria-describedby}}
-    aria-describedby="{{aria-describedby}}"
-  {{/if}}
+  {{#if modal-box--attributes}}
+    {{{modal-box--attributes}}} 
+  {{/if}}  
 >
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/ModalBox/modal-box.hbs
+++ b/src/patternfly/components/ModalBox/modal-box.hbs
@@ -1,9 +1,17 @@
-<div class="pf-c-modal-box {{ pf-c-modal-box--modifier }}" 
+<div class="pf-c-modal-box{{#if modal-box--modifier}} {{modal-box--modifier}}{{/if}}"
   role="dialog" 
-  aria-labelledby="{{ pf-c-modal-box__label }}"
-  {{#if pf-c-model-box__description}}
-    aria-describedby="{{ pf-c-model-box__description }}"
+  aria-modal="true"
+  {{#if id}}
+    id="{{id}}"
   {{/if}}
-  aria-modal="true">
+  {{#if aria-labelledby}}
+    aria-labelledby="{{aria-labelledby}}"
+  {{else}}
+    [Missing required aria-labelledby value]
+  {{/if}}
+  {{#if aria-describedby}}
+    aria-describedby="{{aria-describedby}}"
+  {{/if}}
+>
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -2,24 +2,37 @@
 
 .pf-c-modal-box {
   // Component variables
+  $pf-c-modal-box--breakpoint-sm--Height: 400px;
+  $pf-c-modal-box--breakpoint-md--Height: 700px;
+
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-modal-box--BorderColor: transparent;
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-modal-box--LineClamp: 3;
+  --pf-c-modal-box--MaxLineClamp: 5;
   --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--2xl);
   // MaxWidth is based on optimal line length for reading
   --pf-c-modal-box--MaxWidth: pf-size-prem(560px);
-  --pf-c-modal-box--MaxWidth--lg: pf-size-prem(1120px);
+  --pf-c-modal-box--lg--MaxWidth: pf-size-prem(1120px);
+
   // MinHeight is based on all the spacers we know we have, plus some LineHeight to make some space for at least one line of content in each section
   --pf-c-modal-box--MinHeight: calc(var(--pf-c-modal-box__header--PaddingTop) + var(--pf-c-modal-box__header--PaddingBottom) + var(--pf-c-modal-box__body--PaddingTop) + var(--pf-c-modal-box__body--PaddingBottom) + var(--pf-c-modal-box__footer--PaddingTop) + var(--pf-c-modal-box__footer--PaddingBottom) + calc(1rem * 4 * var(--pf-global--LineHeight--md)));
   // MaxHeight ensures that the modal will not go off the screen and instead the body will scroll
-  --pf-c-modal-box--MaxHeight: calc(100vh - (2 * (var(--pf-global--spacer--3xl))));
+  --pf-c-modal-box--MaxHeight: calc(100vh - var(--pf-global--spacer--2xl));
+  --pf-c-modal-box--MarginRight: var(--pf-global--spacer--md);
+  --pf-c-modal-box--MarginLeft: var(--pf-c-modal-box--MarginRight);
 
   // Box Header variables
   --pf-c-modal-box__header--PaddingTop: var(--pf-global--spacer--xl);
   --pf-c-modal-box__header--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-modal-box__header--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-modal-box__header--PaddingLeft: var(--pf-global--spacer--xl);
+
+  // Box Header Title
+  --pf-c-modal-box__header-title--FontSize: var(--pf-c-title--m-3xl--FontSize);
+  --pf-c-modal-box__header-title--FontWeight: var(--pf-c-title--m-3xl--FontWeight);
+  --pf-c-modal-box__header-title--LineHeight: var(--pf-c-title--m-3xl--LineHeight);
 
   // Box Body variables
   --pf-c-modal-box__body--PaddingTop: var(--pf-global--spacer--sm);
@@ -33,31 +46,104 @@
   --pf-c-modal-box__footer--PaddingBottom: var(--pf-global--spacer--xl);
   --pf-c-modal-box__footer--PaddingLeft: var(--pf-global--spacer--xl);
 
+  // Box Footer Button variables
+  --pf-c-modal-box__footer--ButtonSpacer: var(--pf-global--spacer--md);
+  --pf-c-modal-box__footer--ItemSpacer: var(--pf-global--spacer--xs);
+
+  // Box button-close variables
+  --pf-c-modal-box__button-close--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-modal-box__button-close--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-modal-box__button-close--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-modal-box__button-close--PaddingLeft: var(--pf-global--spacer--sm);
+  --pf-c-modal-box__button-close--FontSize: var(--pf-global--FontSize--xl);
+  --pf-c-modal-box__button-close--Color: var(--pf-global--Color--100);
+  --pf-c-modal-box__button-close--hover--Color: var(--pf-global--Color--200);
+  --pf-c-modal-box__button-close--hover--BackgroundColor: transparent;
+
   // This component always needs to be light
   @extend %pf-t-light;
 
   z-index: var(--pf-c-modal-box--ZIndex);
   display: flex;
   flex-direction: column;
-  max-width: var(--pf-c-modal-box--MaxWidth);
+  // Ensure modal has margins at breakpoint - sm
+  max-width: calc(100% - var(--pf-c-modal-box--MarginLeft) - var(--pf-c-modal-box--MarginRight));
   min-height: var(--pf-c-modal-box--MinHeight);
   max-height: var(--pf-c-modal-box--MaxHeight);
   background-color: var(--pf-c-modal-box--BackgroundColor);
   border: var(--pf-c-modal-box--BorderSize) solid var(--pf-c-modal-box--BorderColor);
   box-shadow: var(--pf-c-modal-box--BoxShadow);
 
-  &.pf-m-lg {
-    max-width: var(--pf-c-modal-box--MaxWidth--lg);
+  // At breakpoint--sm, set max width to variable value and ignore margins
+  &:not(.pf-m-lg) {
+    @media screen and (min-width: $pf-global--breakpoint--sm) {
+      max-width: var(--pf-c-modal-box--MaxWidth);
+    }
   }
 
+  // At breakpoint--xl, set max width to variable value and ignore margins
+  &.pf-m-lg {
+    @media screen and (min-width: $pf-global--breakpoint--xl) {
+      max-width: var(--pf-c-modal-box--lg--MaxWidth);
+    }
+  }
+
+  // Header
   &__header {
     flex: 0 0 auto;
     padding-top: var(--pf-c-modal-box__header--PaddingTop);
     padding-right: var(--pf-c-modal-box__header--PaddingRight);
     padding-bottom: var(--pf-c-modal-box__header--PaddingBottom);
     padding-left: var(--pf-c-modal-box__header--PaddingLeft);
+
+    // Header title
+    &-title {
+      overflow: hidden;
+      font-size: var(--pf-c-modal-box__header-title--FontSize);
+      font-weight: var(--pf-c-modal-box__header-title--FontWeight);
+      line-height: var(--pf-c-modal-box__header-title--LineHeight);
+
+      // If -webkit-line-clamp is supported
+      @supports (-webkit-line-clamp: var(--pf-c-modal-box--LineClamp)) {
+        // Limit maximum number of lines to six
+        /* stylelint-disable */
+        display: -webkit-box;
+        -webkit-line-clamp: var(--pf-c-modal-box--MaxLineClamp);
+        -webkit-box-orient: vertical;
+        /* stylelint-enable */
+
+        // at smaller than $pf-c-modal-box--breakpoint-sm--Height: reset display and set single line overflow ellipsis
+        @media screen and (max-height: $pf-c-modal-box--breakpoint-sm--Height) {
+          display: block;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        // between $pf-c-modal-box--breakpoint-sm--Height and $pf-c-modal-box--breakpoint-md--Height: set line clamp
+        @media screen and (min-height: $pf-c-modal-box--breakpoint-sm--Height) and (max-height: $pf-c-modal-box--breakpoint-md--Height) {
+          /* stylelint-disable */
+          -webkit-line-clamp: var(--pf-c-modal-box--LineClamp);
+          /* stylelint-enable */
+        }
+      }
+
+      // If -webkit-line-clamp is not supported, limit text to overflow to single line
+      @supports not (-webkit-line-clamp: var(--pf-c-modal-box--LineClamp)) {
+        @media screen and (max-height: $pf-c-modal-box--breakpoint-sm--Height) {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        // Reset overflow: hidden
+        @media screen and (min-height: $pf-c-modal-box--breakpoint-sm--Height) {
+          overflow: visible;
+        }
+      }
+    }
   }
 
+  // Body
   &__body {
     flex: 1 1 auto;
     padding-top: var(--pf-c-modal-box__body--PaddingTop);
@@ -69,12 +155,50 @@
     overscroll-behavior: contain;
   }
 
+  // Footer
   &__footer {
+    display: flex;
     flex: 0 0 auto;
+    align-items: center;
     padding-top: var(--pf-c-modal-box__footer--PaddingTop);
     padding-right: var(--pf-c-modal-box__footer--PaddingRight);
     padding-bottom: var(--pf-c-modal-box__footer--PaddingBottom);
     padding-left: var(--pf-c-modal-box__footer--PaddingLeft);
+
+    // Using margin-left instead of justify: flex-end; as there may be other elements in the footer that align left
+    // Limit scope to direct child buttons, allows use of layouts if needed
+    > .pf-c-button:first-of-type {
+      margin-left: auto;
+    }
+
+    > .pf-c-button:not(:last-child) {
+      // Base margin left and right equal for buttons when wrapped
+      margin-right: calc(var(--pf-c-modal-box__footer--ButtonSpacer) / 2);
+
+      @media screen and (min-width: $pf-global--breakpoint--sm) {
+        margin-right: var(--pf-c-modal-box__footer--ButtonSpacer);
+      }
+    }
+  }
+
+  // Button close
+  &__button-close {
+    float: right;
+    padding-top: var(--pf-c-modal-box__button-close--PaddingTop);
+    padding-right: var(--pf-c-modal-box__button-close--PaddingRight);
+    padding-bottom: var(--pf-c-modal-box__button-close--PaddingBottom);
+    padding-left: var(--pf-c-modal-box__button-close--PaddingLeft);
+    // Offset margins by padding-right value
+    margin-right: calc(var(--pf-c-modal-box__button-close--PaddingRight) * -1);
+    font-size: var(--pf-c-modal-box__button-close--FontSize);
+    line-height: 1;
+    color: var(--pf-c-modal-box__button-close--Color);
+    border: 0;
+
+    &:hover {
+      color: var(--pf-c-modal-box__button-close--hover--Color);
+      background-color: var(--pf-c-modal-box__button-close--hover--BackgroundColor);
+    }
   }
 
   // If the first child isn't a header, then we need to put the header's top padding there

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -2,6 +2,7 @@
 
 .pf-c-modal-box {
   // Component variables
+  // Use sass variables defining height breakpoints to simplify use in multiple media queries that require these values.
   $pf-c-modal-box--breakpoint-sm--Height: 400px;
   $pf-c-modal-box--breakpoint-md--Height: 700px;
 
@@ -52,8 +53,8 @@
   --pf-c-modal-box__footer--PaddingLeft: var(--pf-global--spacer--xl);
 
   // Box Footer Button variables
+  // Button spacer is used to manipulate margin-left and/or margin-right values at various breakpoints, with a single value.
   --pf-c-modal-box__footer--ButtonSpacer: var(--pf-global--spacer--md);
-  --pf-c-modal-box__footer--ItemSpacer: var(--pf-global--spacer--xs);
 
   // This component always needs to be light
   @extend %pf-t-light;
@@ -110,17 +111,19 @@
           /* stylelint-disable */
           display: -webkit-box;
           overflow: hidden;
-          -webkit-line-clamp: var(--pf-c-modal-box--LineClamp);
+          -webkit-line-clamp: var(--pf-c-modal-box--MaxLineClamp);
+          line-clamp: var(--pf-c-modal-box--MaxLineClamp);
           -webkit-box-orient: vertical;
           /* stylelint-enable */
         }
 
-        // Up to max width $pf-global--breakpoint--sm: limit lines to 5
+        // Up to max width $pf-global--breakpoint--sm: limit lines to --pf-c-modal-box--MaxLineClamp
         @media screen and (max-width: $pf-global--breakpoint--sm) and (min-height: $pf-c-modal-box--breakpoint-md--Height) {
           /* stylelint-disable */
           display: -webkit-box;
           overflow: hidden;
           -webkit-line-clamp: var(--pf-c-modal-box--MaxLineClamp);
+          line-clamp: var(--pf-c-modal-box--MaxLineClamp);
           -webkit-box-orient: vertical;
           /* stylelint-enable */
         }

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -51,14 +51,8 @@
   --pf-c-modal-box__footer--ItemSpacer: var(--pf-global--spacer--xs);
 
   // Box button-close variables
-  --pf-c-modal-box__button-close--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-modal-box__button-close--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-modal-box__button-close--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-modal-box__button-close--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-modal-box__button-close--FontSize: var(--pf-global--FontSize--xl);
-  --pf-c-modal-box__button-close--Color: var(--pf-global--Color--100);
-  --pf-c-modal-box__button-close--hover--Color: var(--pf-global--Color--200);
-  --pf-c-modal-box__button-close--hover--BackgroundColor: transparent;
+  --pf-c-modal-box__close--MarginRight: calc(var(--pf-global--spacer--sm) * -1);
+  --pf-c-modal-box__close--MarginTop: calc(var(--pf-global--spacer--sm) * -1);
 
   // This component always needs to be light
   @extend %pf-t-light;
@@ -98,31 +92,38 @@
 
     // Header title
     &-title {
-      overflow: hidden;
       font-size: var(--pf-c-modal-box__header-title--FontSize);
       font-weight: var(--pf-c-modal-box__header-title--FontWeight);
       line-height: var(--pf-c-modal-box__header-title--LineHeight);
 
       // If -webkit-line-clamp is supported
       @supports (-webkit-line-clamp: var(--pf-c-modal-box--LineClamp)) {
-        // Limit maximum number of lines to six
-        /* stylelint-disable */
-        display: -webkit-box;
-        -webkit-line-clamp: var(--pf-c-modal-box--MaxLineClamp);
-        -webkit-box-orient: vertical;
-        /* stylelint-enable */
 
-        // at smaller than $pf-c-modal-box--breakpoint-sm--Height: reset display and set single line overflow ellipsis
+        // Up to max height $pf-c-modal-box--breakpoint-sm--Height: reset display and set single line overflow ellipsis
         @media screen and (max-height: $pf-c-modal-box--breakpoint-sm--Height) {
-          display: block;
+          // display: block;
+          overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
         }
 
-        // between $pf-c-modal-box--breakpoint-sm--Height and $pf-c-modal-box--breakpoint-md--Height: set line clamp
+        // Between min height $pf-c-modal-box--breakpoint-sm--Height and max height $pf-c-modal-box--breakpoint-md--Height: set line clamp
         @media screen and (min-height: $pf-c-modal-box--breakpoint-sm--Height) and (max-height: $pf-c-modal-box--breakpoint-md--Height) {
           /* stylelint-disable */
+          display: -webkit-box;
+          overflow: hidden;
           -webkit-line-clamp: var(--pf-c-modal-box--LineClamp);
+          -webkit-box-orient: vertical;
+          /* stylelint-enable */
+        }
+
+        // Up to max width $pf-global--breakpoint--sm: limit lines to 5
+        @media screen and (max-width: $pf-global--breakpoint--sm) and (min-height: $pf-c-modal-box--breakpoint-md--Height) {
+          /* stylelint-disable */
+          display: -webkit-box;
+          overflow: hidden;
+          -webkit-line-clamp: var(--pf-c-modal-box--MaxLineClamp);
+          -webkit-box-orient: vertical;
           /* stylelint-enable */
         }
       }
@@ -133,11 +134,6 @@
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
-        }
-
-        // Reset overflow: hidden
-        @media screen and (min-height: $pf-c-modal-box--breakpoint-sm--Height) {
-          overflow: visible;
         }
       }
     }
@@ -153,6 +149,10 @@
     overflow-x: hidden;
     overflow-y: auto;
     overscroll-behavior: contain;
+
+    .pf-c-modal-box__close {
+      margin-top: var(--pf-c-modal-box__close--MarginTop);
+    }
   }
 
   // Footer
@@ -182,23 +182,9 @@
   }
 
   // Button close
-  &__button-close {
+  &__close {
     float: right;
-    padding-top: var(--pf-c-modal-box__button-close--PaddingTop);
-    padding-right: var(--pf-c-modal-box__button-close--PaddingRight);
-    padding-bottom: var(--pf-c-modal-box__button-close--PaddingBottom);
-    padding-left: var(--pf-c-modal-box__button-close--PaddingLeft);
-    // Offset margins by padding-right value
-    margin-right: calc(var(--pf-c-modal-box__button-close--PaddingRight) * -1);
-    font-size: var(--pf-c-modal-box__button-close--FontSize);
-    line-height: 1;
-    color: var(--pf-c-modal-box__button-close--Color);
-    border: 0;
-
-    &:hover {
-      color: var(--pf-c-modal-box__button-close--hover--Color);
-      background-color: var(--pf-c-modal-box__button-close--hover--BackgroundColor);
-    }
+    margin-right: var(--pf-c-modal-box__close--MarginRight);
   }
 
   // If the first child isn't a header, then we need to put the header's top padding there

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -24,6 +24,10 @@
   --pf-c-modal-box--MarginLeft: var(--pf-c-modal-box--MarginRight);
 
   // Box Header variables
+  --pf-c-modal-box__close--Top: var(--pf-global--spacer--sm);
+  --pf-c-modal-box__close--Right: var(--pf-global--spacer--md);
+
+  // Box Header variables
   --pf-c-modal-box__header--PaddingTop: var(--pf-global--spacer--xl);
   --pf-c-modal-box__header--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-modal-box__header--PaddingBottom: var(--pf-global--spacer--sm);
@@ -39,6 +43,7 @@
   --pf-c-modal-box__body--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-modal-box__body--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-modal-box__body--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-modal-box__body--MarginTop: var(--pf-global--spacer--xl);
 
   // Box Footer variables
   --pf-c-modal-box__footer--PaddingTop: var(--pf-global--spacer--xl);
@@ -53,6 +58,7 @@
   // This component always needs to be light
   @extend %pf-t-light;
 
+  position: relative;
   z-index: var(--pf-c-modal-box--ZIndex);
   display: flex;
   flex-direction: column;
@@ -135,9 +141,17 @@
   &__body {
     flex: 1 1 auto;
     padding: var(--pf-c-modal-box__body--PaddingTop) var(--pf-c-modal-box__body--PaddingRight) var(--pf-c-modal-box__body--PaddingBottom) var(--pf-c-modal-box__body--PaddingLeft);
+    // Adding margin top here for no header being present. When the header is present, margin-top is removed
+    margin-top: var(--pf-c-modal-box__body--MarginTop);
     overflow-x: hidden;
     overflow-y: auto;
     overscroll-behavior: contain;
+    word-break: break-word;
+  }
+
+  // Removing top margin when header is present
+  &__header + &__body {
+    margin-top: 0;
   }
 
   // Footer
@@ -165,13 +179,9 @@
 
   // Button close
   &__close {
-    float: right;
-  }
-
-  // If the first child isn't a header, then we need to put the header's top padding there
-  &__body:first-child,
-  &__footer:first-child {
-    padding-top: var(--pf-c-modal-box__header--PaddingTop);
+    position: absolute;
+    top: var(--pf-c-modal-box__close--Top);
+    right: var(--pf-c-modal-box__close--Right);
   }
 
   // If the last child isn't the footer, then we need to put the footer's bottom padding there

--- a/src/patternfly/components/ModalBox/styles.scss
+++ b/src/patternfly/components/ModalBox/styles.scss
@@ -50,10 +50,6 @@
   --pf-c-modal-box__footer--ButtonSpacer: var(--pf-global--spacer--md);
   --pf-c-modal-box__footer--ItemSpacer: var(--pf-global--spacer--xs);
 
-  // Box button-close variables
-  --pf-c-modal-box__close--MarginRight: calc(var(--pf-global--spacer--sm) * -1);
-  --pf-c-modal-box__close--MarginTop: calc(var(--pf-global--spacer--sm) * -1);
-
   // This component always needs to be light
   @extend %pf-t-light;
 
@@ -85,10 +81,7 @@
   // Header
   &__header {
     flex: 0 0 auto;
-    padding-top: var(--pf-c-modal-box__header--PaddingTop);
-    padding-right: var(--pf-c-modal-box__header--PaddingRight);
-    padding-bottom: var(--pf-c-modal-box__header--PaddingBottom);
-    padding-left: var(--pf-c-modal-box__header--PaddingLeft);
+    padding: var(--pf-c-modal-box__header--PaddingTop) var(--pf-c-modal-box__header--PaddingRight) var(--pf-c-modal-box__header--PaddingBottom) var(--pf-c-modal-box__header--PaddingLeft);
 
     // Header title
     &-title {
@@ -101,7 +94,6 @@
 
         // Up to max height $pf-c-modal-box--breakpoint-sm--Height: reset display and set single line overflow ellipsis
         @media screen and (max-height: $pf-c-modal-box--breakpoint-sm--Height) {
-          // display: block;
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
@@ -142,17 +134,10 @@
   // Body
   &__body {
     flex: 1 1 auto;
-    padding-top: var(--pf-c-modal-box__body--PaddingTop);
-    padding-right: var(--pf-c-modal-box__body--PaddingRight);
-    padding-bottom: var(--pf-c-modal-box__body--PaddingBottom);
-    padding-left: var(--pf-c-modal-box__body--PaddingLeft);
+    padding: var(--pf-c-modal-box__body--PaddingTop) var(--pf-c-modal-box__body--PaddingRight) var(--pf-c-modal-box__body--PaddingBottom) var(--pf-c-modal-box__body--PaddingLeft);
     overflow-x: hidden;
     overflow-y: auto;
     overscroll-behavior: contain;
-
-    .pf-c-modal-box__close {
-      margin-top: var(--pf-c-modal-box__close--MarginTop);
-    }
   }
 
   // Footer
@@ -160,10 +145,7 @@
     display: flex;
     flex: 0 0 auto;
     align-items: center;
-    padding-top: var(--pf-c-modal-box__footer--PaddingTop);
-    padding-right: var(--pf-c-modal-box__footer--PaddingRight);
-    padding-bottom: var(--pf-c-modal-box__footer--PaddingBottom);
-    padding-left: var(--pf-c-modal-box__footer--PaddingLeft);
+    padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-c-modal-box__footer--PaddingRight) var(--pf-c-modal-box__footer--PaddingBottom) var(--pf-c-modal-box__footer--PaddingLeft);
 
     // Using margin-left instead of justify: flex-end; as there may be other elements in the footer that align left
     // Limit scope to direct child buttons, allows use of layouts if needed
@@ -184,7 +166,6 @@
   // Button close
   &__close {
     float: right;
-    margin-right: var(--pf-c-modal-box__close--MarginRight);
   }
 
   // If the first child isn't a header, then we need to put the header's top padding there

--- a/src/patternfly/demos/Modal/docs/code.md
+++ b/src/patternfly/demos/Modal/docs/code.md
@@ -1,8 +1,8 @@
-## Overview
+<!-- ## Overview -->
 
 This demo implements a basic modal, including the backdrop. Both the normal and large variations of the modal are shown.
 
-## Accessibility
+<!-- ## Accessibility
 
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
@@ -16,3 +16,4 @@ This demo implements a basic modal, including the backdrop. Both the normal and 
 | Class | Applies to | Outcome |
 | -- | -- | -- |
 | `.pf-d-modal` | `<div>` |  Initiates a modal. |
+ -->

--- a/src/patternfly/demos/Modal/examples/modal-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-example.hbs
@@ -1,18 +1,18 @@
 {{#> modal}}
   {{#> backdrop}}
     {{#> bullseye}}
-      {{#> modal-box aria-labelledby="modal-title" aria-describedby="modal-description"}}
+      {{#> modal-box modal-box--attributes='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
         {{#> modal-box-header}}
           {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-close"}}
+            {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
               <i class="fas fa-times"></i>
             {{/button}}
           {{/modal-box-close}}
-          {{#> modal-box-header-title id="modal-title"}}
+          {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-title"'}}
             Overwrite existing file?
           {{/modal-box-header-title}}
         {{/modal-box-header}}
-        {{#> modal-box-body id="modal-description"}}
+        {{#> modal-box-body modal-box-body--attributes='id="modal-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
         {{/modal-box-body}}

--- a/src/patternfly/demos/Modal/examples/modal-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-example.hbs
@@ -1,37 +1,27 @@
 {{#> modal}}
-  {{#> backdrop }}
-    {{#> bullseye }}
-      {{#> modal-box pf-c-modal-box-modifier="" pf-c-modal-box__label="titleID" pf-c-model-box__description="descriptionID"}}
-        {{#> modal-box-header }}
-          {{#> split}}
-            {{#> split-item classModifier="pf-m-primary"}}
-              {{#> title titleType="h1" pf-c-title--Modifier="pf-m-3xl" pf-c-title--ID="titleID" }}
-                Overwrite existing file?
-              {{/title}}
-            {{/ split-item }}
-            {{#> split-item classModifier="pf-m-secondary" }}
-              {{!-- Once there is a link button, this should be one and alignment may need to be adjusted --}}
-              {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Close Dialog\" "}}
-                <i class="fas fa-times"></i>
-              {{/ button}}
-            {{/ split-item }}
-          {{/ split }}
-        {{/ modal-box-header }}
-        {{#> modal-box-body }}
+  {{#> backdrop}}
+    {{#> bullseye}}
+      {{#> modal-box aria-labelledby="modal-title" aria-describedby="modal-description"}}
+        {{#> modal-box-header}}
+          {{#> modal-box-button-close id="modal-close"}}
+          {{/modal-box-button-close}}          
+          {{#> modal-box-header-title id="modal-title"}}
+            Overwrite existing file?
+          {{/modal-box-header-title}}
+        {{/modal-box-header}}
+        {{#> modal-box-body id="modal-description"}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
-        {{/ modal-box-body }}
-        {{#> modal-box-footer }}
-          <div class="pf-l-alignment pf-m-right">
-            {{#> button}}
-              Save a copy
-            {{/ button }}
-            {{#> button btnClass="pf-m-primary"}}
-              Overwrite
-            {{/button}}
-          </div>
-        {{/ modal-box-footer }}
-      {{/ modal-box}}
-    {{/ bullseye }}
-  {{/ backdrop }}
-{{/ modal }}
+        {{/modal-box-body}}
+        {{#> modal-box-footer}}
+          {{#> button}}
+            Save a copy
+          {{/button}}
+          {{#> button btnClass="pf-m-primary"}}
+            Overwrite
+          {{/button}}
+        {{/modal-box-footer}}
+      {{/modal-box}}
+    {{/bullseye}}
+  {{/backdrop}}
+{{/modal}}

--- a/src/patternfly/demos/Modal/examples/modal-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-example.hbs
@@ -3,8 +3,11 @@
     {{#> bullseye}}
       {{#> modal-box aria-labelledby="modal-title" aria-describedby="modal-description"}}
         {{#> modal-box-header}}
-          {{#> modal-box-button-close id="modal-close"}}
-          {{/modal-box-button-close}}          
+          {{#> modal-box-close}}
+            {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-close"}}
+              <i class="fas fa-times"></i>
+            {{/button}}
+          {{/modal-box-close}}
           {{#> modal-box-header-title id="modal-title"}}
             Overwrite existing file?
           {{/modal-box-header-title}}

--- a/src/patternfly/demos/Modal/examples/modal-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-example.hbs
@@ -2,12 +2,12 @@
   {{#> backdrop}}
     {{#> bullseye}}
       {{#> modal-box modal-box--attributes='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
+        {{#> modal-box-close}}
+          {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
+            <i class="fas fa-times"></i>
+          {{/button}}
+        {{/modal-box-close}}
         {{#> modal-box-header}}
-          {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
-              <i class="fas fa-times"></i>
-            {{/button}}
-          {{/modal-box-close}}
           {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-title"'}}
             Overwrite existing file?
           {{/modal-box-header-title}}

--- a/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
@@ -2,12 +2,12 @@
   {{#> backdrop}}
     {{#> bullseye}}
       {{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
+        {{#> modal-box-close}}
+          {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
+            <i class="fas fa-times"></i>
+          {{/button}}
+        {{/modal-box-close}}
         {{#> modal-box-header}}
-          {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
-              <i class="fas fa-times"></i>
-            {{/button}}
-          {{/modal-box-close}}
           {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-lg-title"'}}
             This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
           {{/modal-box-header-title}}

--- a/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
@@ -4,7 +4,7 @@
       {{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
         {{#> modal-box-header}}
           {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" btnAttributes='id="modal-lg-close" aria-label="Close Dialog"'}}
+            {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
               <i class="fas fa-times"></i>
             {{/button}}
           {{/modal-box-close}}

--- a/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
@@ -1,14 +1,14 @@
 {{#> modal}}
   {{#> backdrop}}
     {{#> bullseye}}
-      {{#> modal-box modal-box--modifier="pf-m-lg" aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"}}
+      {{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
         {{#> modal-box-header}}
           {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-lg-close"}}
+            {{#> button btnClass="pf-m-action" btnAttributes='id="modal-lg-close" aria-label="Close Dialog"'}}
               <i class="fas fa-times"></i>
             {{/button}}
           {{/modal-box-close}}
-          {{#> modal-box-header-title id="modal-lg-title"}}
+          {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-lg-title"'}}
             This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
           {{/modal-box-header-title}}
         {{/modal-box-header}}

--- a/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
@@ -1,38 +1,27 @@
 {{#> modal}}
-  {{#> backdrop }}
-    {{#> bullseye }}
-      {{#> bullseye-item }}
-        {{#> modal-box pf-c-modal-box--modifier="pf-m-lg" pf-c-modal-box__label="titleID" pf-c-model-box__description="descriptionID"}}
-          {{#> modal-box-header }}
-            {{#> split}}
-              {{#> split-item classModifier="pf-m-primary"}}
-                {{#> title titleType="h1" pf-c-title--Modifier="pf-m-3xl" pf-c-title--ID="titleID" }}
-                  Modal overlay title (large example)
-                {{/title}}
-              {{/ split-item }}
-              {{#> split-item classModifier="pf-m-secondary" }}
-                {{!-- Once there is a link button, this should be one and alignment may need to be adjusted --}}
-                {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Close Dialog\" "}}
-                  <i class="fas fa-times"></i>
-                {{/ button}}
-              {{/ split-item }}
-            {{/ split }}
-          {{/ modal-box-header }}
-          {{#> modal-box-body }}
-            <p>Form here</p>
-          {{/ modal-box-body }}
-          {{#> modal-box-footer }}
-            <div class="pf-l-alignment pf-m-right">
-              {{#> button}}
-                Cancel
-              {{/ button }}
-              {{#> button btnClass="pf-m-primary"}}
-                Save
-              {{/button}}
-            </div>
-          {{/ modal-box-footer }}
-        {{/ modal-box}}
-      {{/ bullseye-item }}
-    {{/ bullseye }}
-  {{/ backdrop }}
-{{/ modal }}
+  {{#> backdrop}}
+    {{#> bullseye}}
+      {{#> modal-box modal-box--modifier="pf-m-lg" aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"}}
+        {{#> modal-box-header}}
+          {{#> modal-box-button-close id="modal-lg-close"}}
+          {{/modal-box-button-close}}        
+          {{#> modal-box-header-title id="modal-lg-title"}}
+            This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
+          {{/modal-box-header-title}}
+        {{/modal-box-header}}
+        {{#> modal-box-body}}
+          <p id="modal-lg-description">The "aria-describedby" attribute can be applied to any text that adequately describes the modal's purpose. It does not have to be assigned to ".pf-c-modal-box__body"</p>
+          <p>Form here</p>
+        {{/modal-box-body}}
+        {{#> modal-box-footer}}
+          {{#> button}}
+            Cancel
+          {{/button}}
+          {{#> button btnClass="pf-m-primary"}}
+            Save
+          {{/button}}
+        {{/modal-box-footer}}
+      {{/modal-box}}
+    {{/bullseye}}
+  {{/backdrop}}
+{{/modal}}

--- a/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-lg-example.hbs
@@ -3,8 +3,11 @@
     {{#> bullseye}}
       {{#> modal-box modal-box--modifier="pf-m-lg" aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"}}
         {{#> modal-box-header}}
-          {{#> modal-box-button-close id="modal-lg-close"}}
-          {{/modal-box-button-close}}        
+          {{#> modal-box-close}}
+            {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-lg-close"}}
+              <i class="fas fa-times"></i>
+            {{/button}}
+          {{/modal-box-close}}
           {{#> modal-box-header-title id="modal-lg-title"}}
             This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
           {{/modal-box-header-title}}

--- a/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
@@ -1,44 +1,34 @@
 {{#> modal}}
-  {{#> backdrop }}
-    {{#> bullseye }}
-      {{#> modal-box pf-c-modal-box-modifier="" pf-c-modal-box__label="titleID" pf-c-model-box__description="descriptionID"}}
-        {{#> modal-box-header }}
-          {{#> split}}
-            {{#> split-item classModifier="pf-m-primary"}}
-              {{#> title titleType="h1" pf-c-title--Modifier="pf-m-3xl" pf-c-title--ID="titleID" }}
-                Overwrite existing file?
-              {{/title}}
-            {{/ split-item }}
-            {{#> split-item classModifier="pf-m-secondary" }}
-              {{!-- Once there is a link button, this should be one and alignment may need to be adjusted --}}
-              {{#> button btnClass="pf-m-action" btnAttributes="aria-label=\"Close Dialog\" "}}
-                <i class="fas fa-times"></i>
-              {{/ button}}
-            {{/ split-item }}
-          {{/ split }}
-        {{/ modal-box-header }}
-        {{#> modal-box-body }}
+  {{#> backdrop}}
+    {{#> bullseye}}
+      {{#> modal-box aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"}}
+        {{#> modal-box-header}}
+          {{#> modal-box-button-close id="modal-scroll-close"}}
+          {{/modal-box-button-close}}
+          {{#> modal-box-header-title id="modal-scroll-title"}}
+            This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
+          {{/modal-box-header-title}}
+        {{/modal-box-header}}
+        {{#> modal-box-body id="modal-scroll-description"}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
-<p>Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Integer tincidunt. Integer tincidunt. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-Duis leo. Praesent blandit laoreet nibh. Ut a nisl id ante tempus hendrerit. Maecenas nec odio et ante tincidunt tempus.
-Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.
-Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
-Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.
-Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
-</p>
-        {{/ modal-box-body }}
-        {{#> modal-box-footer }}
-          <div class="pf-l-alignment pf-m-right">
-            {{#> button}}
-              Save a copy
-            {{/ button }}
-            {{#> button btnClass="pf-m-primary"}}
-              Overwrite
-            {{/button}}
-          </div>
-        {{/ modal-box-footer }}
-      {{/ modal-box}}
-    {{/ bullseye }}
-  {{/ backdrop }}
-{{/ modal }}
+    <p>Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Integer tincidunt. Integer tincidunt. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+    Duis leo. Praesent blandit laoreet nibh. Ut a nisl id ante tempus hendrerit. Maecenas nec odio et ante tincidunt tempus.
+    Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.
+    Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
+    Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.
+    Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
+    </p>
+        {{/modal-box-body}}
+        {{#> modal-box-footer}}
+          {{#> button}}
+            Save a copy
+          {{/button}}
+          {{#> button btnClass="pf-m-primary"}}
+            Overwrite
+          {{/button}}
+        {{/modal-box-footer}}
+      {{/modal-box}}
+    {{/bullseye}}
+  {{/backdrop}}
+{{/modal}}

--- a/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
@@ -1,18 +1,18 @@
 {{#> modal}}
   {{#> backdrop}}
     {{#> bullseye}}
-      {{#> modal-box aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"}}
+      {{#> modal-box modal-box--attributes='aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"'}}
         {{#> modal-box-header}}
           {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-scroll-close"}}
+            {{#> button btnClass="pf-m-action" btnAttributes='id="modal-scroll-close" aria-label="Close Dialog"'}}
               <i class="fas fa-times"></i>
             {{/button}}
           {{/modal-box-close}}
-          {{#> modal-box-header-title id="modal-scroll-title"}}
+          {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-scroll-title"'}}
             This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
           {{/modal-box-header-title}}
         {{/modal-box-header}}
-        {{#> modal-box-body id="modal-scroll-description"}}
+        {{#> modal-box-body modal-box-body--attributes='id="modal-scroll-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
     <p>Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Integer tincidunt. Integer tincidunt. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.

--- a/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
@@ -3,8 +3,11 @@
     {{#> bullseye}}
       {{#> modal-box aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"}}
         {{#> modal-box-header}}
-          {{#> modal-box-button-close id="modal-scroll-close"}}
-          {{/modal-box-button-close}}
+          {{#> modal-box-close}}
+            {{#> button btnClass="pf-m-action" aria-label="Close Dialog" id="modal-scroll-close"}}
+              <i class="fas fa-times"></i>
+            {{/button}}
+          {{/modal-box-close}}
           {{#> modal-box-header-title id="modal-scroll-title"}}
             This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
           {{/modal-box-header-title}}

--- a/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
@@ -2,12 +2,12 @@
   {{#> backdrop}}
     {{#> bullseye}}
       {{#> modal-box modal-box--attributes='aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"'}}
+        {{#> modal-box-close}}
+          {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
+            <i class="fas fa-times"></i>
+          {{/button}}
+        {{/modal-box-close}}
         {{#> modal-box-header}}
-          {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
-              <i class="fas fa-times"></i>
-            {{/button}}
-          {{/modal-box-close}}
           {{#> modal-box-header-title modal-box-header-title--attributes='id="modal-scroll-title"'}}
             This header text is long and will wrap. This text will be truncated when the viewport height or width is limited. To see this in action, reduce the height and/or width of the viewport.
           {{/modal-box-header-title}}
@@ -15,13 +15,13 @@
         {{#> modal-box-body modal-box-body--attributes='id="modal-scroll-description"'}}
           <p>general_modal_final_finalfinal_v9_actualfinal.sketch</p>
           <p>A file with this name already exists, would you like to overwrite the existing file or save a new copy?</p>
-    <p>Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Integer tincidunt. Integer tincidunt. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
-    Duis leo. Praesent blandit laoreet nibh. Ut a nisl id ante tempus hendrerit. Maecenas nec odio et ante tincidunt tempus.
-    Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.
-    Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
-    Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.
-    Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
-    </p>
+          <p>Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Integer tincidunt. Integer tincidunt. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+          <p>Duis leo. Praesent blandit laoreet nibh. Ut a nisl id ante tempus hendrerit. Maecenas nec odio et ante tincidunt tempus.
+          Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.</p>
+          <p>Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.</p>
+          <p>Ut a nisl id ante tempus hendrerit. Nulla sit amet est. Suspendisse nisl elit, rhoncus eget, elementum ac, condimentum eget, diam. Praesent turpis. Phasellus accumsan cursus velit. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Cras ultricies mi eu turpis hendrerit fringilla. Praesent porttitor, nulla vitae posuere iaculis, arcu nisl dignissim dolor, a pretium mi sem ut ipsum.</p>
+          <p>Etiam sit amet orci eget eros faucibus tincidunt. Aliquam eu nunc. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Nunc nec neque.
+          </p>
         {{/modal-box-body}}
         {{#> modal-box-footer}}
           {{#> button}}

--- a/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
+++ b/src/patternfly/demos/Modal/examples/modal-scroll-example.hbs
@@ -4,7 +4,7 @@
       {{#> modal-box modal-box--attributes='aria-labelledby="modal-scroll-title" aria-describedby="modal-scroll-description"'}}
         {{#> modal-box-header}}
           {{#> modal-box-close}}
-            {{#> button btnClass="pf-m-action" btnAttributes='id="modal-scroll-close" aria-label="Close Dialog"'}}
+            {{#> button btnClass="pf-m-action" btnAttributes='aria-label="Close Dialog"'}}
               <i class="fas fa-times"></i>
             {{/button}}
           {{/modal-box-close}}

--- a/src/patternfly/demos/Modal/modal.hbs
+++ b/src/patternfly/demos/Modal/modal.hbs
@@ -1,3 +1,1 @@
-<div class="pf-d-modal {{ pf-d-modal--modifier }}">
-    {{> @partial-block }}
-</div>
+{{> @partial-block }}

--- a/src/patternfly/layouts/Bullseye/bullseye.hbs
+++ b/src/patternfly/layouts/Bullseye/bullseye.hbs
@@ -1,3 +1,3 @@
-<div class="pf-l-bullseye {{ modifierClass }}">
+<div class="pf-l-bullseye{{#if pf-l-bullseye--modifier}} {{pf-l-bullseye--modifier}}{{/if}}">
   {{> @partial-block }}
 </div>

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -224,7 +224,7 @@
 
   tr:nth-child(even) {background: #f1f1f1}
   
-  h2 {
+  h2:not(.pf-c-modal-box__header-title) {
     margin-top: 2rem;
     margin-bottom: 1rem;
     font-size: 1.25em;


### PR DESCRIPTION
Fixes #433 
Closes #336 
Closes #445

- Added close button to modal
- Added title to modal
- Updated modal width to accommodate margin left/right for smaller viewport widths
- Updated documentation
- Added styling for footer buttons

Note: I updated the handlebars attributes as some were prefixed and some were not. This approach, aside from prefix--modifier is most concise/makes most sense to me.

