### PR TITLE
feat(list): add list component

### DIFF
--- a/src/patternfly/components/List/docs/code.md
+++ b/src/patternfly/components/List/docs/code.md
@@ -6,6 +6,6 @@ Typically used with a modifier class.
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-c-list` | `<ul>` |  Initiates a list. **Required** |
+| `.pf-c-list` | `<ul>` |  Initiates a list with the same styling as lists in the content component. **Required** |
 | `.pf-m-inline` | `.pf-c-list` |  Modifies for inline list style. |
 | `.pf-m-grid` | `.pf-c-list` |  Modifies for grid list style. |

--- a/src/patternfly/components/List/docs/code.md
+++ b/src/patternfly/components/List/docs/code.md
@@ -1,0 +1,11 @@
+## Overview
+
+Typically used with a modifier class.
+
+## Usage
+
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-c-list` | `<ul>` |  Initiates a list. **Required** |
+| `.pf-m-inline` | `.pf-c-list` |  Modifies for inline list style. |
+| `.pf-m-grid` | `.pf-c-list` |  Modifies for grid list style. |

--- a/src/patternfly/components/List/examples/index.js
+++ b/src/patternfly/components/List/examples/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import Documentation from '@siteComponents/Documentation';
+import Example from '@siteComponents/Example';
+import listSimpleExampleRaw from '!raw!./list-simple-example.hbs';
+import listInlineExampleRaw from '!raw!./list-inline-example.hbs';
+import listGridExampleRaw from '!raw!./list-grid-example.hbs';
+import ListSimpleExample from './list-simple-example.hbs';
+import ListInlineExample from './list-inline-example.hbs';
+import ListGridExample from './list-grid-example.hbs';
+import docs from '../docs/code.md';
+import '../styles.scss';
+
+export const Docs = docs;
+
+export default () => {
+  const listSimpleExample = ListSimpleExample();
+  const listInlineExample = ListInlineExample();
+  const listGridExample = ListGridExample();
+
+  return (
+    <Documentation docs={Docs}>
+      <Example heading="List" handlebars={listSimpleExampleRaw}>
+        {listSimpleExample}
+      </Example>
+      <Example heading="List Inline" handlebars={listInlineExampleRaw}>
+        {listInlineExample}
+      </Example>
+      <Example heading="List Grid" handlebars={listGridExampleRaw}>
+        {listGridExample}
+      </Example>
+    </Documentation>
+  );
+};

