### PR TITLE
feat(dark cards): make cards change colors when they are in a dark area

### DIFF
--- a/src/patternfly/components/Card/styles.scss
+++ b/src/patternfly/components/Card/styles.scss
@@ -2,7 +2,7 @@
 
 .pf-c-card {
   // Component variables
-  --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  // --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor-100);
   --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--sm);
 
   // Card Header variables
@@ -22,9 +22,6 @@
   --pf-c-card__footer--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-card__footer--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-card__footer--PaddingLeft: var(--pf-global--spacer--lg);
-
-  // This component always needs to be light
-  @extend %pf-t-light;
 
   display: flex;
   flex-direction: column;

--- a/src/patternfly/sass-utilities/placeholders.scss
+++ b/src/patternfly/sass-utilities/placeholders.scss
@@ -48,4 +48,8 @@
     --pf-c-button--m-tertiary--active--BoxShadowColor: var(--pf-global--Color--light-100);
     --pf-c-button--m-tertiary--active--Color: var(--pf-global--Color--light-100);
   }
+
+  .pf-c-card {
+    --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
+  }
 }


### PR DESCRIPTION
This PR closes #684 and makes a card be black whenever they are in a dark environment.

@mceledonia please take a look at this one.

@kybaker 8 Are cards always dark when they are in dark areas, or should we have a modifier class to make them white again in case someone wants a white card in a dark background?