### PR TITLE
feat(forms):adds error/required styles to forms and form-control

### DIFF
--- a/src/patternfly/components/Alert/styles.scss
+++ b/src/patternfly/components/Alert/styles.scss
@@ -42,7 +42,7 @@
   --pf-c-alert--m-info__icon--BackgroundColor: var(--pf-global--info-color--100);
   --pf-c-alert--m-info__title--Color: var(--pf-global--info-color--200);
 
-  // This component always needs to be light  
+  // This component always needs to be light
   @extend %pf-t-light;
 
   display: flex;

--- a/src/patternfly/components/Card/styles.scss
+++ b/src/patternfly/components/Card/styles.scss
@@ -23,7 +23,7 @@
   --pf-c-card__footer--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-card__footer--PaddingLeft: var(--pf-global--spacer--lg);
 
-  // This component always needs to be light  
+  // This component always needs to be light
   @extend %pf-t-light;
 
   display: flex;

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -9,7 +9,7 @@
     <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Link</a>
     <button class="pf-c-dropdown__menu-item" role="menuitem">Action</button>
     <a class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
-    <button class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" disabled>Disabled Action</button>
+    <button class="pf-c-dropdown__menu-item" role="menuitem" disabled>Disabled Action</button>
     <div class="pf-c-dropdown__separator" role="separator"></div>
     <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Separated Link</a>
   </div>

--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -22,6 +22,5 @@
 | `.pf-c-form__section` | `<section>`, `<div>` |  Initiates a form section. For larger forms, section grouping may be necessary. This class wraps chunks of code and separates them with padding. |
 | `.pf-c-form__group` | `<div>` |  Wraps form fields `<label>` + `<field>` + `.helper-text` __(not checkboxes or radios)__. Form groups should have no more than one of each element type. Form groups can be nested and, for more complex fieldsets, it may be necessary to do so. |
 | `.pf-m-error` | `.pf-c-form__helper-text`, `.pf-c-form__input` | Modifies form element border and background-image. |
-| `.pf-m-right` | `.pf-c-form__group > *` | Modifies form element margin-left. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-visually-hidden` | `<label>`, `<legend>` |  Visually hides a label or legend. Most common use case: A section title defines an adjacent radio or checkbox group (fielset), the fieldset legend becomes redundent, but is still necessary for assitive technology. |

--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -24,4 +24,4 @@
 | `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |
-| `.pf-m-required` | `.pf-c-form__section` | Modifies form label to show required state. |
+| `.pf-m-required` | `.pf-c-form__label` | Modifies form label to show required state. |

--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -23,4 +23,5 @@
 | `.pf-c-form__group` | `<div>` |  Wraps form fields `<label>` + `<field>` + `.helper-text` __(not checkboxes or radios)__. Form groups should have no more than one of each element type. Form groups can be nested and, for more complex fieldsets, it may be necessary to do so. |
 | `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
-| `.pf-visually-hidden` | `<label>`, `<legend>` |  Visually hides a label or legend. Most common use case: A section title defines an adjacent radio or checkbox group (fielset), the fieldset legend becomes redundent, but is still necessary for assitive technology. |
+| `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |
+| `.pf-m-required` | `.pf-c-form__section` | Modifies form label to show required state. |

--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -21,6 +21,6 @@
 | `.pf-c-form__helper-text` | `<p>` |  Initiates a form helper text block. |
 | `.pf-c-form__section` | `<section>`, `<div>` |  Initiates a form section. For larger forms, section grouping may be necessary. This class wraps chunks of code and separates them with padding. |
 | `.pf-c-form__group` | `<div>` |  Wraps form fields `<label>` + `<field>` + `.helper-text` __(not checkboxes or radios)__. Form groups should have no more than one of each element type. Form groups can be nested and, for more complex fieldsets, it may be necessary to do so. |
-| `.pf-m-error` | `.pf-c-form__helper-text`, `.pf-c-form__input` | Modifies form element border and background-image. |
+| `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-visually-hidden` | `<label>`, `<legend>` |  Visually hides a label or legend. Most common use case: A section title defines an adjacent radio or checkbox group (fielset), the fieldset legend becomes redundent, but is still necessary for assitive technology. |

