### PR TITLE
Updated Top Level Headings and Navigation Styles in Workspace

### DIFF
--- a/src/patternfly/components/AboutModalBox/examples/index.js
+++ b/src/patternfly/components/AboutModalBox/examples/index.js
@@ -9,7 +9,7 @@ export const Docs = docs;
 
 export default () => {
   const aboutModalBoxExample = AboutModalBoxExample();
-  const headingText = 'About modal box';
+  const headingText = 'About Modal Box';
 
   return (
     <Documentation docs={Docs} heading={headingText}>

--- a/src/patternfly/components/Avatar/examples/index.js
+++ b/src/patternfly/components/Avatar/examples/index.js
@@ -10,9 +10,10 @@ export const Docs = docs;
 
 export default () => {
   const avatarSimpleExample = AvatarSimpleExample();
+  const headingText = 'Avatar';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="Avatar Simple" handlebars={avatarSimpleExampleRaw}>
         {avatarSimpleExample}
       </Example>

--- a/src/patternfly/components/Brand/examples/index.js
+++ b/src/patternfly/components/Brand/examples/index.js
@@ -10,9 +10,10 @@ export const Docs = docs;
 
 export default () => {
   const brandSimpleExample = BrandSimpleExample();
+  const headingText = 'Brand';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="Brand Simple" handlebars={brandSimpleExampleRaw} minHeight="20em">
         {brandSimpleExample}
       </Example>

--- a/src/patternfly/components/LoginBox/examples/index.js
+++ b/src/patternfly/components/LoginBox/examples/index.js
@@ -10,10 +10,11 @@ export const Docs = docs;
 
 export default () => {
   const loginBoxExample = LoginboxExample();
+  const headingText = 'Login Box';
 
   return (
-    <Documentation docs={Docs}>
-      <Example heading="Loginbox" handlebars={loginBoxExampleRaw}>
+    <Documentation docs={Docs} heading={headingText}>
+      <Example heading="Login box" handlebars={loginBoxExampleRaw}>
         {loginBoxExample}
       </Example>
     </Documentation>

--- a/src/patternfly/components/Nav/examples/index.js
+++ b/src/patternfly/components/Nav/examples/index.js
@@ -36,9 +36,10 @@ export default () => {
   const navHorizontalListExample = NavHorizontalListExample();
   const navListTertiaryExample = NavListTertiaryExample();
   const navMixedExample = NavMixedExample();
+  const headingText = 'Navigation';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="Simple Nav" handlebars={navSimpleListExampleRaw}>
         {navSimpleListExample}
       </Example>

--- a/src/patternfly/components/Progress/examples/index.js
+++ b/src/patternfly/components/Progress/examples/index.js
@@ -44,9 +44,10 @@ export default () => {
   const progressNoMeasureExample = ProgressNoMeasureExample();
   const progressNoMeasureFailureExample = ProgressNoMeasureFailureExample();
   const progressDynamicExample = ProgressDynamicExample();
+  const headingText = 'Progress';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="Progress Simple" handlebars={progressSimpleExampleRaw}>
         {progressSimpleExample}
       </Example>

--- a/src/patternfly/demos/AboutModal/examples/index.js
+++ b/src/patternfly/demos/AboutModal/examples/index.js
@@ -8,9 +8,10 @@ export const Docs = docs;
 
 export default () => {
   const aboutModalExample = AboutModalExample();
+  const headingText = 'About Modal Demo';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="About Modal Example" fullPageOnly="true">
         {aboutModalExample}
       </Example>

--- a/src/patternfly/demos/CardUpgradeExamples/examples/index.js
+++ b/src/patternfly/demos/CardUpgradeExamples/examples/index.js
@@ -11,15 +11,12 @@ export const Docs = docs;
 export default () => {
   const cardUpgradeExamplesExample1 = CardupgradeexamplesExample1();
   const cardUpgradeExamplesExample2 = CardupgradeexamplesExample2();
+  const headingText = 'Card Migration';
 
   return (
-    <Documentation docs={Docs}>
-      <Example heading="PatternFly 3 Cards">
-        {cardUpgradeExamplesExample1}
-      </Example>
-      <Example heading="PatternFly 4 Cards">
-        {cardUpgradeExamplesExample2}
-      </Example>
+    <Documentation docs={Docs} heading={headingText}>
+      <Example heading="PatternFly 3 Cards">{cardUpgradeExamplesExample1}</Example>
+      <Example heading="PatternFly 4 Cards">{cardUpgradeExamplesExample2}</Example>
     </Documentation>
   );
 };

--- a/src/patternfly/demos/LoginPage/examples/index.js
+++ b/src/patternfly/demos/LoginPage/examples/index.js
@@ -9,9 +9,10 @@ export const Docs = docs;
 
 export default () => {
   const loginPageSimpleExample = LoginpageSimpleExample();
+  const headingText = 'Login Page Demo';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="Loginpage Simple" fullPageOnly="true" handlebars={loginPageSimpleExampleRaw} minHeight="20em">
         {loginPageSimpleExample}
       </Example>

--- a/src/patternfly/demos/Modal/examples/index.js
+++ b/src/patternfly/demos/Modal/examples/index.js
@@ -15,14 +15,11 @@ export default () => {
   const modalExample = ModalExample();
   const modalScrollExample = ModalScrollExample();
   const modalLgExample = ModalLgExample();
+  const headingText = 'Modal Demo';
 
   return (
-    <Documentation docs={Docs}>
-      <Example
-        heading="Modal Demo"
-        fullPageOnly="true"
-        handlebars={ModalExampleRaw}
-      >
+    <Documentation docs={Docs} heading={headingText}>
+      <Example heading="Modal Demo" fullPageOnly="true" handlebars={ModalExampleRaw}>
         {modalExample}
       </Example>
       <Example
@@ -32,11 +29,7 @@ export default () => {
       >
         {modalScrollExample}
       </Example>
-      <Example
-        heading="Modal Demo - Large"
-        fullPageOnly="true"
-        handlebars={ModalLgExampleRaw}
-      >
+      <Example heading="Modal Demo - Large" fullPageOnly="true" handlebars={ModalLgExampleRaw}>
         {modalLgExample}
       </Example>
     </Documentation>

--- a/src/patternfly/demos/PageLayout/examples/index.js
+++ b/src/patternfly/demos/PageLayout/examples/index.js
@@ -25,9 +25,10 @@ export default () => {
   const pageLayoutHorizontalNavExample = PageLayoutHorizontalNavExample();
   const pageLayoutSimpleNavExample = PageLayoutSimpleNavExample();
   const pageLayoutGroupedNavExample = PageLayoutGroupedNavExample();
+  const headingText = 'Page Layout Demo';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example
         heading="Page Layout Default Nav Example"
         fullPageOnly="true"

--- a/src/patternfly/demos/SimpleFormDemo/examples/index.js
+++ b/src/patternfly/demos/SimpleFormDemo/examples/index.js
@@ -8,9 +8,10 @@ export const Docs = docs;
 
 export default () => {
   const simpleFormDemoExample = SimpleFormDemoExample();
+  const headingText = 'Simple Form Demo';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example heading="Simple Form Demo - check back when all form elements are complete">
         {simpleFormDemoExample}
       </Example>

--- a/src/patternfly/demos/Toolbar/docs/design.md
+++ b/src/patternfly/demos/Toolbar/docs/design.md
@@ -1,0 +1,1 @@
+## design md file

--- a/src/patternfly/layouts/Bullseye/examples/index.js
+++ b/src/patternfly/layouts/Bullseye/examples/index.js
@@ -10,9 +10,10 @@ export const Docs = docs;
 
 export default () => {
   const bullseye = Bullseye();
+  const headingText = 'Bullseye';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Bullseye Example" handlebars={BullseyeRaw}>
         {bullseye}
       </Example>

--- a/src/patternfly/layouts/Gallery/examples/index.js
+++ b/src/patternfly/layouts/Gallery/examples/index.js
@@ -13,9 +13,10 @@ export const Docs = docs;
 export default () => {
   const gallery = Gallery();
   const galleryHasGutter = GalleryHasGutter();
+  const headingText = 'Gallery';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Gallery Example" handlebars={GalleryRaw}>
         {gallery}
       </Example>

--- a/src/patternfly/layouts/Grid/examples/index.js
+++ b/src/patternfly/layouts/Grid/examples/index.js
@@ -31,9 +31,10 @@ export default () => {
   const gridOffsets = GridOffsets();
   const gridResponsive = GridResponsive();
   const gridRowspan = GridRowspan();
+  const headingText = 'Grid';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Smart grid (responsive)" handlebars={GridSmartRaw}>
         {gridSmart}
       </Example>

--- a/src/patternfly/layouts/Level/examples/index.js
+++ b/src/patternfly/layouts/Level/examples/index.js
@@ -16,9 +16,10 @@ export default () => {
   const levelTwo = LevelTwo();
   const levelThree = LevelThree();
   const levelGutters = LevelGutters();
+  const headingText = 'Level';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Level Example" description="(with 2 children)" handlebars={LevelTwoRaw}>
         {levelTwo}
       </Example>

--- a/src/patternfly/layouts/Login/examples/index.js
+++ b/src/patternfly/layouts/Login/examples/index.js
@@ -10,9 +10,10 @@ export const Docs = docs;
 
 export default () => {
   const loginSimpleExample = LoginSimpleExample();
+  const headingText = 'Login';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Login Simple" fullPageOnly="true" handlebars={loginSimpleExampleRaw} minHeight="20em">
         {loginSimpleExample}
       </Example>

--- a/src/patternfly/layouts/Page/examples/index.js
+++ b/src/patternfly/layouts/Page/examples/index.js
@@ -13,9 +13,10 @@ export const Docs = docs;
 export default () => {
   const pageLayoutNavVerticalExample = PageLayoutNavVerticalExample();
   const pageLayoutNavHorizontalExample = PageLayoutNavHorizontalExample();
+  const headingText = 'Page';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Page Layout, Nav Vertical Example" handlebars={PageLayoutNavVerticalExampleRaw}>
         {pageLayoutNavVerticalExample}
       </Example>

--- a/src/patternfly/layouts/Split/examples/index.js
+++ b/src/patternfly/layouts/Split/examples/index.js
@@ -13,8 +13,10 @@ export const Docs = docs;
 export default () => {
   const split = Split();
   const splitGutters = SplitGutters();
+  const headingText = 'Split';
+
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Split Example" handlebars={SplitRaw}>
         {split}
       </Example>

--- a/src/patternfly/layouts/Stack/examples/index.js
+++ b/src/patternfly/layouts/Stack/examples/index.js
@@ -13,9 +13,10 @@ export const Docs = docs;
 export default () => {
   const stack = Stack();
   const stackHasGutter = StackHasGutter();
+  const headingText = 'Stack';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example heading="Stack Example" handlebars={StackRaw}>
         {stack}
       </Example>

--- a/src/patternfly/layouts/Toolbar/examples/index.js
+++ b/src/patternfly/layouts/Toolbar/examples/index.js
@@ -13,9 +13,10 @@ export const Docs = docs;
 export default () => {
   const toolbarBasicExample = ToolbarBasicExample();
   const toolbarSectionExample = ToolbarSectionExample();
+  const headingText = 'Toolbar';
 
   return (
-    <Documentation docs={Docs} className="is-layout-page">
+    <Documentation docs={Docs} heading={headingText} className="is-layout-page">
       <Example
         heading="Toolbar Basic Example - layout will respond naturally, no additional fitting is applied"
         handlebars={ToolbarBasicExampleRaw}

--- a/src/patternfly/utilities/Accessibility/examples/index.js
+++ b/src/patternfly/utilities/Accessibility/examples/index.js
@@ -10,9 +10,10 @@ export const Docs = docs;
 
 export default () => {
   const srOnlyExample = SrOnlyExample();
+  const headingText = 'Accessibility';
 
   return (
-    <Documentation docs={Docs} className="is-utility-page">
+    <Documentation docs={Docs} heading={headingText} className="is-utility-page">
       <Example heading="Screen reader only" handlebars={srOnlyExampleRaw}>
         {srOnlyExample}
       </Example>

--- a/src/patternfly/utilities/BoxShadow/examples/index.js
+++ b/src/patternfly/utilities/BoxShadow/examples/index.js
@@ -10,9 +10,10 @@ export const Docs = docs;
 
 export default () => {
   const boxShadowSimpleExample = BoxshadowSimpleExample();
+  const headingText = 'Box Shadow';
 
   return (
-    <Documentation docs={Docs}>
+    <Documentation docs={Docs} heading={headingText}>
       <Example
         className="box-shadow"
         heading="Boxshadow Utility"

--- a/src/patternfly/utilities/Display/examples/index.js
+++ b/src/patternfly/utilities/Display/examples/index.js
@@ -37,9 +37,10 @@ export default () => {
   const displayInlineExample = DisplayInlineExample();
   const displayTableExample = DisplayTableExample();
   const displayNoneExample = DisplayNoneExample();
+  const headingText = 'Display';
 
   return (
-    <Documentation docs={Docs} className="is-utility-page">
+    <Documentation docs={Docs} heading={headingText} className="is-utility-page">
       <Example heading="Display inline-block" handlebars={displayInlineBlockExampleRaw}>
         {displayInlineBlockExample}
       </Example>

--- a/src/patternfly/utilities/Flex/examples/index.js
+++ b/src/patternfly/utilities/Flex/examples/index.js
@@ -39,9 +39,10 @@ export default () => {
   const flexGrowExample = FlexGrowExample();
   const flexBasisNoneExample = FlexBasisNoneExample();
   const flexFillExample = FlexFillExample();
+  const headingText = 'Flex';
 
   return (
-    <Documentation docs={Docs} className="flex-examples is-utility-page">
+    <Documentation docs={Docs} heading={headingText} className="flex-examples is-utility-page">
       <Example heading="Enable flex" handlebars={flexEnableExampleRaw}>
         {flexEnableExample}
       </Example>

--- a/src/patternfly/utilities/Spacing/examples/index.js
+++ b/src/patternfly/utilities/Spacing/examples/index.js
@@ -17,9 +17,10 @@ export default () => {
   const spacingMarginExample = SpacingMarginExample();
   const spacingPaddingExample = SpacingPaddingExample();
   const spacingCombinedExample = SpacingCombinedExample();
+  const headingText = 'Spacing';
 
   return (
-    <Documentation docs={Docs} className="is-utility-page">
+    <Documentation docs={Docs} heading={headingText} className="is-utility-page">
       <Example heading="Spacer margin" handlebars={spacingMarginExampleRaw}>
         {spacingMarginExample}
       </Example>

--- a/src/site/_site/Documentation/index.js
+++ b/src/site/_site/Documentation/index.js
@@ -15,11 +15,11 @@ export default class Documentation extends React.Component {
   }
 
   render() {
-    const { children, className = '', docs = '' } = this.props;
+    const { children, className = '', docs = '', heading = '' } = this.props;
     const HTML_DOCS = { __html: docs };
     return !this.state.isFull ? (
       <div className={`Documentation ${className}`}>
-        <h3 className="Documentation_heading">Examples</h3>
+        <h3 className="Component_heading">{heading}</h3>
         <div className="Documentation__section">{children}</div>
         <h3 className="Documentation_heading">Documentation</h3>
         <div className="Documentation__section" dangerouslySetInnerHTML={HTML_DOCS} />

--- a/src/site/_site/Documentation/styles.scss
+++ b/src/site/_site/Documentation/styles.scss
@@ -1,8 +1,15 @@
 /* stylelint-disable */
 .Documentation_heading {
   margin-bottom: .5rem;
-  font-size: 2rem;
-  font-weight: 700;
+  font-size: 24px;
+  font-weight: 500;
+  color: #393f44;
+}
+
+.Component_heading {
+  font-size: 28px;
+  font-weight: 500px;
+  color: #292e34;
 }
 
 .Documentation__section + .Documentation__section {

--- a/src/site/_site/Example/styles.scss
+++ b/src/site/_site/Example/styles.scss
@@ -42,9 +42,3 @@
     padding-right: .25em;
   }
 }
-
-.pf-p-secondary-nav {
-  li {
-    display: inline;
-  }
-}

--- a/src/site/_site/Example/styles.scss
+++ b/src/site/_site/Example/styles.scss
@@ -8,10 +8,11 @@
   }
 }
 
-.Example_title {
+.Example_heading {
   margin-bottom: .5rem;
-  font-size: 1.6rem;
-  font-weight: 600;
+  font-size: 21px;
+  font-weight: 500;
+  color: #393f44;
 }
 
 .Example__toolbar {
@@ -39,5 +40,11 @@
   li {
     display: inline-block;
     padding-right: .25em;
+  }
+}
+
+.pf-p-secondary-nav {
+  li {
+    display: inline;
   }
 }

--- a/src/site/_site/Navigation/styles.scss
+++ b/src/site/_site/Navigation/styles.scss
@@ -3,14 +3,26 @@
   display: flex;
 }
 
-.Navigation.is-horizontal .Navigation_link {
-  padding: .5rem;
+.Navigation {
+  &.is-horizontal {
+    .Navigation_link {
+      padding: .5rem;
 
-  &:hover {
-    font-weight: 500;
-    color: #007bba;
-    text-decoration: none;
-    background-color: transparent;
+      &:hover {
+        background-color: transparent;
+      }
+    }
+  }
+
+  &:not(.is-horizontal) {
+    .Navigation_link {
+      padding: .5rem 0 .5rem 2rem;
+
+      &:focus,
+      &:hover {
+        background-color: #f5f5f5;
+      }
+    }
   }
 }
 
@@ -18,7 +30,6 @@
   padding: 0 0 1em;
   margin: 0;
   list-style-type: none;
-  
 }
 
 .Navigation__item {
@@ -27,21 +38,13 @@
 
 .Navigation_link {
   display: block;
-  padding: .5rem 0;
-  padding-left: 2rem;
   color: #393f44;
 
-  &:focus {
-    font-weight: 500;
-    color: #007bba;
-    text-decoration: none;
-  }
-
+  &:focus,
   &:hover {
     font-weight: 500;
     color: #007bba;
     text-decoration: none;
-    background-color: #f5f5f5;
   }
 }
 

--- a/src/site/_site/Navigation/styles.scss
+++ b/src/site/_site/Navigation/styles.scss
@@ -5,12 +5,20 @@
 
 .Navigation.is-horizontal .Navigation_link {
   padding: .5rem;
+
+  &:hover {
+    font-weight: 500;
+    color: #007bba;
+    text-decoration: none;
+    background-color: transparent;
+  }
 }
 
 .Navigation__items {
-  padding: 0;
+  padding: 0 0 1em;
   margin: 0;
   list-style-type: none;
+  
 }
 
 .Navigation__item {
@@ -20,6 +28,21 @@
 .Navigation_link {
   display: block;
   padding: .5rem 0;
+  padding-left: 2rem;
+  color: #393f44;
+
+  &:focus {
+    font-weight: 500;
+    color: #007bba;
+    text-decoration: none;
+  }
+
+  &:hover {
+    font-weight: 500;
+    color: #007bba;
+    text-decoration: none;
+    background-color: #f5f5f5;
+  }
 }
 
 .Navigation_not-found-message {

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -22,14 +22,16 @@
   &__sidebar {
     flex: 0 1 20%;
     max-width: 20%;
-    padding: 1rem 2rem;
+    padding: 2rem 0;
     border-right: 1px solid #eaeaea;
   }
 
   &__sidebar_heading {
+    padding: 0 0 0 2rem;
     margin-bottom: .5rem;
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: 14px;
+    font-weight: 500;
+    color: #72767b;
   }
 
   &__sidebar__item + &__sidebar__item {


### PR DESCRIPTION
This issue closes #650. 

The top level headings on each page now pull in {heading} from the index.js file respective to each component/layout/utility/demo, rather than statically having "Example". Some files needed a headingText assignment so that was added. @dgutride what are your thoughts on this? Or is there a way pull in the navigation heading? 

The Navigation styles have been updated to more closely reflect PF-4 styles, specifically the active and focus states. 

The heading styles have also been updated to reflect the heading sizes and weights of pf4. 

