### PR TITLE
fix(input-group):simplifies input group

### DIFF
--- a/src/patternfly/components/InputGroup/docs/code.md
+++ b/src/patternfly/components/InputGroup/docs/code.md
@@ -14,7 +14,4 @@ When using the `pf-c-input-group` always ensure labels are used outside the inpu
 | Class | Applied To | Outcome |
 | -- | -- | -- |
 | `.pf-c-input-group` | `<div>` |  Iniaties the input group. **Required** |
-| `.pf-c-input-group__text` | `<span>` |  Iniaties the input group text. This can be used to show text, radio, or check boxes. |
-| `.pf-c-input-group__action` | `<button>, <label>` |  Iniaties the input group action. This can be used to show action icons such as dismiss, info, or calendar. |
-| `.pf-m-align-right` | `.pf-c-input-group__action` |  Aligns the action icon to the right of the input |
-| `.pf-m-align-left` | `.pf-c-input-group__action` |  Aligns the action icon to the left of the input |
+| `.pf-c-input-group__text` | `<span>` |  Iniaties the input group text. This can be used to show text, radio, icons, or check boxes. |

--- a/src/patternfly/components/InputGroup/examples/input-group-example.hbs
+++ b/src/patternfly/components/InputGroup/examples/input-group-example.hbs
@@ -1,82 +1,79 @@
 {{#> input-group }}
-  {{#> button btnClass="pf-m-secondary" btnAttributes='id="textAreaButton1"'}} Button {{/button}}
-  {{#> form-control controlType="textarea" name="textarea1" id="textarea1" aria-label="textarea with buttons" aria-describedby="textAreaButton1" }}
+ {{#> button btnClass="pf-m-secondary" btnAttributes='id="textAreaButton1"'}} Button {{/button}}
+ {{#> form-control controlType="textarea" name="textarea1" id="textarea1" aria-label="textarea with buttons" aria-describedby="textAreaButton1" }}
 {{/form-control}}
-    {{#> button btnClass="pf-m-tertiary"}} Button {{/button}}
+   {{#> button btnClass="pf-m-tertiary"}} Button {{/button}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-  {{#> form-control controlType="textarea" name="textarea2" id="textarea2" aria-label="textarea with button" aria-describedby="textAreaButton2" }}
+ {{#> form-control controlType="textarea" name="textarea2" id="textarea2" aria-label="textarea with button" aria-describedby="textAreaButton2" }}
 {{/form-control}}
-    {{#> button btnClass="pf-m-tertiary" btnAttributes='id="textAreaButton2"'}} Button {{/button}}
+   {{#> button btnClass="pf-m-tertiary" btnAttributes='id="textAreaButton2"'}} Button {{/button}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-  {{#> dropdown id="dropdown-example-collapsed1" }}
-    Dropdown
-    <i class="fas fa-caret-down pf-c-dropdown__toggle-icon"></i> 
-  {{/dropdown}}
-  {{#> form-control controlType="input" input="true" type="text" id="textInput3" name="textInput3" aria-label="input with dropdown and button" aria-describedby="inputDropdownButton1"}}
+ {{#> dropdown id="dropdown-example-collapsed1" }}
+   Dropdown
+   <i class="fas fa-caret-down pf-c-dropdown__toggle-icon"></i>
+ {{/dropdown}}
+ {{#> form-control controlType="input" input="true" type="text" id="textInput3" name="textInput3" aria-label="input with dropdown and button" aria-describedby="inputDropdownButton1"}}
 {{/form-control}}
-    {{#> button btnClass="pf-m-secondary" btnAttributes='id="inputDropdownButton1"'}} Button {{/button}}
+   {{#> button btnClass="pf-m-secondary" btnAttributes='id="inputDropdownButton1"'}} Button {{/button}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-  {{#> input-group-text inputGroupTextType="span" }}
-    <i class="fas fa-dollar-sign" aria-hidden="true"></i>
-  {{/input-group-text}}
-  {{#> form-control controlType="input" input="true" type="number" id="textInput5" name="textInput5" aria-label=" Dollar amount input example" }}
+ {{#> input-group-text inputGroupTextType="span" }}
+   <i class="fas fa-dollar-sign" aria-hidden="true"></i>
+ {{/input-group-text}}
+ {{#> form-control controlType="input" input="true" type="number" id="textInput5" name="textInput5" aria-label=" Dollar amount input example" }}
 {{/form-control}}
 {{#> input-group-text inputGroupTextType="span"}}
-    .00
-  {{/input-group-text}}
+   .00
+ {{/input-group-text}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-  {{#> form-control controlType="input" input="true" type="email" id="textInput6" name="textInput6" aria-label="email input field" aria-describedby="email-example" }}
+ {{#> form-control controlType="input" input="true" type="email" id="textInput6" name="textInput6" aria-label="email input field" aria-describedby="email-example" }}
 {{/form-control}}
-  {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="email-example"'}}
-    @example.com
-  {{/input-group-text}}
+ {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="email-example"'}}
+   @example.com
+ {{/input-group-text}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-  {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="username"' aria-label="@"}}
-    <i class="fas fa-at" aria-hidden="true"></i>
-  {{/input-group-text}}
-  {{#> form-control required="true" controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example" aria-describedby="username"}}
-{{/form-control}}
-{{/input-group}}
-<br>
-<br>
-{{#> input-group }}
-  {{#> input-group-text inputGroupTextType="span"}}
-{{#> check pf-c-check-type="checkbox" name="checkbox example" id="checkbox1" aria-label="checkbox for following text input"}}
-{{/check}}
-  {{/input-group-text}}
-  {{#> form-control controlType="input" input="true" type="text" id="textInput8" name="textInput8" aria-label="input with checkbox example" aria-describedby="checkbox1"}}
+ {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="username"' aria-label="@"}}
+   <i class="fas fa-at" aria-hidden="true"></i>
+ {{/input-group-text}}
+ {{#> form-control required="true" controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example" aria-describedby="username"}}
 {{/form-control}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-  {{#> input-group-action input-group-action--modifier="pf-m-align-left" inputGroupTextType="label" for="textInput9" }}
-  <i class="fas fa-calendar-alt" aria-hidden="true"></i>
-  {{/input-group-action}}
-  {{#> form-control controlType="input" input="true" type="date" id="textInput9" name="textInput9" aria-label="Date input example" }}
+ {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="calendar"' aria-label="calendar" }}
+   <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+ {{/input-group-text}}
+ {{#> form-control controlType="input" input="true" type="date" id="textInput9" name="textInput9" aria-label="Date input example" aria-describedby="calendar" }}
 {{/form-control}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
-        {{#> input-group-action input-group-action--modifier="pf-m-align-right" inputGroupTextType="button" aria-label="popover for input"}}
-            <i class="fas fa-question-circle aria-hidden="true"></i>
-        {{/input-group-action}}
-        {{#> form-control controlType="input" input="true" type="text" id="textInput10" name="textInput10" aria-label="input example with popover" }}
+ {{#> form-control controlType="input" input="true" type="search" id="textInput11" name="textInput11" aria-label="search input example" aria-describedby="search" }}
 {{/form-control}}
+{{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="search"' aria-label="search" }}
+   <i class="fas fa-search" aria-hidden="true"></i>
+ {{/input-group-text}}
+{{/input-group}}
+<br>
+<br>
+{{#> input-group }}
+       {{#> form-control controlType="input" input="true" type="text" id="textInput10" name="textInput10" aria-label="input example with popover" }}
+{{/form-control}}
+{{#> button btnClass="pf-m-tertiary" btnAttributes='id="textAreaButton2"'}} <i class="fas fa-question-circle aria-hidden="true"></i> {{/button}}
 {{/input-group}}

--- a/src/patternfly/components/InputGroup/examples/input-group-example.hbs
+++ b/src/patternfly/components/InputGroup/examples/input-group-example.hbs
@@ -39,14 +39,14 @@
 {{#> input-group }}
  {{#> form-control controlType="input" input="true" type="email" id="textInput6" name="textInput6" aria-label="email input field" aria-describedby="email-example" }}
 {{/form-control}}
- {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="email-example"'}}
+ {{#> input-group-text inputGroupTextType="span" input-group-text--attribute='id="email-example"'}}
    @example.com
  {{/input-group-text}}
 {{/input-group}}
 <br>
 <br>
 {{#> input-group }}
- {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="username"' aria-label="@"}}
+ {{#> input-group-text inputGroupTextType="span" input-group-text--attribute='id="username"' aria-label="@"}}
    <i class="fas fa-at" aria-hidden="true"></i>
  {{/input-group-text}}
  {{#> form-control required="true" controlType="input" input="true" type="email" id="textInput7" name="textInput7" aria-invalid="true" aria-label="Error state username example" aria-describedby="username"}}
@@ -55,10 +55,10 @@
 <br>
 <br>
 {{#> input-group }}
- {{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="calendar"' aria-label="calendar" }}
+ {{#> input-group-text inputGroupTextType="label" input-group-text--attribute='for="textInput9"' }}
    <i class="fas fa-calendar-alt" aria-hidden="true"></i>
  {{/input-group-text}}
- {{#> form-control controlType="input" input="true" type="date" id="textInput9" name="textInput9" aria-label="Date input example" aria-describedby="calendar" }}
+ {{#> form-control controlType="input" input="true" type="date" id="textInput9" name="textInput9" aria-label="Date input example" }}
 {{/form-control}}
 {{/input-group}}
 <br>
@@ -66,14 +66,16 @@
 {{#> input-group }}
  {{#> form-control controlType="input" input="true" type="search" id="textInput11" name="textInput11" aria-label="search input example" aria-describedby="search" }}
 {{/form-control}}
-{{#> input-group-text inputGroupTextType="span" input-group-text--attributes='id="search"' aria-label="search" }}
+{{#> input-group-text inputGroupTextType="label" input-group-text--attribute='id="search" for="textInput11"' aria-label="search" }}
    <i class="fas fa-search" aria-hidden="true"></i>
  {{/input-group-text}}
 {{/input-group}}
 <br>
 <br>
+
 {{#> input-group }}
        {{#> form-control controlType="input" input="true" type="text" id="textInput10" name="textInput10" aria-label="input example with popover" }}
 {{/form-control}}
 {{#> button btnClass="pf-m-tertiary" btnAttributes='id="textAreaButton2"'}} <i class="fas fa-question-circle aria-hidden="true"></i> {{/button}}
 {{/input-group}}
+

--- a/src/patternfly/components/InputGroup/examples/input-group-example.hbs
+++ b/src/patternfly/components/InputGroup/examples/input-group-example.hbs
@@ -14,9 +14,8 @@
 <br>
 <br>
 {{#> input-group }}
- {{#> dropdown id="dropdown-example-collapsed1" }}
+ {{#> dropdown id="dropdown-example-collapsed1" pf-c-dropdown--HasToggleIcon="true" }}
    Dropdown
-   <i class="fas fa-caret-down pf-c-dropdown__toggle-icon"></i>
  {{/dropdown}}
  {{#> form-control controlType="input" input="true" type="text" id="textInput3" name="textInput3" aria-label="input with dropdown and button" aria-describedby="inputDropdownButton1"}}
 {{/form-control}}
@@ -64,18 +63,14 @@
 <br>
 <br>
 {{#> input-group }}
- {{#> form-control controlType="input" input="true" type="search" id="textInput11" name="textInput11" aria-label="search input example" aria-describedby="search" }}
+ {{#> form-control controlType="input" input="true" type="search" id="textInput11" name="textInput11" aria-label="search input example" }}
 {{/form-control}}
-{{#> input-group-text inputGroupTextType="label" input-group-text--attribute='id="search" for="textInput11"' aria-label="search" }}
-   <i class="fas fa-search" aria-hidden="true"></i>
- {{/input-group-text}}
+{{#> button btnClass="pf-m-tertiary" btnAttributes='aria-label="search button for search input"' }} <i class="fas fa-search" aria-hidden="true"></i>{{/button}}
 {{/input-group}}
 <br>
 <br>
-
 {{#> input-group }}
        {{#> form-control controlType="input" input="true" type="text" id="textInput10" name="textInput10" aria-label="input example with popover" }}
 {{/form-control}}
-{{#> button btnClass="pf-m-tertiary" btnAttributes='id="textAreaButton2"'}} <i class="fas fa-question-circle aria-hidden="true"></i> {{/button}}
+{{#> button btnClass="pf-m-tertiary" btnAttributes='aria-label="popover for input"' }} <i class="fas fa-question-circle aria-hidden="true"></i> {{/button}}
 {{/input-group}}
-

--- a/src/patternfly/components/InputGroup/input-group-action.hbs
+++ b/src/patternfly/components/InputGroup/input-group-action.hbs
@@ -1,8 +1,0 @@
-<{{ inputGroupTextType }} class="pf-c-input-group__action{{#if input-group-action--modifier}} {{input-group-action--modifier}}{{/if}}"
-{{#if aria-label}}
-    aria-label="{{aria-label}}"
-{{/if}}
-{{#if for}} for="{{for}}"{{/if}}
->
-    {{> @partial-block}}
-</{{ inputGroupTextType }}>

--- a/src/patternfly/components/InputGroup/input-group-text.hbs
+++ b/src/patternfly/components/InputGroup/input-group-text.hbs
@@ -2,8 +2,8 @@
 {{#if aria-label}}
     aria-label="{{aria-label}}"
 {{/if}}
-{{#if input-group-text--attributes}}
-    {{{ input-group-text--attributes }}}
+{{#if input-group-text--attribute}}
+    {{{ input-group-text--attribute}}}
 {{/if}}
 >
     {{> @partial-block}}

--- a/src/patternfly/components/InputGroup/styles.scss
+++ b/src/patternfly/components/InputGroup/styles.scss
@@ -11,16 +11,6 @@
   --pf-c-input-group__text--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-input-group__text--BorderColor: var(--pf-global--BorderColor--dark);
   --pf-c-input-group__text--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-  --pf-c-input-group__action--FontSize: var(--pf-global--FontSize--md);
-  --pf-c-input-group__action--Color: var(--pf-global--Color--200);
-  --pf-c-input-group__action--PaddingTop: var(--pf-global--spacer--sm);
-  --pf-c-input-group__action--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-input-group__action--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-input-group__action--PaddingLeft: var(--pf-global--spacer--sm);
-  --pf-c-input-group__action-hover--Color: var(--pf-global--Color--100);
-  --pf-c-input-group__action-focus--Color: var(--pf-global--Color--100);
-  --pf-c-input-group__action-form-control--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-input-group__action-form-control--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-input-group__textarea--MinHeight: var(--pf-global--spacer--xl);
   --pf-c-input-group__button--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-input-group__button--PaddingLeft: var(--pf-global--spacer--md);
@@ -67,11 +57,6 @@
     border-radius: 0 var(--pf-c-input-group--BorderRadius) var(--pf-c-input-group--BorderRadius) 0;
   }
 
-  // this is to ensure this rule applies regardless of the html order of the elements
-  .pf-c-input-group__action + .pf-c-form-control, .pf-c-form-control + .pf-c-input-group__action {
-    border-radius: var(--pf-c-input-group--BorderRadius);
-  }
-
   .pf-c-dropdown__toggle {
     height: 100%;
   }
@@ -92,51 +77,17 @@
   textarea {
     min-height: var(--pf-c-input-group__textarea--MinHeight);
   }
-}
 
-.pf-c-input-group__text {
-  display: flex;
-  align-items: center;
-  padding-right: var(--pf-c-input-group__text--PaddingRight);
-  padding-left: var(--pf-c-input-group__text--PaddingLeft);
-  font-size: var(--pf-c-input-group__text--FontSize);
-  color: var(--pf-c-input-group__text--Color);
-  text-align: center;
-  background-color: var(--pf-c-input-group__text--BackgroundColor);
-  border: var(--pf-c-input-group__text--BorderSize) solid var(--pf-c-input-group__text--BorderColor);
-}
-
-.pf-c-input-group__action {
-  position: absolute;
-  padding: var(--pf-c-input-group__action--PaddingTop) var(--pf-c-input-group__action--PaddingRight) var(--pf-c-input-group__action--PaddingBottom) var(--pf-c-input-group__action--PaddingLeft);
-  font-size: var(--pf-c-input-group__action--FontSize);
-  color: var(--pf-c-input-group__action--Color);
-  cursor: pointer;
-  border: none;
-
-  &:hover,
-  &.pf-m-hover {
-    color: var(--pf-c-input-group__action-hover--Color);
-  }
-
-  &:focus,
-  &.pf-m-focus {
-    color: var(--pf-c-input-group__action-focus--Color);
-  }
-
-  &.pf-m-align-right {
-    right: 0;
-
-    & + .pf-c-form-control {
-      padding-right: var(--pf-c-input-group__action-form-control--PaddingRight);
-    }
-  }
-
-  &.pf-m-align-left {
-    left: 0;
-
-    & + .pf-c-form-control {
-      padding-left: var(--pf-c-input-group__action-form-control--PaddingLeft);
-    }
+  .pf-c-input-group__text {
+    display: flex;
+    align-items: center;
+    padding-right: var(--pf-c-input-group__text--PaddingRight);
+    padding-left: var(--pf-c-input-group__text--PaddingLeft);
+    font-size: var(--pf-c-input-group__text--FontSize);
+    color: var(--pf-c-input-group__text--Color);
+    text-align: center;
+    background-color: var(--pf-c-input-group__text--BackgroundColor);
+    border: var(--pf-c-input-group__text--BorderSize) solid var(--pf-c-input-group__text--BorderColor);
   }
 }
+

--- a/src/patternfly/components/InputGroup/styles.scss
+++ b/src/patternfly/components/InputGroup/styles.scss
@@ -3,9 +3,7 @@
 .pf-c-input-group {
   --pf-c-input-group--BorderRadius: var(--pf-global--BorderRadius--sm);
   --pf-c-input-group__text--FontSize: var(--pf-global--FontSize--md);
-  --pf-c-input-group__text--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-input-group__text--PaddingRight: var(--pf-global--spacer--sm);
-  --pf-c-input-group__text--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-input-group__text--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-input-group__text--Color: var(--pf-global--Color--dark-200);
   --pf-c-input-group__text--BorderSize: var(--pf-global--BorderWidth--sm);
@@ -32,7 +30,6 @@
 
   position: relative;
   display: flex;
-  align-items: stretch;
   width: 100%;
 
   * {

--- a/src/patternfly/components/InputGroup/styles.scss
+++ b/src/patternfly/components/InputGroup/styles.scss
@@ -17,18 +17,26 @@
   > * + * {
     margin-left: -1px;
   }
+
+  label.pf-c-input-group__text {
+    cursor: pointer;
+  }
   /* stylelint-enable */
 
-  .pf-c-form-control[aria-invalid="true"] {
+  .pf-c-form-control {
     position: relative;
-    z-index: var(--pf-c-input-group--form-control-invalid--ZIndex);
 
-    &:not(:last-child) {
-      margin-right: 1px;
+    &[aria-invalid="true"] {
+      position: relative;
+      z-index: var(--pf-c-input-group--form-control-invalid--ZIndex);
+
+      &:not(:last-child) {
+        margin-right: 1px;
+      }
     }
   }
 
-  position: relative;
+
   display: flex;
   width: 100%;
 


### PR DESCRIPTION
After discussing this with @mceledonia I've adjusted the design to drop the action and just use either the text or a standard button.

This simplifies the input group and makes it more usable. One thing we may want to change is how there is a mixin for the error state icon. If we only end up having one state icon then it makes sense to simplify this as well.

Thanks in advance for reviewing!