### PR TITLE
fix(variable assigns): when assigning sass variable use #{} so css vars knows the value

### DIFF
--- a/src/patternfly/_variables.scss
+++ b/src/patternfly/_variables.scss
@@ -1,151 +1,151 @@
 :root {
   // Colors
   // Background color
-  --pf-global--BackgroundColor--100: $pf-global--BackgroundColor--100;
-  --pf-global--BackgroundColor--200: $pf-global--BackgroundColor--200;
-  --pf-global--BackgroundColor--300: $pf-global--BackgroundColor--300;
-  --pf-global--BackgroundColor--light-100: $pf-global--BackgroundColor--light-100;
-  --pf-global--BackgroundColor--light-200: $pf-global--BackgroundColor--light-200;
-  --pf-global--BackgroundColor--light-300: $pf-global--BackgroundColor--light-300;
-  --pf-global--BackgroundColor--dark-100: $pf-global--BackgroundColor--dark-100;
-  --pf-global--BackgroundColor--dark-200: $pf-global--BackgroundColor--dark-200;
-  --pf-global--BackgroundColor--dark-transparent-100: $pf-global--BackgroundColor--dark-transparent-100;
-  --pf-global--BackgroundColor--dark-transparent-200: $pf-global--BackgroundColor--dark-transparent-200;
+  --pf-global--BackgroundColor--100: #{$pf-global--BackgroundColor--100};
+  --pf-global--BackgroundColor--200: #{$pf-global--BackgroundColor--200};
+  --pf-global--BackgroundColor--300: #{$pf-global--BackgroundColor--300};
+  --pf-global--BackgroundColor--light-100: #{$pf-global--BackgroundColor--light-100};
+  --pf-global--BackgroundColor--light-200: #{$pf-global--BackgroundColor--light-200};
+  --pf-global--BackgroundColor--light-300: #{$pf-global--BackgroundColor--light-300};
+  --pf-global--BackgroundColor--dark-100: #{$pf-global--BackgroundColor--dark-100};
+  --pf-global--BackgroundColor--dark-200: #{$pf-global--BackgroundColor--dark-200};
+  --pf-global--BackgroundColor--dark-transparent-100: #{$pf-global--BackgroundColor--dark-transparent-100};
+  --pf-global--BackgroundColor--dark-transparent-200: #{$pf-global--BackgroundColor--dark-transparent-200};
 
   // Text color
-  --pf-global--Color--100: $pf-global--Color--100;
-  --pf-global--Color--200: $pf-global--Color--200;
-  --pf-global--Color--light-100: $pf-global--Color--light-100;
-  --pf-global--Color--light-200: $pf-global--Color--light-200;
-  --pf-global--Color--dark-100: $pf-global--Color--dark-100;
-  --pf-global--Color--dark-200: $pf-global--Color--dark-200;
+  --pf-global--Color--100: #{$pf-global--Color--100};
+  --pf-global--Color--200: #{$pf-global--Color--200};
+  --pf-global--Color--light-100: #{$pf-global--Color--light-100};
+  --pf-global--Color--light-200: #{$pf-global--Color--light-200};
+  --pf-global--Color--dark-100: #{$pf-global--Color--dark-100};
+  --pf-global--Color--dark-200: #{$pf-global--Color--dark-200};
 
   // States color
-  --pf-global--active-color--100: $pf-global--active-color--100;
-  --pf-global--active-color--200: $pf-global--active-color--200;
-  --pf-global--active-color--300: $pf-global--active-color--300;
-  --pf-global--disabled-color--100: $pf-global--disabled-color--100;
-  --pf-global--disabled-color--200: $pf-global--disabled-color--200;
+  --pf-global--active-color--100: #{$pf-global--active-color--100};
+  --pf-global--active-color--200: #{$pf-global--active-color--200};
+  --pf-global--active-color--300: #{$pf-global--active-color--300};
+  --pf-global--disabled-color--100: #{$pf-global--disabled-color--100};
+  --pf-global--disabled-color--200: #{$pf-global--disabled-color--200};
 
   // Theme color
-  --pf-global--primary-color--100: $pf-global--primary-color--100;
-  --pf-global--primary-color--200: $pf-global--primary-color--200;
-  --pf-global--primary-color--light-100: $pf-global--primary-color--light-100;
-  --pf-global--primary-color--dark-100: $pf-global--primary-color--dark-100;
-  --pf-global--secondary-color--100: $pf-global--secondary-color--100;
-  --pf-global--success-color--100: $pf-global--success-color--100;
-  --pf-global--success-color--200: $pf-global--success-color--200;
-  --pf-global--info-color--100: $pf-global--info-color--100;
-  --pf-global--info-color--200: $pf-global--info-color--200;
-  --pf-global--warning-color--100: $pf-global--warning-color--100;
-  --pf-global--warning-color--200: $pf-global--warning-color--200;
-  --pf-global--danger-color--100: $pf-global--danger-color--100;
-  --pf-global--danger-color--200: $pf-global--danger-color--200;
-  --pf-global--danger-color--300: $pf-global--danger-color--300;
+  --pf-global--primary-color--100: #{$pf-global--primary-color--100};
+  --pf-global--primary-color--200: #{$pf-global--primary-color--200};
+  --pf-global--primary-color--light-100: #{$pf-global--primary-color--light-100};
+  --pf-global--primary-color--dark-100: #{$pf-global--primary-color--dark-100};
+  --pf-global--secondary-color--100: #{$pf-global--secondary-color--100};
+  --pf-global--success-color--100: #{$pf-global--success-color--100};
+  --pf-global--success-color--200: #{$pf-global--success-color--200};
+  --pf-global--info-color--100: #{$pf-global--info-color--100};
+  --pf-global--info-color--200: #{$pf-global--info-color--200};
+  --pf-global--warning-color--100: #{$pf-global--warning-color--100};
+  --pf-global--warning-color--200: #{$pf-global--warning-color--200};
+  --pf-global--danger-color--100: #{$pf-global--danger-color--100};
+  --pf-global--danger-color--200: #{$pf-global--danger-color--200};
+  --pf-global--danger-color--300: #{$pf-global--danger-color--300};
 
   // Shadows
-  --pf-global--BoxShadow--sm: $pf-global--BoxShadow--sm;
-  --pf-global--BoxShadow: $pf-global--BoxShadow;
-  --pf-global--BoxShadow--lg: $pf-global--BoxShadow--lg;
-  --pf-global--BoxShadow--sm-right: $pf-global--BoxShadow--sm-right;
-  --pf-global--BoxShadow--sm-left: $pf-global--BoxShadow--sm-left;
-  --pf-global--BoxShadow--sm-bottom: $pf-global--BoxShadow--sm-bottom;
-  --pf-global--BoxShadow--sm-top: $pf-global--BoxShadow--sm-top;
-  --pf-global--BoxShadow-right: $pf-global--BoxShadow-right;
-  --pf-global--BoxShadow-left: $pf-global--BoxShadow-left;
-  --pf-global--BoxShadow-bottom: $pf-global--BoxShadow-bottom;
-  --pf-global--BoxShadow-top: $pf-global--BoxShadow-top;
-  --pf-global--BoxShadow--lg-right: $pf-global--BoxShadow--lg-right;
-  --pf-global--BoxShadow--lg-left: $pf-global--BoxShadow--lg-left;
-  --pf-global--BoxShadow--lg-bottom: $pf-global--BoxShadow--lg-bottom;
-  --pf-global--BoxShadow--lg-top: $pf-global--BoxShadow--lg-top;
-  --pf-global--BoxShadow--inset: $pf-global--BoxShadow--inset;
+  --pf-global--BoxShadow--sm: #{$pf-global--BoxShadow--sm};
+  --pf-global--BoxShadow: #{$pf-global--BoxShadow};
+  --pf-global--BoxShadow--lg: #{$pf-global--BoxShadow--lg};
+  --pf-global--BoxShadow--sm-right: #{$pf-global--BoxShadow--sm-right};
+  --pf-global--BoxShadow--sm-left: #{$pf-global--BoxShadow--sm-left};
+  --pf-global--BoxShadow--sm-bottom: #{$pf-global--BoxShadow--sm-bottom};
+  --pf-global--BoxShadow--sm-top: #{$pf-global--BoxShadow--sm-top};
+  --pf-global--BoxShadow-right: #{$pf-global--BoxShadow-right};
+  --pf-global--BoxShadow-left: #{$pf-global--BoxShadow-left};
+  --pf-global--BoxShadow-bottom: #{$pf-global--BoxShadow-bottom};
+  --pf-global--BoxShadow-top: #{$pf-global--BoxShadow-top};
+  --pf-global--BoxShadow--lg-right: #{$pf-global--BoxShadow--lg-right};
+  --pf-global--BoxShadow--lg-left: #{$pf-global--BoxShadow--lg-left};
+  --pf-global--BoxShadow--lg-bottom: #{$pf-global--BoxShadow--lg-bottom};
+  --pf-global--BoxShadow--lg-top: #{$pf-global--BoxShadow--lg-top};
+  --pf-global--BoxShadow--inset: #{$pf-global--BoxShadow--inset};
 
   // Fontpath
-  --pf-global--font-path: $pf-global--font-path;
+  --pf-global--font-path: #{$pf-global--font-path};
 
   // Spacers
-  --pf-global--spacer--xs: $pf-global--spacer--xs;
-  --pf-global--spacer--sm: $pf-global--spacer--sm;
-  --pf-global--spacer--md: $pf-global--spacer--md;
-  --pf-global--spacer--lg: $pf-global--spacer--lg;
-  --pf-global--spacer--xl: $pf-global--spacer--xl;
-  --pf-global--spacer--2xl: $pf-global--spacer--2xl;
-  --pf-global--spacer--3xl: $pf-global--spacer--3xl;
+  --pf-global--spacer--xs: #{$pf-global--spacer--xs};
+  --pf-global--spacer--sm: #{$pf-global--spacer--sm};
+  --pf-global--spacer--md: #{$pf-global--spacer--md};
+  --pf-global--spacer--lg: #{$pf-global--spacer--lg};
+  --pf-global--spacer--xl: #{$pf-global--spacer--xl};
+  --pf-global--spacer--2xl: #{$pf-global--spacer--2xl};
+  --pf-global--spacer--3xl: #{$pf-global--spacer--3xl};
 
   // Gutter
-  --pf-global--gutter: $pf-global--gutter;
+  --pf-global--gutter: #{$pf-global--gutter};
 
   // Z-Index
-  --pf-global--ZIndex--xs: $pf-global--ZIndex--xs;
-  --pf-global--ZIndex--sm: $pf-global--ZIndex--sm;
-  --pf-global--ZIndex--md: $pf-global--ZIndex--md;
-  --pf-global--ZIndex--lg: $pf-global--ZIndex--lg;
-  --pf-global--ZIndex--xl: $pf-global--ZIndex--xl;
-  --pf-global--ZIndex--2xl: $pf-global--ZIndex--2xl;
+  --pf-global--ZIndex--xs: #{$pf-global--ZIndex--xs};
+  --pf-global--ZIndex--sm: #{$pf-global--ZIndex--sm};
+  --pf-global--ZIndex--md: #{$pf-global--ZIndex--md};
+  --pf-global--ZIndex--lg: #{$pf-global--ZIndex--lg};
+  --pf-global--ZIndex--xl: #{$pf-global--ZIndex--xl};
+  --pf-global--ZIndex--2xl: #{$pf-global--ZIndex--2xl};
 
   // Grid breakpoints
-  --pf-global--breakpoint--xs: $pf-global--breakpoint--xs;
-  --pf-global--breakpoint--sm: $pf-global--breakpoint--sm;
-  --pf-global--breakpoint--md: $pf-global--breakpoint--md;
-  --pf-global--breakpoint--lg: $pf-global--breakpoint--lg;
-  --pf-global--breakpoint--xl: $pf-global--breakpoint--xl;
+  --pf-global--breakpoint--xs: #{$pf-global--breakpoint--xs};
+  --pf-global--breakpoint--sm: #{$pf-global--breakpoint--sm};
+  --pf-global--breakpoint--md: #{$pf-global--breakpoint--md};
+  --pf-global--breakpoint--lg: #{$pf-global--breakpoint--lg};
+  --pf-global--breakpoint--xl: #{$pf-global--breakpoint--xl};
 
   // Links
-  --pf-global--link--FontWeight: $pf-global--link--FontWeight;
-  --pf-global--link--Color: $pf-global--link--Color;
-  --pf-global--link--TextDecoration: $pf-global--link--TextDecoration;
-  --pf-global--link--Color--hover: $pf-global--link--Color--hover;
-  --pf-global--link--Color--light-hover: $pf-global--link--Color--light-hover;
-  --pf-global--link--TextDecoration--hover: $pf-global--link--TextDecoration--hover;
+  --pf-global--link--FontWeight: #{$pf-global--link--FontWeight};
+  --pf-global--link--Color: #{$pf-global--link--Color};
+  --pf-global--link--TextDecoration: #{$pf-global--link--TextDecoration};
+  --pf-global--link--Color--hover: #{$pf-global--link--Color--hover};
+  --pf-global--link--Color--light-hover: #{$pf-global--link--Color--light-hover};
+  --pf-global--link--TextDecoration--hover: #{$pf-global--link--TextDecoration--hover};
 
   // Borders
-  --pf-global--BorderWidth--sm: $pf-global--BorderWidth--sm;
-  --pf-global--BorderWidth--md: $pf-global--BorderWidth--md;
-  --pf-global--BorderWidth--lg: $pf-global--BorderWidth--lg;
-  --pf-global--BorderColor: $pf-global--BorderColor;
-  --pf-global--BorderColor--dark: $pf-global--BorderColor--dark;
-  --pf-global--BorderColor--light: $pf-global--BorderColor--light;
-  --pf-global--BorderRadius--sm: $pf-global--BorderRadius--sm;
-  --pf-global--BorderRadius--lg: $pf-global--BorderRadius--lg;
+  --pf-global--BorderWidth--sm: #{$pf-global--BorderWidth--sm};
+  --pf-global--BorderWidth--md: #{$pf-global--BorderWidth--md};
+  --pf-global--BorderWidth--lg: #{$pf-global--BorderWidth--lg};
+  --pf-global--BorderColor: #{$pf-global--BorderColor};
+  --pf-global--BorderColor--dark: #{$pf-global--BorderColor--dark};
+  --pf-global--BorderColor--light: #{$pf-global--BorderColor--light};
+  --pf-global--BorderRadius--sm: #{$pf-global--BorderRadius--sm};
+  --pf-global--BorderRadius--lg: #{$pf-global--BorderRadius--lg};
 
 
   // Fonts
 
   // Font family
-  --pf-global--FontFamily--sans-serif: $pf-global--FontFamily--sans-serif;
-  --pf-global--FontFamily--monospace: $pf-global--FontFamily--monospace;
+  --pf-global--FontFamily--sans-serif: #{$pf-global--FontFamily--sans-serif};
+  --pf-global--FontFamily--monospace: #{$pf-global--FontFamily--monospace};
 
   // Font size
-  --pf-global--FontSize--4xl: $pf-global--FontSize--4xl;
-  --pf-global--FontSize--3xl: $pf-global--FontSize--3xl;
-  --pf-global--FontSize--2xl: $pf-global--FontSize--2xl;
-  --pf-global--FontSize--xl: $pf-global--FontSize--xl;
-  --pf-global--FontSize--lg: $pf-global--FontSize--lg;
-  --pf-global--FontSize--md: $pf-global--FontSize--md;
-  --pf-global--FontSize--sm: $pf-global--FontSize--sm;
-  --pf-global--FontSize--xs: $pf-global--FontSize--xs;
+  --pf-global--FontSize--4xl: #{$pf-global--FontSize--4xl};
+  --pf-global--FontSize--3xl: #{$pf-global--FontSize--3xl};
+  --pf-global--FontSize--2xl: #{$pf-global--FontSize--2xl};
+  --pf-global--FontSize--xl: #{$pf-global--FontSize--xl};
+  --pf-global--FontSize--lg: #{$pf-global--FontSize--lg};
+  --pf-global--FontSize--md: #{$pf-global--FontSize--md};
+  --pf-global--FontSize--sm: #{$pf-global--FontSize--sm};
+  --pf-global--FontSize--xs: #{$pf-global--FontSize--xs};
 
   // Font weight
-  --pf-global--FontWeight--light: $pf-global--FontWeight--light;
-  --pf-global--FontWeight--normal: $pf-global--FontWeight--normal;
-  --pf-global--FontWeight--semi-bold: $pf-global--FontWeight--semi-bold;
-  --pf-global--FontWeight--bold: $pf-global--FontWeight--bold;
+  --pf-global--FontWeight--light: #{$pf-global--FontWeight--light};
+  --pf-global--FontWeight--normal: #{$pf-global--FontWeight--normal};
+  --pf-global--FontWeight--semi-bold: #{$pf-global--FontWeight--semi-bold};
+  --pf-global--FontWeight--bold: #{$pf-global--FontWeight--bold};
 
   // Line height
-  --pf-global--LineHeight--sm: $pf-global--LineHeight--sm;
-  --pf-global--LineHeight--md: $pf-global--LineHeight--md;
+  --pf-global--LineHeight--sm: #{$pf-global--LineHeight--sm};
+  --pf-global--LineHeight--md: #{$pf-global--LineHeight--md};
 
   // List
-  --pf-global--ListStyle: $pf-global--ListStyle;
-  --pf-global--Transition: $pf-global--Transition;
-  --pf-global--TimingFunction: $pf-global--TimingFunction;
+  --pf-global-ListStyle: #{$pf-global--ListStyle};
+  --pf-global--Transition: #{$pf-global--Transition};
+  --pf-global--TimingFunction: #{$pf-global--TimingFunction};
 
   // Arrow Size
-  --pf-global--arrow--width: $pf-global--arrow--width;
-  --pf-global--arrow--width-lg: $pf-global--arrow--width-lg;
+  --pf-global--arrow--width: #{$pf-global--arrow--width};
+  --pf-global--arrow--width-lg: #{$pf-global--arrow--width-lg};
 
   // A11y
-  --pf-global--target-size--MinWidth: $pf-global--target-size--MinWidth;
-  --pf-global--target-size--MinHeight: $pf-global--target-size--MinHeight;
+  --pf-global--target-size--MinWidth: #{$pf-global--target-size--MinWidth};
+  --pf-global--target-size--MinHeight: #{$pf-global--target-size--MinHeight};
 }

