### PR TITLE
docs(a11y): add section on testing for a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,7 @@ To setup the PatternFly Next development environment:
 - run `npm run dev`
 - open your browser to `http://localhost:8000`
 
-To run the a11y audit locally
-- install latest [chromedriver](http://chromedriver.chromium.org/downloads) and ensure its available on your system `$PATH`
-- alternatively, macOS users can simply `brew cask install chromedriver`
-- run `npm run dev`
-- run `npm run a11y`
+After working on your contribution, check for [accessibility violations](#testing-for-accessibility).
 
 ### Create a new component
 
@@ -56,6 +52,33 @@ To run the a11y audit locally
 - run `pf generate demo <name>`
 
 *To view visit http://localhost:8000/demos/<name>*
+
+## Testing for Accessibility
+
+PatternFly uses [aXe: The Accessibility Engine](https://www.deque.com/axe/) to check for accessibility violations. Our goal is to meet WCAG 2.0 AA requirements, as noted in our [Accessibility Guide](https://pf-next.com/accessibility-guide).
+
+### How to Perform an Accessibility Audit with aXe
+aXe is available as either a browser extension or npm script.
+
+To run the a11y audit locally:
+- install the latest [chromedriver](http://chromedriver.chromium.org/downloads) and ensure its available on your system `$PATH`
+  - alternatively, macOS users can simply `brew cask install chromedriver`
+- run `npm run dev`
+- run `npm run a11y` (in a separate terminal)
+
+The tool is configured to return WCAG 2.0 AA violations for the full page renderings of all components, layouts, utilities, and demos. The tool will provide feedback about what the violation is and a link to documentation about how to address the violation.
+
+The same tool is also available as a browser extension for [Chrome](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/). 
+
+### Fixing Violations
+
+Ignore the violations that aren’t related to your contribution.
+
+Fix violations related to your contribution.
+
+If there are violations that are not obvious how to fix, then create an issue with information about the violation that was found. For example, some violations might require further discussion before they can be addressed. And some violations may not be valid and require changes to the workspace or tooling to stop flagging the violation.
+
+If you have any suggestions about ways that we can improve how we use this tool, please let us know by opening an issue.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Ignore the violations that aren’t related to your contribution.
 
 Fix violations related to your contribution.
 
-If there are violations that are not obvious how to fix, then create an issue with information about the violation that was found. For example, some violations might require further discussion before they can be addressed. And some violations may not be valid and require changes to the workspace or tooling to stop flagging the violation.
+If there are violations that are not obvious how to fix, then [create an issue](https://github.com/patternfly/patternfly-next/issues/new) with information about the violation that was found. For example, some violations might require further discussion before they can be addressed. And some violations may not be valid and require changes to the workspace or tooling to stop flagging the violation.
 
 If you have any suggestions about ways that we can improve how we use this tool, please let us know by opening an issue.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To run the a11y audit locally:
 - install the latest [chromedriver](http://chromedriver.chromium.org/downloads) and ensure its available on your system `$PATH`
   - alternatively, macOS users can simply `brew cask install chromedriver`
 - run `npm run dev`
-- run `npm run a11y` (in a separate terminal)
+- run `npm run a11y` (in another console)
 
 The tool is configured to return WCAG 2.0 AA violations for the full page renderings of all components, layouts, utilities, and demos. The tool will provide feedback about what the violation is and a link to documentation about how to address the violation.
 

--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -142,7 +142,7 @@ The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#conte
 
 ## Testing
 Many accessibility issues can be found by doing a few simple checks:
-1. Use an accessibility audit tool to check for violations. If you are using PatternFly in your project, we recommend using [aXe: The Accessibility Engine](https://www.deque.com/axe/) to check for accessibility violations. If you are contributing to PatternFly, refer to our [README.md](https://github.com/patternfly/patternfly-next/blob/master/README.md) on how to run this tool.
+1. Use an accessibility audit tool to check for violations. If you are using PatternFly in your project, we recommend using [aXe: The Accessibility Engine](https://www.deque.com/axe/) to check for accessibility violations. If you are contributing to PatternFly, refer to our [README.md](https://github.com/patternfly/patternfly-next/blob/master/README.md#testing-for-accessibility) on how to run this tool.
 2. Test keyboard accessibility, and check that these requirements are met:
     - All functionality is keyboard accessible
     - Order of elements in the HTML and in the layout follow a logical order

--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -141,14 +141,15 @@ The [WCAG 2.0 techniques](https://www.w3.org/TR/WCAG20-TECHS/Overview.html#conte
 
 
 ## Testing
-To keep testing simple and easy to complete, we ask that contributors complete the following tests to try to catch most of the accessibility issues that may be present:
-1. Test keyboard accessibility, and check that these requirements are met:
+Many accessibility issues can be found by doing a few simple checks:
+1. Use an accessibility audit tool to check for violations. If you are using PatternFly in your project, we recommend using [aXe: The Accessibility Engine](https://www.deque.com/axe/) to check for accessibility violations. If you are contributing to PatternFly, refer to our [README.md](https://github.com/patternfly/patternfly-next/blob/master/README.md) on how to run this tool.
+2. Test keyboard accessibility, and check that these requirements are met:
     - All functionality is keyboard accessible
     - Order of elements in the HTML and in the layout follow a logical order
     - Elements with focus are clearly visible
-2. Use the [WAVE browser extension from WebAIM](https://wave.webaim.org/extension/) to disable styles, then test the information architecture and presence of adequate text labels.
-3. Test with any screen reader available in your operating system
-4. Check color contrast for:
+3. Use the [WAVE browser extension from WebAIM](https://wave.webaim.org/extension/) to disable styles, then test the information architecture and presence of adequate text labels.
+4. Test with any screen reader available in your operating system
+5. Check color contrast for:
     - Text color against background color ([Understanding WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))
     - Text color against link color ([Technique G183](https://www.w3.org/TR/WCAG20-TECHS/G183.html))
     - Visible boundaries of buttons and form elements against adjacent background color ([Understanding WCAG 1.4.11](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html))

--- a/src/site/pages/accessibility-guide.md
+++ b/src/site/pages/accessibility-guide.md
@@ -147,8 +147,11 @@ Many accessibility issues can be found by doing a few simple checks:
     - All functionality is keyboard accessible
     - Order of elements in the HTML and in the layout follow a logical order
     - Elements with focus are clearly visible
-3. Use the [WAVE browser extension from WebAIM](https://wave.webaim.org/extension/) to disable styles, then test the information architecture and presence of adequate text labels.
-4. Test with any screen reader available in your operating system
+3. Disable styles, then test the information architecture and presence of adequate text labels. The [WAVE browser extension from WebAIM](https://wave.webaim.org/extension/) provides this feature if it isn't available in the browser you are using. 
+4. Test with any screen reader available in your operating system. Screen readers that we target for testing PatternFly are:
+    - JAWS with Chrome, Windows ([keyboard shortcuts](https://dequeuniversity.com/screenreaders/jaws-keyboard-shortcuts))
+    - Voiceover with Safari, Mac ([keyboard shortcuts](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts))
+    - NVDA with Firefox, Windows ([keyboard shortcuts](https://dequeuniversity.com/screenreaders/nvda-keyboard-shortcuts))
 5. Check color contrast for:
     - Text color against background color ([Understanding WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html))
     - Text color against link color ([Technique G183](https://www.w3.org/TR/WCAG20-TECHS/G183.html))


### PR DESCRIPTION
Closes #528  

Adds section to README.md on how to test for accessibility. Moves the section added in #615 down to this section and explains how to handle the violations that are flagged. 

Also adds a bullet to the Accessibility Guide in the Testing section to recommend aXe and link back to the README.md.