### PR TITLE
chore(yarn): Add resolutions to force node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,9 @@
       "@semantic-release/github"
     ]
   },
+  "resolutions": {
+    "node-sass": "4.7.2"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "tag": "latest"


### PR DESCRIPTION
Adding support for using yarn by adding a hardcoded resolution for node-sass.  Versions above 4.7.2
break how we are referencing sass variables for CSS custom properties.

Version 4.8.0 uses Futura (libsass 3.5.0) which requires the following syntax for using sass variables as a CSS custom property value:
```scss
: root {
  --some-var: #{$some-var};
}
```

See this issue for more information: https://github.com/sass/libsass/issues/2621 

A Separate issue will be raised to update the existing syntax and contributor guidelines to the new syntax.