--- a/src/patternfly/components/AboutModalBox/styles.scss
+++ b/src/patternfly/components/AboutModalBox/styles.scss
@@ -3,17 +3,17 @@
 .pf-c-about-modal-box {
   // Component variables
   // Modal uses a non-standard background color
-  --pf-c-about-modal-box--BackgroundColor: $pf-color-black-1000;
+  --pf-c-about-modal-box--BackgroundColor: #{$pf-color-black-1000};
 
   // This is a special one-off glow for the about modal
   --pf-c-about-modal-box--BoxShadow: 0 0 100px 0 rgba(256, 256, 256, .4);
   --pf-c-about-modal-box--ZIndex: var(--pf-global--ZIndex--2xl);
 
   // Width and height values are determined by design
-  --pf-c-about-modal-box--MaxWidth: pf-size-prem(1232px);
+  --pf-c-about-modal-box--MaxWidth: #{pf-size-prem(1232px)};
 
   // Height is optimized for the exact height desired
-  --pf-c-about-modal-box--Height: pf-size-prem(762px);
+  --pf-c-about-modal-box--Height: #{pf-size-prem(762px)};
 
   // MinHeight is based on all the spacers we know we have, plus some LineHeight to make some space for at least one line of content in each section
   --pf-c-about-modal-box--MinHeight: calc(var(--pf-c-about-modal-box__brand--PaddingTop) + var(--pf-c-about-modal-box__brand--PaddingBottom) + var(--pf-c-about-modal-box__header--PaddingTop) + var(--pf-c-about-modal-box__header--PaddingBottom) + var(--pf-c-about-modal-box__content--PaddingTop) + var(--pf-c-about-modal-box__content--PaddingBottom) + var(--pf-c-about-modal-box__brand-image--Height) + (1rem * 6 * var(--pf-global--LineHeight--md)));
@@ -91,8 +91,8 @@
   --pf-c-about-modal-box__logo-image--PaddingLeft: var(--pf-global--spacer--md);
 
   // height and width determined manually by visual design
-  --pf-c-about-modal-box__logo-image--Width: pf-size-prem(236px);
-  --pf-c-about-modal-box__logo-image--Height: pf-size-prem(110px);
+  --pf-c-about-modal-box__logo-image--Width: #{pf-size-prem(236px)};
+  --pf-c-about-modal-box__logo-image--Height: #{pf-size-prem(110px)};
   --pf-c-about-modal-box__logo-image--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
 
   // Button close
@@ -106,7 +106,7 @@
   --pf-c-about-modal-box__button-close--Height: calc(var(--pf-c-about-modal-box__button-close--FontSize) * 2);
 
   // Close button uses a non-standard background color
-  --pf-c-about-modal-box__button-close--BackgroundColor: $pf-color-black-1000;
+  --pf-c-about-modal-box__button-close--BackgroundColor: #{$pf-color-black-1000};
   --pf-c-about-modal-box__button-close--hover--BackgroundColor: rgba($pf-color-black-1000, .4);
 
   // This component always needs to be dark

--- a/src/patternfly/components/Dropdown/styles.scss
+++ b/src/patternfly/components/Dropdown/styles.scss
@@ -2,9 +2,9 @@
 
 .pf-c-dropdown {
   // Toggle
-  --pf-c-dropdown__toggle--PaddingTop: pf-size-prem(6px); // The top and bottom padding for the dropdown is a one-off
+  --pf-c-dropdown__toggle--PaddingTop: #{pf-size-prem(6px)}; // The top and bottom padding for the dropdown is a one-off
   --pf-c-dropdown__toggle--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-dropdown__toggle--PaddingBottom: pf-size-prem(6px);
+  --pf-c-dropdown__toggle--PaddingBottom: #{pf-size-prem(6px)};
   --pf-c-dropdown__toggle--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-dropdown__toggle--MinWidth: var(--pf-global--target-size--MinWidth);
   --pf-c-dropdown__toggle--MinHeight: var(--pf-global--target-size--MinHeight);

--- a/src/patternfly/components/NavSystem/styles.scss
+++ b/src/patternfly/components/NavSystem/styles.scss
@@ -1,7 +1,7 @@
 @import "../../patternfly-utilities";
 
 .pf-c-nav {
-  --pf-c-nav--Width: pf-size-prem(290px);
+  --pf-c-nav--Width: #{pf-size-prem(290px)};
   --pf-c-nav--Transition: var(--pf-global--Transition);
 
   // List link
@@ -60,9 +60,9 @@
 
   // background
   --pf-c-nav__simple-list-link--BackgroundColor: transparent;
-  --pf-c-nav__simple-list-link--hover--BackgroundColor: $pf-color-black-150;
-  --pf-c-nav__simple-list-link--active--BackgroundColor: $pf-color-black-150;
-  --pf-c-nav__simple-list-link--focus--BackgroundColor: $pf-color-black-150;
+  --pf-c-nav__simple-list-link--hover--BackgroundColor: #{$pf-color-black-150};
+  --pf-c-nav__simple-list-link--active--BackgroundColor: #{$pf-color-black-150};
+  --pf-c-nav__simple-list-link--focus--BackgroundColor: #{$pf-color-black-150};
 
   // List horizontal link
   --pf-c-nav__horizontal-list-item--MarginRight: var(--pf-global--spacer--xl);
@@ -75,7 +75,7 @@
   --pf-c-nav__horizontal-list-link--focus--FontWeight: var(--pf-global--FontWeight--bold);
 
   // color
-  --pf-c-nav__horizontal-list-link--Color: $pf-color-black-300;
+  --pf-c-nav__horizontal-list-link--Color: #{$pf-color-black-300};
   --pf-c-nav__horizontal-list-link--hover--Color: var(--pf-global--active-color--300);
   --pf-c-nav__horizontal-list-link--active--Color: var(--pf-global--active-color--300);
   --pf-c-nav__horizontal-list-link--focus--Color: var(--pf-global--active-color--300);
@@ -129,13 +129,13 @@
 
   // Subnav links
   --pf-c-nav__subnav--MarginTop: var(--pf-global--spacer--md);
-  --pf-c-nav__subnav--MaxHeight: pf-size-prem(600px);
+  --pf-c-nav__subnav--MaxHeight: #{pf-size-prem(600px)};
   --pf-c-nav__subnav-item--PaddingLeft: calc(var(--pf-global--spacer--xl) + var(--pf-global--spacer--md)); // automate this value based on previously set values
 
   // List toggle
   --pf-c-nav__list-toggle--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-nav__list-toggle--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-nav__list-toggle--FontSize: pf-font-prem(20px); // set unique font size for dropdown caret based on design spec
+  --pf-c-nav__list-toggle--FontSize: #{pf-font-prem(20px)}; // set unique font size for dropdown caret based on design spec
   --pf-c-nav__list-toggle--Transition: .1s ease-in-out;
 
   // Nav section
@@ -165,7 +165,7 @@
   // Modifier - simple list current
   --pf-c-nav__simple-list-link--m-current--Color: var(--pf-global--link--Color);
   --pf-c-nav__simple-list-link--m-current--FontWeight: var(--pf-global--FontWeight--semi-bold);
-  --pf-c-nav__simple-list-link--m-current--BackgroundColor: $pf-color-black-150;
+  --pf-c-nav__simple-list-link--m-current--BackgroundColor: #{$pf-color-black-150};
 
   // Modifier - current item
   --pf-c-nav__list-horizontal-link--m-current--Color: var(--pf-global--active-color--300);

--- a/src/patternfly/components/Popover/styles.scss
+++ b/src/patternfly/components/Popover/styles.scss
@@ -2,8 +2,8 @@
 
 .pf-c-popover {
   // Component variables
-  --pf-c-popover--MinWidth: pf-size-prem(100px);
-  --pf-c-popover--MaxWidth: pf-size-prem(300px);
+  --pf-c-popover--MinWidth: #{pf-size-prem(100px)};
+  --pf-c-popover--MaxWidth: #{pf-size-prem(300px)};
   --pf-c-popover--BoxShadow: var(--pf-global--BoxShadow);
 
   // Set margin to arrow width for placement

--- a/src/patternfly/components/Tooltip/styles.scss
+++ b/src/patternfly/components/Tooltip/styles.scss
@@ -2,7 +2,7 @@
 
 .pf-c-tooltip {
   // Component variables
-  --pf-c-tooltip--MaxWidth: pf-size-prem(200px);
+  --pf-c-tooltip--MaxWidth: #{pf-size-prem(200px)};
   --pf-c-tooltip--BoxShadow: var(--pf-global--BoxShadow);
   --pf-c-tooltip--MarginBottom: var(--pf-global--arrow--width); // Set margins to arrow width for placement
   --pf-c-tooltip--MarginTop: var(--pf-global--arrow--width);


### PR DESCRIPTION
### Follows https://github.com/patternfly/patternfly-next/issues/493
This PR is fixing problems with wrong assignment of sass variables to css variables. All of var reassign is fixed and uses `--var: #{$sass-var}` and custom functions as well, however build in functions should be either covered in seperate PR or differently so this PR is not that big.