--- a/src/patternfly/components/Form/examples/form-check-radio-example.hbs
+++ b/src/patternfly/components/Form/examples/form-check-radio-example.hbs
@@ -9,7 +9,7 @@
       {{#> check pf-c-check-type="checkbox" name="checkbox2" id="checkbox2" checked="true"}}{{/check}}
           Checkbox 2, checked
     {{/form-label}}
-    {{#> form-label pf-c-form--modifier="pf-m-disabled" for="checkbox3"}}
+    {{#> form-label pf-c-form__label--modifier="pf-m-disabled" for="checkbox3"}}
       {{#> check pf-c-check-type="checkbox" name="checkbox3" id="checkbox3" disabled="true"}}{{/check}}
           Checkbox 3, disabled
     {{/form-label}}

--- a/src/patternfly/components/Form/examples/form-input-group-example.hbs
+++ b/src/patternfly/components/Form/examples/form-input-group-example.hbs
@@ -29,7 +29,7 @@
   {{#> form-group}}
     {{#> form-label for="textInput3" required="true"}}Input with text{{/form-label}}
     {{#> form-input-group}}
-        {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-required" type="text" name="textInput3" id="textInput3" required="true"}}{{/form-controls}}
+        {{#> form-controls controlType="input" input="true" type="text" name="textInput3" id="textInput3" required="true"}}{{/form-controls}}
         {{#> form-input-group__text}}
             @example.com
         {{/ form-input-group__text}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -27,7 +27,7 @@
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label for="textInput4"}}Error state input with helper text{{/form-label}}
-    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
+    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" aria-invalid="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
     {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper3"}}This is helper text{{/form-helper-text}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -15,4 +15,14 @@
     {{#> form-label for="textInput4" pf-c-form__label--modifier="pf-m-disabled"}}Disabled input{{/form-label}}
     {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-disabled" type="text" name="textInput4" id="textInput4"  disabled="yes" aria-label="disabled text input" placeholder="Disabled input example"}}{{/form-controls}}
   {{/form-group}}
+  {{#> form-group}}
+    {{#> form-label for="textInput4"}}Input with helper text{{/form-label}}
+    {{#> form-controls controlType="input" input="true" type="text" name="textInput4" id="textInput4"  aria-label="input with helper text" aria-describedby="helper1"}}{{/form-controls}}
+    {{#> form-helper-text id="helper1"}}This is helper text{{/form-helper-text}}
+  {{/form-group}}
+  {{#> form-group}}
+    {{#> form-label for="textInput4"}}Error state input with helper text{{/form-label}}
+    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper2"}}{{/form-controls}}
+    {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper2"}}This is helper text{{/form-helper-text}}
+  {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -20,11 +20,12 @@
     {{#> form-controls controlType="input" input="true" type="text" name="textInput4" id="textInput4"  aria-label="input with helper text" aria-describedby="helper1"}}{{/form-controls}}
     {{#> form-helper-text id="helper1"}}This is helper text{{/form-helper-text}}
   {{/form-group}}
-  {{#> form-group}}
+  {{!-- leaving this for now for furture testing for a11y }}
+  {{!-- {{#> form-group}}
     {{#> form-label for="textInput5"}}Inactive Error state input with helper text{{/form-label}}
     {{#> form-controls controlType="input" input="true" aria-invalid="false" aria-errormessage="helper2" type="text" name="textInput5" id="textInput5"  aria-label="Error state text input" aria-describedby="helper2"}}{{/form-controls}}
-    {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper2" aria-live="off" style="visibility:hidden"}}This is helper text{{/form-helper-text}}
-  {{/form-group}}
+    {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper2" aria-live="off" styles="visibility:hidden"}}This is helper text{{/form-helper-text}}
+  {{/form-group}} --}}
   {{#> form-group}}
     {{#> form-label for="textInput4"}}Error state input with helper text{{/form-label}}
     {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" reqiured="true" aria-invalid="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -27,7 +27,7 @@
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label for="textInput4"}}Error state input with helper text{{/form-label}}
-    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" aria-invalid="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
+    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" reqiured="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
     {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper3"}}This is helper text{{/form-helper-text}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -9,11 +9,11 @@
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label for="textInput3" required="true"}}Required input{{/form-label}}
-    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-required" type="text" name="textInput3" id="textInput3" required="true"}}{{/form-controls}}
+    {{#> form-controls controlType="input" input="true" type="text" name="textInput3" id="textInput3" required="true"}}{{/form-controls}}
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label for="textInput4" pf-c-form__label--modifier="pf-m-disabled"}}Disabled input{{/form-label}}
-    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-disabled" type="text" name="textInput4" id="textInput4"  disabled="yes" aria-label="disabled text input" placeholder="Disabled input example"}}{{/form-controls}}
+    {{#> form-controls controlType="input" input="true" type="text" name="textInput4" id="textInput4"  disabled="yes" aria-label="disabled text input" placeholder="Disabled input example"}}{{/form-controls}}
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label for="textInput4"}}Input with helper text{{/form-label}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -27,7 +27,7 @@
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label for="textInput4"}}Error state input with helper text{{/form-label}}
-    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" reqiured="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
+    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" reqiured="true" aria-invalid="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
     {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper3"}}This is helper text{{/form-helper-text}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/examples/form-text-input-example.hbs
+++ b/src/patternfly/components/Form/examples/form-text-input-example.hbs
@@ -21,8 +21,13 @@
     {{#> form-helper-text id="helper1"}}This is helper text{{/form-helper-text}}
   {{/form-group}}
   {{#> form-group}}
+    {{#> form-label for="textInput5"}}Inactive Error state input with helper text{{/form-label}}
+    {{#> form-controls controlType="input" input="true" aria-invalid="false" aria-errormessage="helper2" type="text" name="textInput5" id="textInput5"  aria-label="Error state text input" aria-describedby="helper2"}}{{/form-controls}}
+    {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper2" aria-live="off" style="visibility:hidden"}}This is helper text{{/form-helper-text}}
+  {{/form-group}}
+  {{#> form-group}}
     {{#> form-label for="textInput4"}}Error state input with helper text{{/form-label}}
-    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper2"}}{{/form-controls}}
-    {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper2"}}This is helper text{{/form-helper-text}}
+    {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="helper3" type="text" name="textInput4" id="textInput4"  aria-label="Error state text input" aria-describedby="helper3"}}{{/form-controls}}
+    {{#> form-helper-text pf-c-form__helper--modifier="pf-m-error" id="helper3"}}This is helper text{{/form-helper-text}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -15,7 +15,6 @@
   --pf-c-form__label--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-form__label--FontSize: var(--pf-global--FontSize--md);
   --pf-c-form__label--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-form__label--disabled--Color: var(--pf-global--Color--disabled);
 
   // nested Label
   --pf-c-form__label-nested--PaddingTop: var(--pf-global--spacer--xs);
@@ -23,6 +22,11 @@
   --pf-c-form__label-nested--PaddingBottom: var(--pf-global--spacer--xs);
   --pf-c-form__label-nested--PaddingLeft: 0;
   // --pf-c-form__check--addons--MarginLeft:   var(--pf-global--spacer--sm);
+
+  // required labels
+  --pf-c-form__label-requried-after--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-form__label-requried-after--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-form__label-requried-after--Color: var(--pf-global--danger-color--100);
 
   // Group
   --pf-c-form--group--MarginLeft: var(--pf-global--spacer--sm);
@@ -103,15 +107,14 @@
     }
 
     &.pf-m-disabled {
-      color: var(--pf-c-form__label--disabled--Color);
       cursor: not-allowed;
     }
     &.pf-m-required {
       position: relative;
       &::after {
-        margin-left: 4px;
-        font-size: 14px;
-        color: #c00;
+        margin-left: var(--pf-c-form__label-requried-after--MarginLeft);
+        font-size: var(--pf-c-form__label-requried-after--FontSize);
+        color: var(--pf-c-form__label-requried-after--Color);
         content: "*";
       }
     }

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -164,8 +164,9 @@
   &__helper-text {
     margin-top: var(--pf-c-form__helper-text--MarginTop);
     font-size: var(--pf-c-form__helper-text--FontSize);
-    color: var(--pf-c-form__helper-text--Color);
-
+    &:not(.pf-m-error){
+      color: var(--pf-c-form__helper-text--Color);
+    }
     &.pf-m-error {
       color: var(--pf-c-form--error--Color);
     }
@@ -198,11 +199,6 @@
         padding-bottom: var(--pf-c-form__label-nested--PaddingBottom);
         padding-left: var(--pf-c-form__label-nested--PaddingLeft);
       }
-    }
-
-    // Align right
-    &-right {
-      margin-left: auto;
     }
 
     // Sub-section title

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -1,4 +1,5 @@
 
+
 @import "../../patternfly-utilities";
 
 // // Select - chevron
@@ -8,14 +9,49 @@
 // $pf-c-form__select--chevron-svg--Height: 10px !default;
 // $pf-c-form__select--chevron-svg--Coordinates: "M0 1.7L1.7 0l4.7 4.6L11 0l1.7 1.7L6.4 8L0 1.7z" !default;
 // $pf-c-form__select--chevron-svg--Viewbox: "0 0 32 10" !default;
+
+// // Input - error
+// $pf-c-form__select--m-error-svg--Color: $pf-global--danger-color--200 !default;
+// $pf-c-form__select--m-error-svg--Width: 32px !default;
+// $pf-c-form__select--m-error-svg--Height: 14px !default;
+// $pf-c-form__select--m-error-svg--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
+// $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
+
+// // Function - strip-unit
+// @function pf-strip-unit($val) {
+//   @if type-of($val) == "number" and not unitless($val) {
+//     @return $val / ($val * 0 + 1);
+//   } @else {
+//     @return $val;
+//   }
+// }
+
+// // Background svg mixin - likely temporary
+// @mixin pf-bg-svg($svg-coordinates, $svg-color, $svg-width: 24, $svg-height: 8,  $svg-viewbox: "0 0 32 10") {
+//   $color: str-slice(#{$svg-color}, 2);
+//   $svg-width: pf-strip-unit($svg-width);
+//   $svg-height: pf-strip-unit($svg-height);
+//   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$svg-width}' height='#{$svg-height}' viewBox='#{$svg-viewbox}'%3E%3Cpath fill='%23#{$color}' d='#{$svg-coordinates}'/%3E%3C/svg%3E");
+//   background-repeat: no-repeat;
+//   background-position: center right;
+// }
+
 // Base form
 .pf-c-form {
+  // // Input m-error
+  // --pf-c-form__input--m-error--PaddingRight:      calc(#{$pf-global--spacer--sm} + #{$pf-global--spacer--md} + #{var(--pf-c-form__input--FontSize)});
+  // --pf-c-form__input--m-error--BorderColor:       var(--pf-global--danger-color--200);
+  // --pf-c-form__input__m-error--BackgroundColor:   var(--pf-global--BackgroundColor--light-100);
+  // --pf-c-form__input--m-error--BorderSize:        var(--pf-global--BorderWidth--sm);
+
   // Label
-  --pf-c-form__label--Color: var(--pf-global--Color--100);
+  --pf-c-form__label--Color: var(--pf-global--Color--dark-100);
   --pf-c-form__label--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-form__label--FontSize: var(--pf-global--FontSize--md);
   --pf-c-form__label--PaddingBottom: var(--pf-global--spacer--sm);
-  --pf-c-form__label--disabled--Color: var(--pf-global--Color--disabled);
+  // --pf-c-form__label--m-required--Left: -12px;
+  // --pf-c-form__label--m-required--Top: 2px;
+  --pf-c-form__label--m-disabled--Color: var(--pf-global--disabled-color--100);
 
   // nested Label
   --pf-c-form__label-nested--PaddingTop: var(--pf-global--spacer--xs);
@@ -30,11 +66,8 @@
   // Section
   --pf-c-form--section--PaddingTop: var(--pf-global--spacer--xl);
   --pf-c-form--section--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-form--section--border--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-form--section--border--BorderBottomColor: var(--pf-global--BorderColor--light);
-
-  // Sub-section
-  --pf-c-form--subsection-title--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-c-form--section--m-border--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-form--section--m-border--BorderBottomColor: var(--pf-global--BorderColor--light);
 
   // Legend
   --pf-c-form__legend--MarginBottom: var(--pf-global--spacer--md);
@@ -42,12 +75,12 @@
   --pf-c-form__legend--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
   // // States
-  --pf-c-form--error--Color: var(--pf-global--danger-color--200);
+  // --pf-c-form--m-error--Color: var(--pf-global--danger-color--100);
 
   // Helpers
   --pf-c-form__helper-text--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--xs);
-  --pf-c-form__helper-text--Color: var(--pf-global--Color--100);
+  --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-form__helper-text--Color: var(--pf-global--Color--dark-200);
   // Inline
   --pf-c-form--inline--MarginRight: var(--pf-global--spacer--lg);
   // Checkbox
@@ -61,7 +94,7 @@
     padding-bottom: var(--pf-c-form--section--PaddingBottom);
 
     &.pf-m-border {
-      border-bottom: var(--pf-c-form--section--border--BorderBottomWidth) solid var(--pf-c-form--section--border--BorderBottomColor);
+      border-bottom: var(--pf-c-form--section--m-border--BorderBottomWidth) solid var(--pf-c-form--section--m-border--BorderBottomColor);
     }
   }
 
@@ -103,17 +136,8 @@
     }
 
     &.pf-m-disabled {
-      color: var(--pf-c-form__label--disabled--Color);
+      color: var(--pf-c-form__label--m-disabled--Color);
       cursor: not-allowed;
-    }
-    &.pf-m-required {
-      position: relative;
-      &::after {
-        margin-left: 4px;
-        font-size: 14px;
-        color: #c00;
-        content: "*";
-      }
     }
   }
 
@@ -164,11 +188,10 @@
   &__helper-text {
     margin-top: var(--pf-c-form__helper-text--MarginTop);
     font-size: var(--pf-c-form__helper-text--FontSize);
-    &:not(.pf-m-error){
-      color: var(--pf-c-form__helper-text--Color);
-    }
+    color: var(--pf-c-form__helper-text--Color);
+
     &.pf-m-error {
-      color: var(--pf-c-form--error--Color);
+      color: var(--pf-c-form--m-error--Color);
     }
   }
 
@@ -200,23 +223,5 @@
         padding-left: var(--pf-c-form__label-nested--PaddingLeft);
       }
     }
-
-    // Sub-section title
-    &-subsection-title {
-      margin-bottom: var(--pf-c-form--subsection-title--MarginBottom);
-    }
-
-
-    &-visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
-      /* stylelint-disable */
-      position: absolute !important;
-      /* stylelint-enable */
-      width: 1px;
-      height: 1px;
-      overflow: hidden;
-      clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-      clip: rect(1px, 1px, 1px, 1px);
-    }
   }
 }
-

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -104,7 +104,7 @@
     flex-flow: row wrap;
     align-items: baseline;
     // Handle additional items within __group without having an additional wrapper or selector
-    > *:not(.pf-c-form__label):not(.pf-c-input-group):not(.pf-c-form-control):not(.pf-c-form__helper-text):not(.pf-c-form__legend):not(.pf-c-form__button-group):not([class*="pf-l-"]):not(.pf-m-right) {
+    > *:not(.pf-c-form__label):not(.pf-c-input-group):not(.pf-c-form-control):not(.pf-c-form__helper-text):not(.pf-c-form__legend):not(.pf-c-form__button-group):not([class*="pf-l-"]) {
       margin-left: var(--pf-c-form--group--MarginLeft);
     }
 
@@ -221,11 +221,6 @@
         padding-bottom: var(--pf-c-form__label-nested--PaddingBottom);
         padding-left: var(--pf-c-form__label-nested--PaddingLeft);
       }
-    }
-
-    // Align right
-    &-right {
-      margin-left: auto;
     }
 
     &-visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -8,49 +8,14 @@
 // $pf-c-form__select--chevron-svg--Height: 10px !default;
 // $pf-c-form__select--chevron-svg--Coordinates: "M0 1.7L1.7 0l4.7 4.6L11 0l1.7 1.7L6.4 8L0 1.7z" !default;
 // $pf-c-form__select--chevron-svg--Viewbox: "0 0 32 10" !default;
-
-// // Input - error
-// $pf-c-form__select--m-error-svg--Color: $pf-global--danger-color--200 !default;
-// $pf-c-form__select--m-error-svg--Width: 32px !default;
-// $pf-c-form__select--m-error-svg--Height: 14px !default;
-// $pf-c-form__select--m-error-svg--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
-// $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
-
-// // Function - strip-unit
-// @function pf-strip-unit($val) {
-//   @if type-of($val) == "number" and not unitless($val) {
-//     @return $val / ($val * 0 + 1);
-//   } @else {
-//     @return $val;
-//   }
-// }
-
-// // Background svg mixin - likely temporary
-// @mixin pf-bg-svg($svg-coordinates, $svg-color, $svg-width: 24, $svg-height: 8,  $svg-viewbox: "0 0 32 10") {
-//   $color: str-slice(#{$svg-color}, 2);
-//   $svg-width: pf-strip-unit($svg-width);
-//   $svg-height: pf-strip-unit($svg-height);
-//   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$svg-width}' height='#{$svg-height}' viewBox='#{$svg-viewbox}'%3E%3Cpath fill='%23#{$color}' d='#{$svg-coordinates}'/%3E%3C/svg%3E");
-//   background-repeat: no-repeat;
-//   background-position: center right;
-// }
-
 // Base form
 .pf-c-form {
-  // // Input m-error
-  // --pf-c-form__input--m-error--PaddingRight:      calc(#{$pf-global--spacer--sm} + #{$pf-global--spacer--md} + #{var(--pf-c-form__input--FontSize)});
-  // --pf-c-form__input--m-error--BorderColor:       var(--pf-global--danger-color--200);
-  // --pf-c-form__input__m-error--BackgroundColor:   var(--pf-global--BackgroundColor--light-100);
-  // --pf-c-form__input--m-error--BorderSize:        var(--pf-global--BorderWidth--sm);
-
   // Label
-  --pf-c-form__label--Color: var(--pf-global--Color--dark-100);
+  --pf-c-form__label--Color: var(--pf-global--Color--100);
   --pf-c-form__label--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-form__label--FontSize: var(--pf-global--FontSize--md);
   --pf-c-form__label--PaddingBottom: var(--pf-global--spacer--sm);
-  // --pf-c-form__label--m-required--Left: -12px;
-  // --pf-c-form__label--m-required--Top: 2px;
-  --pf-c-form__label--m-disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-form__label--disabled--Color: var(--pf-global--Color--disabled);
 
   // nested Label
   --pf-c-form__label-nested--PaddingTop: var(--pf-global--spacer--xs);
@@ -65,8 +30,11 @@
   // Section
   --pf-c-form--section--PaddingTop: var(--pf-global--spacer--xl);
   --pf-c-form--section--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-form--section--m-border--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-form--section--m-border--BorderBottomColor: var(--pf-global--BorderColor--light);
+  --pf-c-form--section--border--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-form--section--border--BorderBottomColor: var(--pf-global--BorderColor--light);
+
+  // Sub-section
+  --pf-c-form--subsection-title--MarginBottom: var(--pf-global--spacer--sm);
 
   // Legend
   --pf-c-form__legend--MarginBottom: var(--pf-global--spacer--md);
@@ -74,12 +42,12 @@
   --pf-c-form__legend--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
   // // States
-  // --pf-c-form--m-error--Color: var(--pf-global--danger-color--100);
+  --pf-c-form--error--Color: var(--pf-global--danger-color--200);
 
   // Helpers
   --pf-c-form__helper-text--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-form__helper-text--Color: var(--pf-global--Color--dark-200);
+  --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-form__helper-text--Color: var(--pf-global--Color--100);
   // Inline
   --pf-c-form--inline--MarginRight: var(--pf-global--spacer--lg);
   // Checkbox
@@ -93,7 +61,7 @@
     padding-bottom: var(--pf-c-form--section--PaddingBottom);
 
     &.pf-m-border {
-      border-bottom: var(--pf-c-form--section--m-border--BorderBottomWidth) solid var(--pf-c-form--section--m-border--BorderBottomColor);
+      border-bottom: var(--pf-c-form--section--border--BorderBottomWidth) solid var(--pf-c-form--section--border--BorderBottomColor);
     }
   }
 
@@ -135,8 +103,17 @@
     }
 
     &.pf-m-disabled {
-      color: var(--pf-c-form__label--m-disabled--Color);
+      color: var(--pf-c-form__label--disabled--Color);
       cursor: not-allowed;
+    }
+    &.pf-m-required {
+      position: relative;
+      &::after {
+        margin-left: 4px;
+        font-size: 14px;
+        color: #c00;
+        content: "*";
+      }
     }
   }
 
@@ -190,7 +167,7 @@
     color: var(--pf-c-form__helper-text--Color);
 
     &.pf-m-error {
-      color: var(--pf-c-form--m-error--Color);
+      color: var(--pf-c-form--error--Color);
     }
   }
 
@@ -222,6 +199,17 @@
         padding-left: var(--pf-c-form__label-nested--PaddingLeft);
       }
     }
+
+    // Align right
+    &-right {
+      margin-left: auto;
+    }
+
+    // Sub-section title
+    &-subsection-title {
+      margin-bottom: var(--pf-c-form--subsection-title--MarginBottom);
+    }
+
 
     &-visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
       /* stylelint-disable */

--- a/src/patternfly/components/Form/styles.scss
+++ b/src/patternfly/components/Form/styles.scss
@@ -1,5 +1,4 @@
 
-
 @import "../../patternfly-utilities";
 
 // // Select - chevron
@@ -9,49 +8,14 @@
 // $pf-c-form__select--chevron-svg--Height: 10px !default;
 // $pf-c-form__select--chevron-svg--Coordinates: "M0 1.7L1.7 0l4.7 4.6L11 0l1.7 1.7L6.4 8L0 1.7z" !default;
 // $pf-c-form__select--chevron-svg--Viewbox: "0 0 32 10" !default;
-
-// // Input - error
-// $pf-c-form__select--m-error-svg--Color: $pf-global--danger-color--200 !default;
-// $pf-c-form__select--m-error-svg--Width: 32px !default;
-// $pf-c-form__select--m-error-svg--Height: 14px !default;
-// $pf-c-form__select--m-error-svg--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
-// $pf-c-form__select--m-error-svg--Viewbox: "0 0 26 15.8" !default;
-
-// // Function - strip-unit
-// @function pf-strip-unit($val) {
-//   @if type-of($val) == "number" and not unitless($val) {
-//     @return $val / ($val * 0 + 1);
-//   } @else {
-//     @return $val;
-//   }
-// }
-
-// // Background svg mixin - likely temporary
-// @mixin pf-bg-svg($svg-coordinates, $svg-color, $svg-width: 24, $svg-height: 8,  $svg-viewbox: "0 0 32 10") {
-//   $color: str-slice(#{$svg-color}, 2);
-//   $svg-width: pf-strip-unit($svg-width);
-//   $svg-height: pf-strip-unit($svg-height);
-//   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$svg-width}' height='#{$svg-height}' viewBox='#{$svg-viewbox}'%3E%3Cpath fill='%23#{$color}' d='#{$svg-coordinates}'/%3E%3C/svg%3E");
-//   background-repeat: no-repeat;
-//   background-position: center right;
-// }
-
 // Base form
 .pf-c-form {
-  // // Input m-error
-  // --pf-c-form__input--m-error--PaddingRight:      calc(#{$pf-global--spacer--sm} + #{$pf-global--spacer--md} + #{var(--pf-c-form__input--FontSize)});
-  // --pf-c-form__input--m-error--BorderColor:       var(--pf-global--danger-color--200);
-  // --pf-c-form__input__m-error--BackgroundColor:   var(--pf-global--BackgroundColor--light-100);
-  // --pf-c-form__input--m-error--BorderSize:        var(--pf-global--BorderWidth--sm);
-
   // Label
-  --pf-c-form__label--Color: var(--pf-global--Color--dark-100);
+  --pf-c-form__label--Color: var(--pf-global--Color--100);
   --pf-c-form__label--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-form__label--FontSize: var(--pf-global--FontSize--md);
   --pf-c-form__label--PaddingBottom: var(--pf-global--spacer--sm);
-  // --pf-c-form__label--m-required--Left: -12px;
-  // --pf-c-form__label--m-required--Top: 2px;
-  --pf-c-form__label--m-disabled--Color: var(--pf-global--disabled-color--100);
+  --pf-c-form__label--disabled--Color: var(--pf-global--Color--disabled);
 
   // nested Label
   --pf-c-form__label-nested--PaddingTop: var(--pf-global--spacer--xs);
@@ -66,8 +30,11 @@
   // Section
   --pf-c-form--section--PaddingTop: var(--pf-global--spacer--xl);
   --pf-c-form--section--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-form--section--m-border--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-form--section--m-border--BorderBottomColor: var(--pf-global--BorderColor--light);
+  --pf-c-form--section--border--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-form--section--border--BorderBottomColor: var(--pf-global--BorderColor--light);
+
+  // Sub-section
+  --pf-c-form--subsection-title--MarginBottom: var(--pf-global--spacer--sm);
 
   // Legend
   --pf-c-form__legend--MarginBottom: var(--pf-global--spacer--md);
@@ -75,12 +42,12 @@
   --pf-c-form__legend--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
   // // States
-  // --pf-c-form--m-error--Color: var(--pf-global--danger-color--100);
+  --pf-c-form--error--Color: var(--pf-global--danger-color--200);
 
   // Helpers
   --pf-c-form__helper-text--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-form__helper-text--Color: var(--pf-global--Color--dark-200);
+  --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--xs);
+  --pf-c-form__helper-text--Color: var(--pf-global--Color--100);
   // Inline
   --pf-c-form--inline--MarginRight: var(--pf-global--spacer--lg);
   // Checkbox
@@ -94,7 +61,7 @@
     padding-bottom: var(--pf-c-form--section--PaddingBottom);
 
     &.pf-m-border {
-      border-bottom: var(--pf-c-form--section--m-border--BorderBottomWidth) solid var(--pf-c-form--section--m-border--BorderBottomColor);
+      border-bottom: var(--pf-c-form--section--border--BorderBottomWidth) solid var(--pf-c-form--section--border--BorderBottomColor);
     }
   }
 
@@ -136,8 +103,17 @@
     }
 
     &.pf-m-disabled {
-      color: var(--pf-c-form__label--m-disabled--Color);
+      color: var(--pf-c-form__label--disabled--Color);
       cursor: not-allowed;
+    }
+    &.pf-m-required {
+      position: relative;
+      &::after {
+        margin-left: 4px;
+        font-size: 14px;
+        color: #c00;
+        content: "*";
+      }
     }
   }
 
@@ -188,10 +164,11 @@
   &__helper-text {
     margin-top: var(--pf-c-form__helper-text--MarginTop);
     font-size: var(--pf-c-form__helper-text--FontSize);
-    color: var(--pf-c-form__helper-text--Color);
-
+    &:not(.pf-m-error){
+      color: var(--pf-c-form__helper-text--Color);
+    }
     &.pf-m-error {
-      color: var(--pf-c-form--m-error--Color);
+      color: var(--pf-c-form--error--Color);
     }
   }
 

--- a/src/patternfly/components/FormControls/docs/code.md
+++ b/src/patternfly/components/FormControls/docs/code.md
@@ -9,5 +9,4 @@ Input, Textarea, and select are provided in the form controls component for use 
 | -- | -- | -- |
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or Radios see the <a href="/components/Check/examples/">check component</a>. **required**  |
 | `.pf-m-form-control-alt` | `input[type="text"].pf-c-form-control` |  Applies alternative form control styles. |
-| `.pf-m-disabled` | `.pf-c-form-control` |  Forces display of the disabled state of the form control. This state is primarily for demonstration purposes and would not normally be used in lieu of the :disabled pseudo-class. |
 | `.pf-m-error` | `.pf-c-form-control` |  Applies error styles. |

--- a/src/patternfly/components/FormControls/docs/code.md
+++ b/src/patternfly/components/FormControls/docs/code.md
@@ -10,3 +10,4 @@ Input, Textarea, and select are provided in the form controls component for use 
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or Radios see the <a href="/components/Check/examples/">check component</a>. **required**  |
 | `.pf-m-form-control-alt` | `input[type="text"].pf-c-form-control` |  Applies alternative form control styles. |
 | `.pf-m-disabled` | `.pf-c-form-control` |  Applies disabled styles. |
+| `.pf-m-error` | `.pf-c-form-control` |  Applies error styles. |

--- a/src/patternfly/components/FormControls/docs/code.md
+++ b/src/patternfly/components/FormControls/docs/code.md
@@ -9,4 +9,4 @@ Input, Textarea, and select are provided in the form controls component for use 
 | -- | -- | -- |
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or Radios see the <a href="/components/Check/examples/">check component</a>. **required**  |
 | `.pf-m-form-control-alt` | `input[type="text"].pf-c-form-control` |  Applies alternative form control styles. |
-| `.pf-m-error` | `.pf-c-form-control` |  Applies error styles. |
+| `.pf-m-invalid` | `.pf-c-form-control` |  Forces display of the invalid state of the form control. This state is primarily for demonstration purposes and would not normally be used in lieu of the :invalid pseudo-class. |

--- a/src/patternfly/components/FormControls/docs/code.md
+++ b/src/patternfly/components/FormControls/docs/code.md
@@ -9,5 +9,5 @@ Input, Textarea, and select are provided in the form controls component for use 
 | -- | -- | -- |
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or Radios see the <a href="/components/Check/examples/">check component</a>. **required**  |
 | `.pf-m-form-control-alt` | `input[type="text"].pf-c-form-control` |  Applies alternative form control styles. |
-| `.pf-m-disabled` | `.pf-c-form-control` |  Applies disabled styles. |
+| `.pf-m-disabled` | `.pf-c-form-control` |  Forces display of the disabled state of the form control. This state is primarily for demonstration purposes and would not normally be used in lieu of the :disabled pseudo-class. |
 | `.pf-m-error` | `.pf-c-form-control` |  Applies error styles. |

--- a/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
@@ -8,3 +8,5 @@
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt" type="text" id="textInput4" aria-label="login input example"}}
 {{/form-controls}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt pf-m-error" type="text" id="textInput5" aria-invalid="true" aria-errormessage="incorrect text" aria-label="Error state login input example"}}
+{{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
@@ -4,9 +4,9 @@
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" type="text" id="textInput3" required="true" aria-label="required input example"}}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" type="text" id="textInput3"  aria-errormessage="textInput3error" aria-label="Error state input example"}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" type="text" id="textInput3" required="true"  aria-errormessage="textInput3error" aria-label="Error state input example"}}
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt" type="text" id="textInput4" aria-label="login input example"}}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt pf-m-invalid" type="text" id="textInput5" aria-errormessage="textInput5error" aria-label="Error state login input example"}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt pf-m-invalid" type="text" id="textInput5" aria-errormessage="textInput5error" required="true" aria-label="Error state login input example"}}
 {{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
@@ -2,6 +2,8 @@
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" type="text" id="textInput1" aria-label="standard input example" }}
 {{/form-controls}}
+{{#> form-controls controlType="input" input="true" type="text" id="textInput1" aria-label="readonly input example" value="readonly input example" readonly="true"}}
+{{/form-controls}}
 {{#> form-controls controlType="input" input="true" type="text" id="textInput3" required="true" aria-label="required input example"}}
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" type="text" id="textInput3" required="true"  aria-errormessage="textInput3error" aria-label="Error state input example"}}

--- a/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
@@ -1,8 +1,10 @@
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-disabled" type="text" id="textInput4" disabled="yes" aria-label="disabled text input" placeholder="Disabled input example"}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-disabled" type="text" id="textInput4" disabled="yes" aria-label="disabled text input"}}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" type="text" id="textInput1" placeholder="Standard input example" aria-label="standard input example" }}
+{{#> form-controls controlType="input" input="true" type="text" id="textInput1" aria-label="standard input example" }}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" type="text" id="textInput3" required="true" placeholder="Required input example" aria-label="required input example"}}
+{{#> form-controls controlType="input" input="true" type="text" id="textInput3" required="true" aria-label="required input example"}}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt" type="text" id="textInput4"  placeholder="Login input example" aria-label="login input example"}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-error" type="text" id="textInput3" aria-invalid="true" aria-errormessage="incorrect text" aria-label="Error state input example"}}
+{{/form-controls}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt" type="text" id="textInput4" aria-label="login input example"}}
 {{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-input-example.hbs
@@ -1,12 +1,12 @@
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-disabled" type="text" id="textInput4" disabled="yes" aria-label="disabled text input"}}
+{{#> form-controls controlType="input" input="true" type="text" id="textInput4" disabled="yes" aria-label="disabled text input"}}
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" type="text" id="textInput1" aria-label="standard input example" }}
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" type="text" id="textInput3" required="true" aria-label="required input example"}}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-error" type="text" id="textInput3" aria-invalid="true" aria-errormessage="incorrect text" aria-label="Error state input example"}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-invalid" type="text" id="textInput3"  aria-errormessage="textInput3error" aria-label="Error state input example"}}
 {{/form-controls}}
 {{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt" type="text" id="textInput4" aria-label="login input example"}}
 {{/form-controls}}
-{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt pf-m-error" type="text" id="textInput5" aria-invalid="true" aria-errormessage="incorrect text" aria-label="Error state login input example"}}
+{{#> form-controls controlType="input" input="true" pf-c-form-control--modifier="pf-m-form-control-alt pf-m-invalid" type="text" id="textInput5" aria-errormessage="textInput5error" aria-label="Error state login input example"}}
 {{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
@@ -8,6 +8,7 @@
   <option value="Other">Other</option>
 {{/form-controls}}
 {{#> form-controls controlType="select" id="select2" name="selectexample2" aria-label="select group example"}}
+  <option value="">make selection</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
     <option value="Option 2" selected>The second option is selected by default</option>
@@ -17,7 +18,7 @@
     <option value="Option 4">The fourth option</option>
   </optgroup>
 {{/form-controls}}
-{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text" id="select2" name="selectexample2" aria-label="select group example"}}
+{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-invalid" aria-errormessage="incorrect text" id="select2" name="selectexample2" aria-label="select group example"}}
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
     <option value="Option 2" selected>The second option is selected by default</option>

--- a/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
@@ -17,7 +17,7 @@
     <option value="Option 4">The fourth option</option>
   </optgroup>
 {{/form-controls}}
-{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-invalid" required="true" aria-errormessage="incorrect text" id="select2" name="selectexample2" aria-label="select group example"}}
+{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-invalid" required="true" aria-errormessage="select2ErrorText" id="select2" name="selectexample2" aria-label="select group example"}}
   <option value="">make selection</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>

--- a/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
@@ -17,3 +17,13 @@
     <option value="Option 4">The fourth option</option>
   </optgroup>
 {{/form-controls}}
+{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text" id="select2" name="selectexample2" aria-label="select group example"}}
+  <optgroup label="Group 1">
+    <option value="Option 1">The first option</option>
+    <option value="Option 2" selected>The second option is selected by default</option>
+  </optgroup>
+  <optgroup label="Group 2">
+    <option value="Option 3">The third option</option>
+    <option value="Option 4">The fourth option</option>
+  </optgroup>
+{{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-select-example.hbs
@@ -8,7 +8,6 @@
   <option value="Other">Other</option>
 {{/form-controls}}
 {{#> form-controls controlType="select" id="select2" name="selectexample2" aria-label="select group example"}}
-  <option value="">make selection</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
     <option value="Option 2" selected>The second option is selected by default</option>
@@ -18,10 +17,11 @@
     <option value="Option 4">The fourth option</option>
   </optgroup>
 {{/form-controls}}
-{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-invalid" aria-errormessage="incorrect text" id="select2" name="selectexample2" aria-label="select group example"}}
+{{#> form-controls controlType="select" pf-c-form-control--modifier="pf-m-invalid" required="true" aria-errormessage="incorrect text" id="select2" name="selectexample2" aria-label="select group example"}}
+  <option value="">make selection</option>
   <optgroup label="Group 1">
     <option value="Option 1">The first option</option>
-    <option value="Option 2" selected>The second option is selected by default</option>
+    <option value="Option 2">The second option</option>
   </optgroup>
   <optgroup label="Group 2">
     <option value="Option 3">The third option</option>

--- a/src/patternfly/components/FormControls/examples/form-controls-textarea-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-textarea-example.hbs
@@ -1,2 +1,4 @@
-{{#> form-controls controlType="textarea" name="textarea" id="textarea1" aria-label="textarea example" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text"}}
+{{#> form-controls controlType="textarea" name="textarea" id="textarea1" aria-label="textarea example"}}
+{{/form-controls}}
+{{#> form-controls controlType="textarea" name="textarea" id="textarea2" aria-label="Error state textarea example" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text"}}
 {{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-textarea-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-textarea-example.hbs
@@ -1,2 +1,2 @@
-{{#> form-controls controlType="textarea" name="textarea" id="textarea1" aria-label="textarea example"}}
+{{#> form-controls controlType="textarea" name="textarea" id="textarea1" aria-label="textarea example" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text"}}
 {{/form-controls}}

--- a/src/patternfly/components/FormControls/examples/form-controls-textarea-example.hbs
+++ b/src/patternfly/components/FormControls/examples/form-controls-textarea-example.hbs
@@ -1,4 +1,4 @@
 {{#> form-controls controlType="textarea" name="textarea" id="textarea1" aria-label="textarea example"}}
 {{/form-controls}}
-{{#> form-controls controlType="textarea" name="textarea" id="textarea2" aria-label="Error state textarea example" pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text"}}
+{{#> form-controls controlType="textarea" name="textarea" id="textarea2" aria-label="Error state textarea example" pf-c-form-control--modifier="pf-m-invalid" required="true"}}
 {{/form-controls}}

--- a/src/patternfly/components/FormControls/form-controls.hbs
+++ b/src/patternfly/components/FormControls/form-controls.hbs
@@ -1,5 +1,6 @@
 <{{ controlType }} class="pf-c-form-control{{#if pf-c-form-control--modifier}} {{pf-c-form-control--modifier}}{{/if}}" 
  {{#if type}} type="{{type}}"{{/if}}
+ {{#if readonly}} readonly{{/if}}
  {{#if placeholder}} placeholder="{{placeholder}}"{{/if}}
  {{#if value}} value="{{value}}"{{/if}}
  {{#if name}} name="{{name}}"{{/if}}

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -67,7 +67,8 @@ $pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3
     background-color: var(--pf-c-form-control--disabled--BackgroundColor);
     border-color: var(--pf-c-form-control--disabled--BorderColor);
   }
-  &.pf-m-error {
+  &.pf-m-invalid,
+  :invalid {
     @include pf-bg-svg($pf-c-form-controls--error--Coordinates, $pf-c-form-controls--error--Color);
     &:not(.pf-m-form-control-alt){
       padding: var(--pf-c-form-control--error--PaddingTop) var(--pf-c-form-control--error--PaddingRight) var(--pf-c-form-control--error--PaddingBottom) var(--pf-c-form-control--error--PaddingLeft);
@@ -90,7 +91,7 @@ $pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3
     border: none;
     border-bottom: var(--pf-c-form-control--alt--BottomBorderWidth) solid var(--pf-c-form-control--BorderColor);
     border-radius: 0;
-    &.pf-m-error {
+    &.pf-m-invalid {
       border-bottom-color: var(--pf-c-form-control--error--BorderColor);
     }
   }

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -35,6 +35,12 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
   --pf-c-form-control--disabled--BorderColor: var(--pf-global--disabled-color--200);
   --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
 
+  // input readonly style
+  --pf-c-form-control--readonly--Color: var(--pf-global--Color--100);
+  --pf-c-form-control--readonly--BorderSize: var(--pf-global--BorderWidth--sm);
+  --pf-c-form-control--readonly--BorderColor: var(--pf-global--BorderColor--dark);
+  --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--BackgroundColor--150);
+
   // input alt style
   --pf-c-form-control--alt--BottomBorderWidth: var(--pf-global--BorderWidth--md);
 
@@ -65,6 +71,10 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
     cursor: not-allowed;
     background-color: var(--pf-c-form-control--disabled--BackgroundColor);
     border-color: var(--pf-c-form-control--disabled--BorderColor);
+  }
+  &[readonly]{
+    background-color: var(--pf-c-form-control--readonly--BackgroundColor);
+    border-color: var(--pf-c-form-control--readonly--BorderColor);
   }
   &.pf-m-invalid,
   :invalid {

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -1,28 +1,14 @@
 @import "../../patternfly-utilities";
 // Input - error
-$pf-c-form-controls--error-svg--Color: $pf-global--danger-color--100 !default;
-$pf-c-form-controls--error-svg--Width: 24px !default;
-$pf-c-form-controls--error-svg--Height: 24px !default;
-$pf-c-form-controls--error-svg--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
-$pf-c-form-controls--error-svg--Viewbox: "0 0 26 15.8" !default;
-
-// Function - strip-unit
-@function pf-strip-unit($val) {
-  @if type-of($val) == "number" and not unitless($val) {
-    @return $val / ($val * 0 + 1);
-  } @else {
-    @return $val;
-  }
-}
-
-// Background svg mixin - likely temporary
-@mixin pf-bg-svg($svg-coordinates, $svg-color, $svg-width: 24, $svg-height: 8,  $svg-viewbox: "0 0 32 10") {
+$pf-c-form-controls--error--Color: $pf-global--danger-color--100 !default;
+$pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
+// Background svg mixin
+@mixin pf-bg-svg($svg-coordinates, $svg-color) {
   $color: str-slice(#{$svg-color}, 2);
-  $svg-width: pf-strip-unit($svg-width);
-  $svg-height: pf-strip-unit($svg-height);
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$svg-width}' height='#{$svg-height}' viewBox='#{$svg-viewbox}'%3E%3Cpath fill='%23#{$color}' d='#{$svg-coordinates}'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill='%23#{$color}' d='#{$svg-coordinates}'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right top 4px;
+  background-position: right 6px top 8px;
+  background-size: var(--pf-c-form-control--BackgroundWidth) var(--pf-c-form-control--BackgroundHeight);
 }
 
 .pf-c-form-control {
@@ -50,16 +36,18 @@ $pf-c-form-controls--error-svg--Viewbox: "0 0 26 15.8" !default;
   --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--BackgroundColor--disabled);
 
   // input alt style
-  --pf-c-form-control--m-alt--focus--BottomBorderWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-form-control--alt--BottomBorderWidth: var(--pf-global--BorderWidth--md);
 
   // Input m-error
   --pf-c-form-control--error--PaddingTop: calc(#{var(--pf-global--spacer--sm)} - 4px);
   --pf-c-form-control--error--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-form-control--error--PaddingBottom: calc(#{var(--pf-global--spacer--sm)} - 4px);
+  --pf-c-form-control--error--PaddingLeft: calc(#{var(--pf-global--spacer--sm)} - 1px);
   --pf-c-form-control--error--BorderColor: var(--pf-global--BorderColor--error);
   --pf-c-form-control--error--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-form-control--error--BorderSize: var(--pf-global--BorderWidth--md);
-
+  --pf-c-form-control--BackgroundWidth: var(--pf-global--FontSize--md);
+  --pf-c-form-control--BackgroundHeight: var(--pf-global--FontSize--md);
   width: 100%;
   padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
   font-size: var(--pf-c-form-control--FontSize);
@@ -80,30 +68,30 @@ $pf-c-form-controls--error-svg--Viewbox: "0 0 26 15.8" !default;
     border-color: var(--pf-c-form-control--disabled--BorderColor);
   }
   &.pf-m-error {
-    padding-top: var(--pf-c-form-control--error--PaddingTop);
-    padding-bottom: var(--pf-c-form-control--error--PaddingBottom);
-    border-color: var(--pf-c-form-control--error--BorderColor);
-    border-width: var(--pf-c-form-control--error--BorderSize);
-    &:not(select){
-      padding-right: var(--pf-c-form-control--error--PaddingRight);
-      @include pf-bg-svg($pf-c-form-controls--error-svg--Coordinates, $pf-c-form-controls--error-svg--Color, $pf-c-form-controls--error-svg--Width, $pf-c-form-controls--error-svg--Height, $pf-c-form-controls--error-svg--Viewbox);
+    @include pf-bg-svg($pf-c-form-controls--error--Coordinates, $pf-c-form-controls--error--Color);
+    &:not(.pf-m-form-control-alt){
+      padding: var(--pf-c-form-control--error--PaddingTop) var(--pf-c-form-control--error--PaddingRight) var(--pf-c-form-control--error--PaddingBottom) var(--pf-c-form-control--error--PaddingLeft);
+      border-color: var(--pf-c-form-control--error--BorderColor);
+      border-width: var(--pf-c-form-control--error--BorderSize);
     }
   }
 
   @at-root select#{&} {
     height: var(--pf-c-form-control--Height);
     &.pf-m-error {
-      padding-right: var(--pf-c-form-control--PaddingRight);
       background: none;
     }
   }
 
-  // styles for unique login form input
+  // styles for alternative form input
   &.pf-m-form-control-alt {
     padding-right: 0;
     padding-left: 0;
     border: none;
-    border-bottom: var(--pf-c-form-control--BorderSize) solid var(--pf-c-form-control--BorderColor);
+    border-bottom: var(--pf-c-form-control--alt--BottomBorderWidth) solid var(--pf-c-form-control--BorderColor);
     border-radius: 0;
+    &.pf-m-error {
+      border-bottom-color: var(--pf-c-form-control--error--BorderColor);
+    }
   }
 }

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -81,16 +81,19 @@ $pf-c-form-controls--error-svg--Viewbox: "0 0 26 15.8" !default;
   }
   &.pf-m-error {
     padding-top: var(--pf-c-form-control--error--PaddingTop);
-    padding-right: var(--pf-c-form-control--error--PaddingRight);
     padding-bottom: var(--pf-c-form-control--error--PaddingBottom);
     border-color: var(--pf-c-form-control--error--BorderColor);
     border-width: var(--pf-c-form-control--error--BorderSize);
-    @include pf-bg-svg($pf-c-form-controls--error-svg--Coordinates, $pf-c-form-controls--error-svg--Color, $pf-c-form-controls--error-svg--Width, $pf-c-form-controls--error-svg--Height, $pf-c-form-controls--error-svg--Viewbox);
+    &:not(select){
+      padding-right: var(--pf-c-form-control--error--PaddingRight);
+      @include pf-bg-svg($pf-c-form-controls--error-svg--Coordinates, $pf-c-form-controls--error-svg--Color, $pf-c-form-controls--error-svg--Width, $pf-c-form-controls--error-svg--Height, $pf-c-form-controls--error-svg--Viewbox);
+    }
   }
 
   @at-root select#{&} {
     height: var(--pf-c-form-control--Height);
     &.pf-m-error {
+      padding-right: var(--pf-c-form-control--PaddingRight);
       background: none;
     }
   }

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -27,7 +27,7 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
   --pf-c-form-control--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
 
   // input placeholder style
-  --pf-c-form-control--placeholder--Color: var(--pf-global--Color--200);
+  --pf-c-form-control--placeholder--Color: var(--pf-global--Color--dark-200);
 
   // input disabled style
   --pf-c-form-control--disabled--Color: var(--pf-global--disabled-color--100);
@@ -39,7 +39,7 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
   --pf-c-form-control--readonly--Color: var(--pf-global--Color--100);
   --pf-c-form-control--readonly--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-form-control--readonly--BorderColor: var(--pf-global--BorderColor--dark);
-  --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--BackgroundColor--150);
+  --pf-c-form-control--readonly--BackgroundColor: var(--pf-global--disabled-color--200);
 
   // input alt style
   --pf-c-form-control--alt--BottomBorderWidth: var(--pf-global--BorderWidth--md);
@@ -54,6 +54,10 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
   --pf-c-form-control--invalid--BorderSize: var(--pf-global--BorderWidth--md);
   --pf-c-form-control--BackgroundWidth: var(--pf-global--FontSize--md);
   --pf-c-form-control--BackgroundHeight: var(--pf-global--FontSize--md);
+
+  // This component always needs to be light
+  @extend %pf-t-light;
+
   width: 100%;
   padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
   font-size: var(--pf-c-form-control--FontSize);
@@ -66,19 +70,23 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
   &::placeholder {
     color: var(--pf-c-form-control--placeholder--Color);
   }
+
   &:disabled {
     color: var(--pf-c-form-control--disabled--Color);
     cursor: not-allowed;
     background-color: var(--pf-c-form-control--disabled--BackgroundColor);
     border-color: var(--pf-c-form-control--disabled--BorderColor);
   }
+
   &[readonly]{
     background-color: var(--pf-c-form-control--readonly--BackgroundColor);
     border-color: var(--pf-c-form-control--readonly--BorderColor);
   }
+
   &.pf-m-invalid,
   :invalid {
     @include pf-bg-svg($pf-c-form-controls--invalid--Coordinates, $pf-c-form-controls--invalid--Color);
+
     &:not(.pf-m-form-control-alt){
       padding: var(--pf-c-form-control--invalid--PaddingTop) var(--pf-c-form-control--invalid--PaddingRight) var(--pf-c-form-control--invalid--PaddingBottom) var(--pf-c-form-control--invalid--PaddingLeft);
       border-color: var(--pf-c-form-control--invalid--BorderColor);
@@ -88,6 +96,7 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
 
   @at-root select#{&} {
     height: var(--pf-c-form-control--Height);
+
     &.pf-m-invalid,
     :invalid {
       background: none;
@@ -101,6 +110,7 @@ $pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12
     border: none;
     border-bottom: var(--pf-c-form-control--alt--BottomBorderWidth) solid var(--pf-c-form-control--BorderColor);
     border-radius: 0;
+
     &.pf-m-invalid,
     :invalid {
       border-bottom-color: var(--pf-c-form-control--invalid--BorderColor);

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -1,5 +1,29 @@
 @import "../../patternfly-utilities";
-// Input, select, datalist, and textarea
+// Input - error
+$pf-c-form-controls--error-svg--Color: $pf-global--danger-color--100 !default;
+$pf-c-form-controls--error-svg--Width: 24px !default;
+$pf-c-form-controls--error-svg--Height: 24px !default;
+$pf-c-form-controls--error-svg--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
+$pf-c-form-controls--error-svg--Viewbox: "0 0 26 15.8" !default;
+
+// Function - strip-unit
+@function pf-strip-unit($val) {
+  @if type-of($val) == "number" and not unitless($val) {
+    @return $val / ($val * 0 + 1);
+  } @else {
+    @return $val;
+  }
+}
+
+// Background svg mixin - likely temporary
+@mixin pf-bg-svg($svg-coordinates, $svg-color, $svg-width: 24, $svg-height: 8,  $svg-viewbox: "0 0 32 10") {
+  $color: str-slice(#{$svg-color}, 2);
+  $svg-width: pf-strip-unit($svg-width);
+  $svg-height: pf-strip-unit($svg-height);
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$svg-width}' height='#{$svg-height}' viewBox='#{$svg-viewbox}'%3E%3Cpath fill='%23#{$color}' d='#{$svg-coordinates}'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right top 4px;
+}
 
 .pf-c-form-control {
   --pf-c-form-control--FontSize: var(--pf-global--FontSize--md);
@@ -11,17 +35,31 @@
   --pf-c-form-control--PaddingBottom: calc(#{var(--pf-global--spacer--sm)} - 3px);
   --pf-c-form-control--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-form-control--Color: var(--pf-global--Color--dark-100);
-  --pf-c-form-control--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-form-control--BorderSize: var(--pf-global--BorderWidth--sm);
-  --pf-c-form-control--focus--BorderSize: var(--pf-global--BorderWidth--md);
-  --pf-c-form-control--disabled--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-form-control--BorderColor: var(--pf-global--BorderColor--dark);
   --pf-c-form-control--BorderRadius: var(--pf-global--BorderRadius--sm);
-  --pf-c-form-control--disabled--BorderColor: var(--pf-global--disabled-color--200);
   --pf-c-form-control--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
-  --pf-c-form-control--placeholder--Color: var(--pf-global--Color--dark-200);
-  --pf-c-form-control--m-login--focus--BottomBorderWidth: var(--pf-global--BorderWidth--md);
+
+  // input placeholder style
+  --pf-c-form-control--placeholder--Color: var(--pf-global--Color--200);
+
+  // input disabled style
+  --pf-c-form-control--disabled--Color: var(--pf-global--Color--disabled);
+  --pf-c-form-control--disabled--BorderSize: var(--pf-global--BorderWidth--sm);
+  --pf-c-form-control--disabled--BorderColor: var(--pf-global--BorderColor--disabled);
+  --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--BackgroundColor--disabled);
+
+  // input alt style
+  --pf-c-form-control--m-alt--focus--BottomBorderWidth: var(--pf-global--BorderWidth--md);
+
+  // Input m-error
+  --pf-c-form-control--error--PaddingTop: calc(#{var(--pf-global--spacer--sm)} - 4px);
+  --pf-c-form-control--error--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-form-control--error--PaddingBottom: calc(#{var(--pf-global--spacer--sm)} - 4px);
+  --pf-c-form-control--error--BorderColor: var(--pf-global--BorderColor--error);
+  --pf-c-form-control--error--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-form-control--error--BorderSize: var(--pf-global--BorderWidth--md);
+
   width: 100%;
   padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
   font-size: var(--pf-c-form-control--FontSize);
@@ -34,7 +72,6 @@
   &::placeholder {
     color: var(--pf-c-form-control--placeholder--Color);
   }
-
   &.pf-m-disabled,
   &:disabled {
     color: var(--pf-c-form-control--disabled--Color);
@@ -42,9 +79,20 @@
     background-color: var(--pf-c-form-control--disabled--BackgroundColor);
     border-color: var(--pf-c-form-control--disabled--BorderColor);
   }
+  &.pf-m-error {
+    padding-top: var(--pf-c-form-control--error--PaddingTop);
+    padding-right: var(--pf-c-form-control--error--PaddingRight);
+    padding-bottom: var(--pf-c-form-control--error--PaddingBottom);
+    border-color: var(--pf-c-form-control--error--BorderColor);
+    border-width: var(--pf-c-form-control--error--BorderSize);
+    @include pf-bg-svg($pf-c-form-controls--error-svg--Coordinates, $pf-c-form-controls--error-svg--Color, $pf-c-form-controls--error-svg--Width, $pf-c-form-controls--error-svg--Height, $pf-c-form-controls--error-svg--Viewbox);
+  }
 
   @at-root select#{&} {
     height: var(--pf-c-form-control--Height);
+    &.pf-m-error {
+      background: none;
+    }
   }
 
   // styles for unique login form input

--- a/src/patternfly/components/FormControls/styles.scss
+++ b/src/patternfly/components/FormControls/styles.scss
@@ -1,7 +1,7 @@
 @import "../../patternfly-utilities";
 // Input - error
-$pf-c-form-controls--error--Color: $pf-global--danger-color--100 !default;
-$pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
+$pf-c-form-controls--invalid--Color: $pf-global--danger-color--100 !default;
+$pf-c-form-controls--invalid--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3,0 7.9C0 3.5 3.5 0 7.9 0S15.8,3.5,15.8,7.9z M7.9 9.5c-0.8 0-1.5 0.7-1.5 1.5 s0.7,1.5 1.5 1.5s1.5-0.7 1.5-1.5S8.7 9.5 7.9,9.5z M6.5 4.2l0.2 4.3c0 0.2 0.2 0.4 0.4 0.4h1.5c0.2 0 0.4-0.2 0.4-0.4l0.2-4.3 c0-0.2-0.2-0.4-0.4-0.4h-2C6.7 3.8 6.5 4 6.5 4.2L6.5 4.2z" !default;
 // Background svg mixin
 @mixin pf-bg-svg($svg-coordinates, $svg-color) {
   $color: str-slice(#{$svg-color}, 2);
@@ -30,22 +30,22 @@ $pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3
   --pf-c-form-control--placeholder--Color: var(--pf-global--Color--200);
 
   // input disabled style
-  --pf-c-form-control--disabled--Color: var(--pf-global--Color--disabled);
+  --pf-c-form-control--disabled--Color: var(--pf-global--disabled-color--100);
   --pf-c-form-control--disabled--BorderSize: var(--pf-global--BorderWidth--sm);
-  --pf-c-form-control--disabled--BorderColor: var(--pf-global--BorderColor--disabled);
-  --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--BackgroundColor--disabled);
+  --pf-c-form-control--disabled--BorderColor: var(--pf-global--disabled-color--200);
+  --pf-c-form-control--disabled--BackgroundColor: var(--pf-global--disabled-color--200);
 
   // input alt style
   --pf-c-form-control--alt--BottomBorderWidth: var(--pf-global--BorderWidth--md);
 
-  // Input m-error
-  --pf-c-form-control--error--PaddingTop: calc(#{var(--pf-global--spacer--sm)} - 4px);
-  --pf-c-form-control--error--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-form-control--error--PaddingBottom: calc(#{var(--pf-global--spacer--sm)} - 4px);
-  --pf-c-form-control--error--PaddingLeft: calc(#{var(--pf-global--spacer--sm)} - 1px);
-  --pf-c-form-control--error--BorderColor: var(--pf-global--BorderColor--error);
-  --pf-c-form-control--error--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-form-control--error--BorderSize: var(--pf-global--BorderWidth--md);
+  // Input m-invalid
+  --pf-c-form-control--invalid--PaddingTop: calc(#{var(--pf-global--spacer--sm)} - 4px);
+  --pf-c-form-control--invalid--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-form-control--invalid--PaddingBottom: calc(#{var(--pf-global--spacer--sm)} - 4px);
+  --pf-c-form-control--invalid--PaddingLeft: calc(#{var(--pf-global--spacer--sm)} - 1px);
+  --pf-c-form-control--invalid--BorderColor: var(--pf-global--danger-color--100);
+  --pf-c-form-control--invalid--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-form-control--invalid--BorderSize: var(--pf-global--BorderWidth--md);
   --pf-c-form-control--BackgroundWidth: var(--pf-global--FontSize--md);
   --pf-c-form-control--BackgroundHeight: var(--pf-global--FontSize--md);
   width: 100%;
@@ -60,7 +60,6 @@ $pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3
   &::placeholder {
     color: var(--pf-c-form-control--placeholder--Color);
   }
-  &.pf-m-disabled,
   &:disabled {
     color: var(--pf-c-form-control--disabled--Color);
     cursor: not-allowed;
@@ -69,17 +68,18 @@ $pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3
   }
   &.pf-m-invalid,
   :invalid {
-    @include pf-bg-svg($pf-c-form-controls--error--Coordinates, $pf-c-form-controls--error--Color);
+    @include pf-bg-svg($pf-c-form-controls--invalid--Coordinates, $pf-c-form-controls--invalid--Color);
     &:not(.pf-m-form-control-alt){
-      padding: var(--pf-c-form-control--error--PaddingTop) var(--pf-c-form-control--error--PaddingRight) var(--pf-c-form-control--error--PaddingBottom) var(--pf-c-form-control--error--PaddingLeft);
-      border-color: var(--pf-c-form-control--error--BorderColor);
-      border-width: var(--pf-c-form-control--error--BorderSize);
+      padding: var(--pf-c-form-control--invalid--PaddingTop) var(--pf-c-form-control--invalid--PaddingRight) var(--pf-c-form-control--invalid--PaddingBottom) var(--pf-c-form-control--invalid--PaddingLeft);
+      border-color: var(--pf-c-form-control--invalid--BorderColor);
+      border-width: var(--pf-c-form-control--invalid--BorderSize);
     }
   }
 
   @at-root select#{&} {
     height: var(--pf-c-form-control--Height);
-    &.pf-m-error {
+    &.pf-m-invalid,
+    :invalid {
       background: none;
     }
   }
@@ -91,8 +91,9 @@ $pf-c-form-controls--error--Coordinates: "M15.8 7.9c0 4.4-3.5 7.9-7.9,7.9S0 12.3
     border: none;
     border-bottom: var(--pf-c-form-control--alt--BottomBorderWidth) solid var(--pf-c-form-control--BorderColor);
     border-radius: 0;
-    &.pf-m-invalid {
-      border-bottom-color: var(--pf-c-form-control--error--BorderColor);
+    &.pf-m-invalid,
+    :invalid {
+      border-bottom-color: var(--pf-c-form-control--invalid--BorderColor);
     }
   }
 }

--- a/src/patternfly/components/InputGroup/docs/code.md
+++ b/src/patternfly/components/InputGroup/docs/code.md
@@ -2,7 +2,7 @@
 Use the input group to extend form controls by adding text, buttons, dropdowns, etc.
 
 ## Accessibility
-When using the `pf-c-input-group` always ensure labels are used outside the input group with the `.sr-only` class applied. You can also make use of the `aria-describedby`, `aria-label`, or `aria-labelledby` attributues. For more information on accessibility and forms see the <a href="/components/form/examples/">form component</a>.
+When using the `pf-c-input-group` always ensure labels are used outside the input group with the `.pf-u-sr-only` class applied. You can also make use of the `aria-describedby`, `aria-label`, or `aria-labelledby` attributues. For more information on accessibility and forms see the <a href="/components/form/examples/">form component</a>.
 
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/InputGroup/examples/input-group-example.hbs
+++ b/src/patternfly/components/InputGroup/examples/input-group-example.hbs
@@ -60,6 +60,6 @@
   <span class="pf-c-input-group__text" aria-label="text input label">
     <i class="fas fa-at" aria-hidden="true"></i>
   </span>
-  {{#> form-controls pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text" controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-label="standard input example" }}
+  {{#> form-controls pf-c-form-control--modifier="pf-m-invalid" required="true" aria-errormessage="textInput7error" controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-label="standard input example" }}
 {{/form-controls}}
 </div>

--- a/src/patternfly/components/InputGroup/examples/input-group-example.hbs
+++ b/src/patternfly/components/InputGroup/examples/input-group-example.hbs
@@ -26,7 +26,7 @@
 <br>
 <div class="pf-c-input-group">
   {{#> form-controls controlType="input" input="true" type="text" id="textInput4" name="textInput4" }}
-  {{/form-controls}}
+  {{/form-controls}} 
   {{#> button btnClass="pf-m-secondary"}} Button {{/button}}
   {{#> dropdown id="dropdown-example-collapsed"}}
     Dropdown
@@ -60,6 +60,6 @@
   <span class="pf-c-input-group__text" aria-label="text input label">
     <i class="fas fa-at" aria-hidden="true"></i>
   </span>
-  {{#> form-controls controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-label="standard input example" }}
+  {{#> form-controls pf-c-form-control--modifier="pf-m-error" aria-invalid="true" aria-errormessage="incorrect text" controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-label="standard input example" }}
 {{/form-controls}}
 </div>

--- a/src/patternfly/components/InputGroup/styles.scss
+++ b/src/patternfly/components/InputGroup/styles.scss
@@ -19,7 +19,13 @@
   margin-left: -1px;
 }
 
- /* stylelint-enable */
+  .pf-m-error {
+    margin-left: 0;
+    &:not(:last-child){
+      margin-right: 1px;
+    }
+  }
+
   display: flex;
   align-items: stretch;
   width: 100%;

--- a/src/patternfly/components/InputGroup/styles.scss
+++ b/src/patternfly/components/InputGroup/styles.scss
@@ -19,7 +19,7 @@
   margin-left: -1px;
 }
 
-  .pf-m-error {
+  .pf-m-invalid {
     margin-left: 0;
     &:not(:last-child){
       margin-right: 1px;

--- a/src/patternfly/sass-utilities/variables.scss
+++ b/src/patternfly/sass-utilities/variables.scss
@@ -50,21 +50,8 @@ $pf-global--active-color--100:   $pf-color-blue-400 !default;
 $pf-global--active-color--200:   $pf-color-blue-100 !default;
 $pf-global--active-color--300:   $pf-color-blue-300 !default;
 
-<<<<<<< HEAD
 $pf-global--disabled-color--100: $pf-color-black-600 !default;
 $pf-global--disabled-color--200: $pf-color-black-300 !default;
-=======
-$pf-global--Color--disabled:               $pf-color-black-600 !default;
-$pf-global--BackgroundColor--disabled:     $pf-color-black-300 !default;
-$pf-global--BorderColor--disabled:         $pf-color-black-300 !default;
-
-
-$pf-global--BorderColor--error:         $pf-color-red-100 !default;
-
-// do not use - state colors for exceptions and defining theme
-$pf-global--Color--light-active:           $pf-color-blue-300 !default;
-$pf-global--Color--dark-active:            $pf-color-blue-400 !default;
->>>>>>> feat(forms):adds error/required styles to forms and form-component
 
 // Theme color
 $pf-global--primary-color--100:         $pf-color-blue-400 !default;
@@ -278,23 +265,11 @@ $pf-global--spacer-map: (
   --pf-global--Color--dark-200: $pf-global--Color--dark-200;
 
   // States color
-<<<<<<< HEAD
   --pf-global--active-color--100:    $pf-global--active-color--100;
   --pf-global--active-color--200:    $pf-global--active-color--200;
   --pf-global--active-color--300:    $pf-global--active-color--300;
   --pf-global--disabled-color--100:  $pf-global--disabled-color--100;
   --pf-global--disabled-color--200:  $pf-global--disabled-color--200;
-=======
-  --pf-global--Color--active: $pf-global--Color--active;
-  --pf-global--Color--light-active: $pf-global--Color--light-active;
-  --pf-global--Color--dark-active: $pf-global--Color--dark-active;
-  --pf-global--BackgroundColor--active: $pf-global--BackgroundColor--active;
-  --pf-global--BorderColor--active: $pf-global--BorderColor--active;
-  --pf-global--BorderColor--error: $pf-global--BorderColor--error;
-  --pf-global--Color--disabled: $pf-global--Color--disabled;
-  --pf-global--BackgroundColor--disabled: $pf-global--BackgroundColor--disabled;
-  --pf-global--BorderColor--disabled: $pf-global--BorderColor--disabled;
->>>>>>> feat(forms):adds error/required styles to forms and form-component
   
   // Theme color
   --pf-global--primary-color--100: $pf-global--primary-color--100;

--- a/src/patternfly/sass-utilities/variables.scss
+++ b/src/patternfly/sass-utilities/variables.scss
@@ -21,6 +21,7 @@ $pf-global--space-size-root: 16 !default; // for spaces
 // Colors
 // Background color
 $pf-global--BackgroundColor--100: $pf-color-white !default;
+$pf-global--BackgroundColor--150: $pf-color-black-150 !default;
 $pf-global--BackgroundColor--200: $pf-color-black-100 !default;
 $pf-global--BackgroundColor--300: $pf-color-black-200 !default;
 
@@ -246,6 +247,7 @@ $pf-global--spacer-map: (
   // Colors
   // Background color
   --pf-global--BackgroundColor--100: $pf-global--BackgroundColor--100;
+  --pf-global--BackgroundColor--150: $pf-global--BackgroundColor--150;
   --pf-global--BackgroundColor--200: $pf-global--BackgroundColor--200;
   --pf-global--BackgroundColor--300: $pf-global--BackgroundColor--300;
   --pf-global--BackgroundColor--light-100: $pf-global--BackgroundColor--light-100;

--- a/src/patternfly/sass-utilities/variables.scss
+++ b/src/patternfly/sass-utilities/variables.scss
@@ -50,8 +50,21 @@ $pf-global--active-color--100:   $pf-color-blue-400 !default;
 $pf-global--active-color--200:   $pf-color-blue-100 !default;
 $pf-global--active-color--300:   $pf-color-blue-300 !default;
 
+<<<<<<< HEAD
 $pf-global--disabled-color--100: $pf-color-black-600 !default;
 $pf-global--disabled-color--200: $pf-color-black-300 !default;
+=======
+$pf-global--Color--disabled:               $pf-color-black-600 !default;
+$pf-global--BackgroundColor--disabled:     $pf-color-black-300 !default;
+$pf-global--BorderColor--disabled:         $pf-color-black-300 !default;
+
+
+$pf-global--BorderColor--error:         $pf-color-red-100 !default;
+
+// do not use - state colors for exceptions and defining theme
+$pf-global--Color--light-active:           $pf-color-blue-300 !default;
+$pf-global--Color--dark-active:            $pf-color-blue-400 !default;
+>>>>>>> feat(forms):adds error/required styles to forms and form-component
 
 // Theme color
 $pf-global--primary-color--100:         $pf-color-blue-400 !default;
@@ -199,7 +212,7 @@ $pf-global--arrow--width-lg: pf-font-prem(25px);
   @import url("https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.37.10/css/patternfly-additions.min.css");
 }
 
-// Global sass maps - used for 
+// Global sass maps - used for
 // Breakpoints
 $pf-global--breakpoint-map: (
   "": null,
@@ -265,11 +278,23 @@ $pf-global--spacer-map: (
   --pf-global--Color--dark-200: $pf-global--Color--dark-200;
 
   // States color
+<<<<<<< HEAD
   --pf-global--active-color--100:    $pf-global--active-color--100;
   --pf-global--active-color--200:    $pf-global--active-color--200;
   --pf-global--active-color--300:    $pf-global--active-color--300;
   --pf-global--disabled-color--100:  $pf-global--disabled-color--100;
   --pf-global--disabled-color--200:  $pf-global--disabled-color--200;
+=======
+  --pf-global--Color--active: $pf-global--Color--active;
+  --pf-global--Color--light-active: $pf-global--Color--light-active;
+  --pf-global--Color--dark-active: $pf-global--Color--dark-active;
+  --pf-global--BackgroundColor--active: $pf-global--BackgroundColor--active;
+  --pf-global--BorderColor--active: $pf-global--BorderColor--active;
+  --pf-global--BorderColor--error: $pf-global--BorderColor--error;
+  --pf-global--Color--disabled: $pf-global--Color--disabled;
+  --pf-global--BackgroundColor--disabled: $pf-global--BackgroundColor--disabled;
+  --pf-global--BorderColor--disabled: $pf-global--BorderColor--disabled;
+>>>>>>> feat(forms):adds error/required styles to forms and form-component
   
   // Theme color
   --pf-global--primary-color--100: $pf-global--primary-color--100;

--- a/src/patternfly/sass-utilities/variables.scss
+++ b/src/patternfly/sass-utilities/variables.scss
@@ -21,7 +21,6 @@ $pf-global--space-size-root: 16 !default; // for spaces
 // Colors
 // Background color
 $pf-global--BackgroundColor--100: $pf-color-white !default;
-$pf-global--BackgroundColor--150: $pf-color-black-150 !default;
 $pf-global--BackgroundColor--200: $pf-color-black-100 !default;
 $pf-global--BackgroundColor--300: $pf-color-black-200 !default;
 
@@ -247,7 +246,6 @@ $pf-global--spacer-map: (
   // Colors
   // Background color
   --pf-global--BackgroundColor--100: $pf-global--BackgroundColor--100;
-  --pf-global--BackgroundColor--150: $pf-global--BackgroundColor--150;
   --pf-global--BackgroundColor--200: $pf-global--BackgroundColor--200;
   --pf-global--BackgroundColor--300: $pf-global--BackgroundColor--300;
   --pf-global--BackgroundColor--light-100: $pf-global--BackgroundColor--light-100;


### PR DESCRIPTION
This adds the error state and required styles to the form-control component.

Included in this is the help messaging (both standard and error).

I have a few questions. @mattnolting I'm making use of your mixin for the icon for the error state. I'm not aware of the discussion around this and why it was marked as temporary. Do we want to take this approach or something else? Also, @kybaker in the sketch file I didn't see a form select with an error, but I've gone ahead and added it, I removed the icon because it conflicts with the arrow for the select. Please advise if you'd like to take another approach.

@jgiardino can you confirm that I'm implementing the proper Aria attributes for the error state?
On the topic of accessibility the helper text size is 12px and the color was `pf-black-700` which doesn't currently exist anywhere in the global variables. We could create it or just use the `pf-black-600` which is the secondary text colour. I've mentioned this in the issue as well.

I've also included what @mcoker did in #498 so we can close that.

This closes #260 #259

Thanks in advance!