### PR TITLE
Corrected “aria-labelledby” spelling in docs

### DIFF
--- a/src/patternfly/components/ModalBox/docs/code.md
+++ b/src/patternfly/components/ModalBox/docs/code.md
@@ -7,7 +7,7 @@ A modal box is a generic rectangular container that can be used to build modals.
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
 | `role="dialog"` | `.pf-c-modal-box` | Identifies the element that serves as the modal container. **Required**|
-| `aria-labeledby="[id value of .pf-c-modal-box__header-title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-modal-box__header-title is present** |
+| `aria-labelledby="[id value of .pf-c-modal-box__header-title]"` | `.pf-c-modal-box` | Gives the modal an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-modal-box__header-title is present** |
 | `aria-label="[title of modal]"` | `.pf-c-modal-box` | Gives the modal an accessible name. **Required when .pf-c-modal-box__header-title is _not_ present** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-modal-box` | Gives the modal an accessible description by referring to the modal content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the modal. |
 | `aria-modal="true"` | `.pf-c-modal-box` | Tells assistive technologies that the windows underneath the current modal are not available for interaction. **Required**|

--- a/src/patternfly/components/Popover/docs/code.md
+++ b/src/patternfly/components/Popover/docs/code.md
@@ -7,7 +7,7 @@ A popover is used to provide contextual information for another component on cli
 | Attribute | Applies to | Outcome |
 | -- | -- | -- |
 | `role="dialog"` | `.pf-c-popover` | Identifies the element that serves as the popover container. **Required**|
-| `aria-labeledby="[id value of .pf-c-popover__header-title]"` | `.pf-c-popover` | Gives the popover an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-popover__header-title is present** |
+| `aria-labelledby="[id value of .pf-c-popover__header-title]"` | `.pf-c-popover` | Gives the popover an accessible name by referring to the element that provides the dialog title. **Required when .pf-c-popover__header-title is present** |
 | `aria-label="[title of popover]"` | `.pf-c-popover` | Gives the popover an accessible name. **Required when .pf-c-popover__header-title is _not_ present** |
 | `aria-describedby="[id value of applicable content]"` | `.pf-c-popover` | Gives the popover an accessible description by referring to the popover content that describes the primary message or purpose of the dialog. Not used if there is no static text that describes the popover. |
 | `aria-popover="true"` | `.pf-c-popover` | Tells assistive technologies that the windows underneath the current popover are not available for interaction. **Required**|


### PR DESCRIPTION
Added the second L to the misspelled “aria-labeledby” attribute in the ModalBox and Popover documentation. Resolves #590.