--- a/src/patternfly/components/List/examples/list-grid-example.hbs
+++ b/src/patternfly/components/List/examples/list-grid-example.hbs
@@ -1,0 +1,8 @@
+{{#> list pf-c-list--modifier="pf-m-grid"}}
+<li>First</li>
+<li>Second</li>
+<li>Third</li>
+<li>Fourth</li>
+<li>Fifth</li>
+<li>Sixth</li>
+{{/list}}

--- a/src/patternfly/components/List/examples/list-grid-example.hbs
+++ b/src/patternfly/components/List/examples/list-grid-example.hbs
@@ -1,4 +1,4 @@
-{{#> list pf-c-list--modifier="pf-m-grid"}}
+{{#> list list--modifier="pf-m-grid"}}
 <li>First</li>
 <li>Second</li>
 <li>Third</li>

--- a/src/patternfly/components/List/examples/list-inline-example.hbs
+++ b/src/patternfly/components/List/examples/list-inline-example.hbs
@@ -1,4 +1,4 @@
-{{#> list pf-c-list--modifier="pf-m-inline"}}
+{{#> list list--modifier="pf-m-inline"}}
 <li>First</li>
 <li>Second</li>
 <li>Third</li>

--- a/src/patternfly/components/List/examples/list-inline-example.hbs
+++ b/src/patternfly/components/List/examples/list-inline-example.hbs
@@ -1,0 +1,5 @@
+{{#> list pf-c-list--modifier="pf-m-inline"}}
+<li>First</li>
+<li>Second</li>
+<li>Third</li>
+{{/list}}

--- a/src/patternfly/components/List/examples/list-simple-example.hbs
+++ b/src/patternfly/components/List/examples/list-simple-example.hbs
@@ -1,0 +1,5 @@
+{{#> list}}
+<li>First</li>
+<li>Second</li>
+<li>Third</li>
+{{/list}}

--- a/src/patternfly/components/List/list.hbs
+++ b/src/patternfly/components/List/list.hbs
@@ -1,0 +1,6 @@
+<ul class="pf-c-list{{#if pf-c-list--modifier}} {{ pf-c-list--modifier }}{{/if}}"
+  {{#if pf-c-list__id}}
+    id="{{pf-c-list__id}}"
+  {{/if}}>
+  {{> @partial-block}}
+</ul>

--- a/src/patternfly/components/List/list.hbs
+++ b/src/patternfly/components/List/list.hbs
@@ -1,6 +1,6 @@
-<ul class="pf-c-list{{#if pf-c-list--modifier}} {{ pf-c-list--modifier }}{{/if}}"
-  {{#if pf-c-list__id}}
-    id="{{pf-c-list__id}}"
+<ul class="pf-c-list{{#if list--modifier}} {{list--modifier}}{{/if}}"
+  {{#if list--attribute}}
+    {{{list--attribute}}}
   {{/if}}>
   {{> @partial-block}}
 </ul>

--- a/src/patternfly/components/List/styles.scss
+++ b/src/patternfly/components/List/styles.scss
@@ -39,11 +39,13 @@
     margin-left: var(--pf-c-content--ul--MarginLeft);
     list-style: var(--pf-c-content--ul--ListStyle);
 
+    // Sub-element type selector used to maintain consistency with the content component's list styling
     ul {
       margin-top: var(--pf-c-content--ul--nested--MarginTop);
       margin-left: var(--pf-c-content--ul--nested--MarginLeft);
     }
 
+    // Sub-element type selector used to maintain consistency with the content component's list styling
     li + li {
       margin-top: var(--pf-c-content--li--MarginTop);
     }

--- a/src/patternfly/components/List/styles.scss
+++ b/src/patternfly/components/List/styles.scss
@@ -1,0 +1,51 @@
+@import "../../patternfly-utilities";
+
+.pf-c-list {
+  // Inline modifier variables
+  --pf-c-list--m-inline--MarginRight: var(--pf-global--spacer--md);
+
+  // Grid modifier variables
+  --pf-c-list--m-grid--GridGap: var(--pf-global--spacer--md);
+
+  // Content variables (no modifier)
+  --pf-c-content--li--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-content--ul--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-content--ul--MarginTop: var(--pf-global--spacer--md);
+  --pf-c-content--MarginBottom: var(--pf-global--spacer--md);
+  --pf-c-content--ul--MarginLeft: var(--pf-global--spacer--lg);
+  --pf-c-content--ul--ListStyle: var(--pf-global--ListStyle);
+  --pf-c-content--ul--nested--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-content--ul--nested--MarginLeft: var(--pf-global--spacer--sm);
+
+  &.pf-m-inline {
+    display: flex;
+
+    & li:not(:last-child) {
+      margin-right: var(--pf-c-list--m-inline--MarginRight);
+    }
+  }
+
+  &.pf-m-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    grid-gap: var(--pf-c-list--m-grid--GridGap);
+  }
+
+  &:not(.pf-m-grid):not(.pf-m-inline) {
+    padding-left: var(--pf-c-content--ul--PaddingLeft);
+    margin: 0;
+    margin-top: var(--pf-c-content--ul--MarginTop);
+    margin-bottom: var(--pf-c-content--MarginBottom);
+    margin-left: var(--pf-c-content--ul--MarginLeft);
+    list-style: var(--pf-c-content--ul--ListStyle);
+
+    ul {
+      margin-top: var(--pf-c-content--ul--nested--MarginTop);
+      margin-left: var(--pf-c-content--ul--nested--MarginLeft);
+    }
+
+    li + li {
+      margin-top: var(--pf-c-content--li--MarginTop);
+    }
+  }
+}

--- a/src/patternfly/components/List/styles.scss
+++ b/src/patternfly/components/List/styles.scss
@@ -19,6 +19,7 @@
 
   &.pf-m-inline {
     display: flex;
+    flex-wrap: wrap;
 
     & li:not(:last-child) {
       margin-right: var(--pf-c-list--m-inline--MarginRight);


### PR DESCRIPTION
Introduces the list component with two modifiers (inline and grid) that change the presentation of list items. If the list component is used without modifiers, it gets the same styling as lists within the content component.

The inline modifier displays the list items in a horizontal line using flexbox. The grid modifier positions list items within a flexible grid with a minimum column width of 100px.

This closes #675.