### PR TITLE
fix(doc): update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ To setup the PatternFly Next development environment:
 - run `npm run cli:setup` (only needed if doing development)
 - run `npm run dev`
 - open your browser to `http://localhost:8000`
-- check for a11y violations with `npm run a11y` (ensure dev server is running first)
+
+To run the a11y audit locally
+- install latest chromedriver from http://chromedriver.chromium.org/downloads
+- place downloaded chromedriver on your `$PATH`
+- run `npm run dev`
+- run `npm run a11y`
 
 ### Create a new component
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To setup the PatternFly Next development environment:
 - open your browser to `http://localhost:8000`
 
 To run the a11y audit locally
-- install latest chromedriver from http://chromedriver.chromium.org/downloads
-- place downloaded chromedriver on your `$PATH`
+- install latest [chromedriver](http://chromedriver.chromium.org/downloads) and ensure its available on your system `$PATH`
+- alternatively, macOS users can simply `brew cask install chromedriver`
 - run `npm run dev`
 - run `npm run a11y`
 


### PR DESCRIPTION
This PR clarifies steps required to run the a11y audit locally. Specifically, we need to mention installing chromedriver and adding to your system path.

Without this knowledge, users trying to run the script will see an error like the one below and it's not so obvious how to fix.

`Error: The ChromeDriver could not be found on the current PATH. Please download the latest version of the ChromeDriver from http://chromedriver.storage.googleapis.com/index.html and ensure it can be found on your PATH.`

Sort of related to https://github.com/patternfly/patternfly-next/issues/528. It's one of the first experiences one may have in doing a11y stuff with Patternfly, so it would be good to explain all the things upfront, rather than allow user to run into this error and then figure out how to fix it.

list all steps required to run the a11y audit locally