### PR TITLE
update(button, link, dropdown): add link button examples, updates documentation for buttons, links and dropdowns

### DIFF
--- a/src/patternfly/components/Button/button-link.hbs
+++ b/src/patternfly/components/Button/button-link.hbs
@@ -1,0 +1,12 @@
+<a href="{{button--href}}" class="pf-c-button{{#if btnClass}} {{btnClass}}{{/if}}{{#if button--disabled}} pf-m-disabled{{/if}}"
+  {{#if btnAttributes}}
+    {{{btnAttributes}}} 
+  {{/if}}
+  {{#if button--disabled}}
+    aria-disabled="true"
+    tabindex="-1"
+  {{/if}}>
+  {{#if @partial-block}}
+    {{> @partial-block}}
+  {{/if}}
+</a>

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -1,8 +1,11 @@
-<button class="pf-c-button {{ btnClass }}" 
+<button class="pf-c-button{{#if btnClass}} {{btnClass}}{{/if}}{{#if button--disabled}} pf-m-disabled{{/if}}"
   {{#if btnAttributes}}
     {{{ btnAttributes }}} 
   {{/if}} 
-  >
+  {{#if button--disabled}}
+    aria-disabled="disabled"
+    disabled 
+  {{/if}}>
 
   {{#if @partial-block}}
     {{> @partial-block }}

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -3,7 +3,7 @@
     {{{ btnAttributes }}} 
   {{/if}} 
   {{#if button--disabled}}
-    aria-disabled="disabled"
+    aria-disabled="true"
     disabled 
   {{/if}}>
 

--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -3,12 +3,10 @@
     {{{ btnAttributes }}} 
   {{/if}} 
   {{#if button--disabled}}
-    aria-disabled="true"
     disabled 
   {{/if}}>
 
   {{#if @partial-block}}
     {{> @partial-block }}
   {{/if}}
-  
 </button>

--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -10,7 +10,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |
 | `disabled` | `.pf-c-button` | Indicates the disabled state of the `button` to user agents. **Required when button is disabled** |
-| `aria-disabled="true"` | `.pf-c-button`, `a.pf-c-button` | Indicates the disabled state of the `button` or `a` to assistive technologies. **Required when link or button is disabled** |
+| `aria-disabled="true"` | `a.pf-c-button` | Indicates the disabled state of the `a` to assistive technologies. **Required when link is disabled** |
 | `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
 | `aria-label="[button label text]"` | `.pf-m-action` | Provides an accessible name for the button when an icon is used instead of text. **Required when icon is used with no supporting text** |
 | `aria-label="[link description]"` | `a.pf-c-button` | The link text should adequately describe the link's purpose. If it does not, aria-label can provide more detailed interaction information. As a rule, always provide an aria-label value for hyperlinks. |

--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -9,12 +9,12 @@ Semantic buttons and links are important for usability as well as accessibility.
 
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |
-| `disabled` | `.pf-c-button` | Indicates the disabled state of the `button` to user agents. **Required when button is disabled** |
-| `aria-disabled="true"` | `a.pf-c-button` | Indicates the disabled state of the `a` to assistive technologies. **Required when link is disabled** |
 | `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
 | `aria-label="[button label text]"` | `.pf-m-action` | Provides an accessible name for the button when an icon is used instead of text. **Required when icon is used with no supporting text** |
 | `aria-label="[link description]"` | `a.pf-c-button` | The link text should adequately describe the link's purpose. If it does not, aria-label can provide more detailed interaction information. As a rule, always provide an aria-label value for hyperlinks. |
-| `tabindex="-1"` | `a.pf-c-button` | Indicates that the link should be unreachable to user agents and assistive technologies. **Required when link is disabled** |
+| `disabled` | `button.pf-c-button` | When a button element is used, indicates that it is unavailable and removes it from keyboard focus. **Required when button is disabled** |
+| `aria-disabled="true"` | `a.pf-c-button` | When a link element is used, indicates that it is unavailable. **Required when link is disabled** |
+| `tabindex="-1"` | `a.pf-c-button` | When a link element is used, removes it from keyboard focus. **Required when link is disabled** |
 
 ## Usage
 

--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -11,7 +11,7 @@ Semantic buttons and links are important for usability as well as accessibility.
 | -- | -- | -- |
 | `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
 | `aria-label="[button label text]"` | `.pf-m-action` | Provides an accessible name for the button when an icon is used instead of text. **Required when icon is used with no supporting text** |
-| `aria-label="[link description]"` | `a.pf-c-button` | The link text should adequately describe the link's purpose. If it does not, aria-label can provide more detailed interaction information. As a rule, always provide an aria-label value for hyperlinks. |
+| `aria-label="[link description]"` | `a.pf-c-button` | The link text should adequately describe the link's purpose. If it does not, aria-label can provide more detailed interaction information. |
 | `disabled` | `button.pf-c-button` | When a button element is used, indicates that it is unavailable and removes it from keyboard focus. **Required when button is disabled** |
 | `aria-disabled="true"` | `a.pf-c-button` | When a link element is used, indicates that it is unavailable. **Required when link is disabled** |
 | `tabindex="-1"` | `a.pf-c-button` | When a link element is used, removes it from keyboard focus. **Required when link is disabled** |

--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -2,20 +2,25 @@
 
 Always add a modifier class to add color to the button.
 
+## Button vs Link
+Semantic buttons and links are important for usability as well as accessibility. Using an `a` instead of a `button` element to perform user initiated actions should be avoided, unless absolutely necessary.
+
 ## Accessibility
 
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |
-| `disabled="disabled"` | `.pf-c-button` | Indicates the disabled state of the `button` to assistive technologies. |
-| `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. |
-| `aria-label="[button label text]"` | `.pf-m-action` | Provides an accessible name for the button when an icon is used instead of text. |
-
+| `disabled` | `.pf-c-button` | Indicates the disabled state of the `button` to user agents. **Required when button is disabled** |
+| `aria-disabled="true"` | `.pf-c-button`, `a.pf-c-button` | Indicates the disabled state of the `button` or `a` to assistive technologies. **Required when link or button is disabled** |
+| `aria-pressed="true or false"` | `.pf-c-button` | Indicates that the button is a toggle. When set to "true", `pf-m-active` should also be set so that the button displays in an active state. **Required when button is a toggle** |
+| `aria-label="[button label text]"` | `.pf-m-action` | Provides an accessible name for the button when an icon is used instead of text. **Required when icon is used with no supporting text** |
+| `aria-label="[link description]"` | `a.pf-c-button` | The link text should adequately describe the link's purpose. If it does not, aria-label can provide more detailed interaction information. As a rule, always provide an aria-label value for hyperlinks. |
+| `tabindex="-1"` | `a.pf-c-button` | Indicates that the link should be unreachable to user agents and assistive technologies. **Required when link is disabled** |
 
 ## Usage
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. |
+| `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. **Required** |
 | `.pf-m-primary` | `.pf-c-button` | Modifies for primary styles. |
 | `.pf-m-secondary` | `.pf-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-c-button` | Modifies for tertiary styles. |

--- a/src/patternfly/components/Button/examples/button-link-example.hbs
+++ b/src/patternfly/components/Button/examples/button-link-example.hbs
@@ -1,0 +1,9 @@
+{{#> button-link button--href="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" btnClass="pf-m-primary"}}
+    Primary Link to W3.org
+{{/button-link}}
+{{#> button-link button--href="#overview" btnClass="pf-m-secondary"}}
+    Secondary Link to Anchor
+{{/button-link}}
+{{#> button-link button--href="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" btnClass="pf-m-tertiary" button--disabled="true"}}
+    Tertiary Link to W3.org
+{{/button-link}}

--- a/src/patternfly/components/Button/examples/button-link-example.hbs
+++ b/src/patternfly/components/Button/examples/button-link-example.hbs
@@ -1,7 +1,7 @@
 {{#> button-link button--href="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" btnClass="pf-m-primary"}}
     Primary Link to W3.org
 {{/button-link}}
-{{#> button-link button--href="#overview" btnClass="pf-m-secondary"}}
+{{#> button-link button--href="#overview" btnClass="pf-m-secondary" btnAttributes='aria-label="Read more about button documentation"'}}
     Secondary Link to Anchor
 {{/button-link}}
 {{#> button-link button--href="https://www.w3.org/TR/WCAG20-TECHS/ARIA8.html#ARIA8-examples" btnClass="pf-m-tertiary" button--disabled="true"}}

--- a/src/patternfly/components/Button/examples/buttonStates.hbs
+++ b/src/patternfly/components/Button/examples/buttonStates.hbs
@@ -8,7 +8,7 @@
     {{#> button btnClass="pf-m-primary pf-m-active"}}
         Primary Active
     {{/button}}
-    {{#> button btnClass="pf-m-primary pf-m-disabled" btnAttributes="disabled=\"disabled\" " }}
+    {{#> button btnClass="pf-m-primary" button--disabled="true"}}
         Primary Disabled
     {{/button}}
 
@@ -21,7 +21,7 @@
     {{#> button btnClass="pf-m-secondary pf-m-active"}}
         Secondary Active
     {{/button}}
-    {{#> button btnClass="pf-m-secondary pf-m-disabled" btnAttributes="disabled=\"disabled\"" }}
+    {{#> button btnClass="pf-m-secondary" button--disabled="true"}}
         Secondary Disabled
     {{/button}}
 
@@ -34,7 +34,7 @@
     {{#> button btnClass="pf-m-tertiary pf-m-active"}}
         Tertiary Active
     {{/button}}
-    {{#> button btnClass="pf-m-tertiary pf-m-disabled" btnAttributes="disabled=\"disabled\"" }}
+    {{#> button btnClass="pf-m-tertiary" button--disabled="true"}}
         Tertiary Disabled
     {{/button}}
 
@@ -47,7 +47,7 @@
     {{#> button btnClass="pf-m-danger pf-m-active"}}
         Danger Active
     {{/button}}
-    {{#> button btnClass="pf-m-danger pf-m-disabled" btnAttributes="disabled=\"disabled\"" }}
+    {{#> button btnClass="pf-m-danger" button--disabled="true"}}
         Danger Disabled
     {{/button}}
 
@@ -64,7 +64,7 @@
         <i class="fas fa-plus-circle"></i> 
         Link button
     {{/button}}
-    {{#> button btnClass="pf-m-link pf-m-disabled" btnAttributes="disabled=\"disabled\"" }}
+    {{#> button btnClass="pf-m-link" button--disabled="true"}}
         <i class="fas fa-plus-circle"></i> 
         Link button
     {{/button}}

--- a/src/patternfly/components/Button/examples/index.js
+++ b/src/patternfly/components/Button/examples/index.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
+import ButtonTypesTemplateRaw from '!raw!./buttonTypes.hbs';
+import ButtonStatesTemplateRaw from '!raw!./buttonStates.hbs';
+import ButtonBlockTemplateRaw from '!raw!./buttonBlock.hbs';
+import ButtonLinkExampleRaw from '!raw!./button-link-example.hbs';
 import ButtonTypesTemplate from './buttonTypes.hbs';
 import ButtonStatesTemplate from './buttonStates.hbs';
+import ButtonLinkExample from './button-link-example.hbs';
 import ButtonBlockTemplate from './buttonBlock.hbs';
 import docs from '../docs/code.md';
 import '../styles.scss';
@@ -12,13 +17,26 @@ export const Docs = docs;
 export default () => {
   const buttonTypesTemplate = ButtonTypesTemplate();
   const buttonStatesTemplate = ButtonStatesTemplate();
+  const buttonLinkExample = ButtonLinkExample();
   const buttonBlockTemplate = ButtonBlockTemplate();
 
   return (
     <Documentation docs={Docs}>
-      <Example heading="Button Types">{buttonTypesTemplate}</Example>
-      <Example heading="Button States">{buttonStatesTemplate}</Example>
-      <Example heading="Button (Block Level)">{buttonBlockTemplate}</Example>
+      <Example heading="Button Types" handlebars={ButtonTypesTemplateRaw}>
+        {buttonTypesTemplate}
+      </Example>
+      <Example heading="Button States" handlebars={ButtonStatesTemplateRaw}>
+        {buttonStatesTemplate}
+      </Example>
+      <Example heading="Links as Buttons" handlebars={ButtonLinkExampleRaw}>
+        {buttonLinkExample}
+      </Example>
+      <Example
+        heading="Button (Block Level)"
+        handlebars={ButtonBlockTemplateRaw}
+      >
+        {buttonBlockTemplate}
+      </Example>
     </Documentation>
   );
 };

--- a/src/patternfly/components/Button/styles.scss
+++ b/src/patternfly/components/Button/styles.scss
@@ -149,6 +149,7 @@
   &:hover,
   &.pf-m-hover {
     color: var(--pf-c-button--hover--Color);
+    text-decoration: none;
     background-color: var(--pf-c-button--hover--BackgroundColor);
     &::after {
       border-color: var(--pf-c-button--hover--BorderColor);

--- a/src/patternfly/components/Dropdown/docs/code.md
+++ b/src/patternfly/components/Dropdown/docs/code.md
@@ -14,7 +14,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `aria-expanded="true"` | `.pf-c-dropdown__menu` | Indicates that the menu is visible |
 | `role="menuitem"` | `.pf-c-dropdown__menu-item` | Indicates that the menu item is a menu item |
 | `role="separator"` | `.pf-c-dropdown__separator` | Indicates that the separator is a separator |
-| `disabled="disabled"` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus |
+| `disabled` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus |
 | `aria-disabled="true"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, indicates that it is unavailable |
 | `tabindex="-1"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, removes it from keyboard focus |
 

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -6,7 +6,7 @@
     <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Link</a>
     <button class="pf-c-dropdown__menu-item" role="menuitem">Action</button>
     <a class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
-    <button class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" disabled="disabled">Disabled Action</button>
+    <button class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" disabled>Disabled Action</button>
     <div class="pf-c-dropdown__separator" role="separator"></div>
     <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Separated Link</a>
   </div>


### PR DESCRIPTION
Closes #402 

Add hyperlink button examples, updated documentation for disabled states for buttons and links, as well as dropdowns.

Updates `disabled="disabled"` to `disabled` according to w3 spec https://www.w3.org/TR/html4/intro/sgmltut.html#h-3.3.4.2
> Authors should be aware that many user agents only recognize the minimized form of boolean attributes and not the full form.

