### PR TITLE
Changed aria-label of ModalBox & Popover X buttons

### DIFF
--- a/src/patternfly/components/ModalBox/docs/code.md
+++ b/src/patternfly/components/ModalBox/docs/code.md
@@ -11,7 +11,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | `aria-label="[title of modal]"` | `.pf-c-modal-box` | Gives the modal an accessible name. **Required when .pf-c-modal-box__header-title is _not_ present** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|
-| `aria-label="Close Dialog"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
+| `aria-label="Close"` | `.pf-c-modal-box__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
 
 ## Usage
 

--- a/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-basic-example.hbs
@@ -1,6 +1,6 @@
 {{#> modal-box modal-box--attributes='aria-labelledby="modal-title" aria-describedby="modal-description"'}}
   {{#> modal-box-close}}
-    {{#> button btnClass="pf-m-plain" btnAttributes='aria-label="Close Dialog"'}}
+    {{#> button btnClass="pf-m-plain" btnAttributes='aria-label="Close"'}}
       <i class="fas fa-times"></i>
     {{/button}}
   {{/modal-box-close}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-lg-example.hbs
@@ -1,6 +1,6 @@
 {{#> modal-box modal-box--modifiers="pf-m-lg" modal-box--attributes='aria-labelledby="modal-lg-title" aria-describedby="modal-lg-description"'}}
   {{#> modal-box-close}}
-    {{#> button btnClass="pf-m-plain" btnAttributes='aria-label="Close Dialog"'}}
+    {{#> button btnClass="pf-m-plain" btnAttributes='aria-label="Close"'}}
       <i class="fas fa-times"></i>
     {{/button}}
   {{/modal-box-close}}

--- a/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
+++ b/src/patternfly/components/ModalBox/examples/modal-box-no-header-example.hbs
@@ -1,6 +1,6 @@
 {{#> modal-box modal-box--attributes='aria-label="Example of a modal without a header" aria-describedby="modal-no-header-description"'}}
   {{#> modal-box-close}}
-    {{#> button btnClass="pf-m-plain" btnAttributes='aria-label="Close Dialog"'}}
+    {{#> button btnClass="pf-m-plain" btnAttributes='aria-label="Close"'}}
       <i class="fas fa-times"></i>
     {{/button}}
   {{/modal-box-close}}  

--- a/src/patternfly/components/Popover/docs/code.md
+++ b/src/patternfly/components/Popover/docs/code.md
@@ -11,7 +11,7 @@ A popover is used to provide contextual information for another component on cli
 | `aria-label="[title of popover]"` | `.pf-c-popover` | Gives the popover an accessible name. **Required when .pf-c-popover__header-title is _not_ present** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-popover` | Gives the popover an accessible description by referring to the popover content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the popover. |
 | `aria-popover="true"` | `.pf-c-popover` | Tells assistive technologies that the windows underneath the current popover are not available for interaction. **Required**|
-| `aria-label="Close Dialog"` | `.pf-c-popover__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
+| `aria-label="Close"` | `.pf-c-popover__close .pf-c-button` | Provides an accessible name for the close button as it uses an icon instead of text. **Required**|
 
 
 ## Usage

--- a/src/patternfly/components/Popover/popover.hbs
+++ b/src/patternfly/components/Popover/popover.hbs
@@ -4,7 +4,7 @@
       <div class="pf-c-popover__arrow"></div>
       <div class="pf-c-popover__content" role="dialog" aria-modal="true" aria-labelledby="popover-title" aria-describedby="popover-description">
         <div class="pf-c-popover__close">
-          <button class="pf-c-button pf-m-plain" aria-label="Close Dialog">
+          <button class="pf-c-button pf-m-plain" aria-label="Close">
             <i class="fas fa-times"></i>
           </button>
         </div>


### PR DESCRIPTION
The “Close Dialog” value of aria-label is now just “Close” in both the examples and docs. This should be clearer to users who don’t know/care about the difference. Resolves #525.