### PR TITLE
feat(reporting): add PR status indicator for a11y audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,16 +1083,6 @@
         }
       }
     },
-    "JSONStream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
-      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -3746,6 +3736,16 @@
               "dev": true,
               "optional": true
             },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3755,16 +3755,6 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
               }
             },
             "strip-ansi": {
@@ -6336,8 +6326,8 @@
       "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.3",
         "lodash": "4.17.5",
         "meow": "4.0.1",
         "split2": "2.2.0",
@@ -11569,6 +11559,15 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11578,15 +11577,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -16168,6 +16158,16 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jspm": {
       "version": "0.17.0-beta.47",
@@ -27126,6 +27126,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -27175,15 +27184,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {

--- a/test-a11y/config.js
+++ b/test-a11y/config.js
@@ -1,0 +1,38 @@
+/* eslint global-require: 0, import/no-dynamic-require: 0 */
+const path = require('path');
+const program = require('commander');
+
+const defaultConfig = {
+  toleranceThreshold: 14,
+  host: 'localhost',
+  port: '8000',
+  protocol: 'http',
+  logColors: {
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    blue: '\x1b[36m',
+    yellow: '\x1b[33m',
+    reset: '\x1b[0m'
+  }
+};
+let incomingConfig = {};
+let config = {};
+
+program.option('-c, --config <path>', 'specifies a user defined configuration').parse(process.argv);
+
+if (program.config) {
+  const configPath = path.resolve(process.cwd(), program.config);
+  incomingConfig = require(configPath);
+  config = {
+    ...defaultConfig,
+    ...incomingConfig
+  };
+} else {
+  config = {
+    ...defaultConfig
+  };
+}
+
+module.exports = {
+  ...config
+};

--- a/test-a11y/utils.js
+++ b/test-a11y/utils.js
@@ -1,0 +1,10 @@
+module.exports = {
+  errorsExceedThreshold: (errors, limit) => errors > limit,
+  dec: r => {
+    let e;
+    const n = r.match(/.{1,4}/g) || [];
+    let t = '';
+    for (e = 0; e < n.length; e++) t += String.fromCharCode(parseInt(n[e], 16));
+    return t;
+  }
+};


### PR DESCRIPTION
This PR adds a status reporter for our a11y audit, which can now be ran automatically as part of a standard build on travis.

After a travis build is kicked off, the audit runs. Once the audit has started, a new status will be reported to the PR in a "pending" status. For example, like the screenshot below.

<img width="781" alt="screen shot 2018-08-21 at 4 55 46 pm" src="https://user-images.githubusercontent.com/5942899/44430610-3b4f4500-a569-11e8-9240-37a3e90cae5c.png">

### Once the audit has completed:

If the total number of violations has increased beyond the threshold we've set (currently 18) we'll fail the build and include a status reported back to the PR so users can understand what went wrong more quickly. For example, like in the screenshot below.

<img width="784" alt="screen shot 2018-08-21 at 4 56 21 pm" src="https://user-images.githubusercontent.com/5942899/44430796-d2b49800-a569-11e8-83d2-e1ca2b58ec8a.png">

If the total number of violations is below the active threshold, we include a status back to the PR indicating success scenario. For example, like in the screenshot below.

<img width="781" alt="screen shot 2018-08-21 at 4 52 17 pm" src="https://user-images.githubusercontent.com/5942899/44430969-65edcd80-a56a-11e8-90c3-8ce4b3e4a401.png">

Status can also be seen from commit view. For example, like in the screenshot below.

![screen shot 2018-08-21 at 6 37 15 pm](https://user-images.githubusercontent.com/5942899/44432752-5de55c00-a571-11e8-9ac4-a4658382403d.png)

Steps taken toward making our a11y audit tool available "as a service" by allowing configuration to be passed in like `node ./test-a11y/ -c path/to/config.json`

Contents of a config file could look like

`{
  "toleranceThreshold": 1
}
`

use github statuses api for reporting back to open PR's
refactor a11y audit control flow to rely on promises
introduce utils and config
allow for passed in config with -c flag