### PR TITLE
refactor(utilities): removal of dormant variables, Remove `$pf-global--DropShadow-2`

### DIFF
--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -76,6 +76,8 @@ $pf-global--danger-color--300:          $pf-color-red-400 !default;
 $pf-global--primary-color--light-100:   $pf-color-blue-300 !default;
 $pf-global--primary-color--dark-100:    $pf-color-blue-400 !default;
 
+// shadows
+
 // small
 $pf-global--BoxShadow--sm: 0 pf-size-prem(1) pf-size-prem(2) 0 rgba($pf-color-black-1000, .2) !default;
 $pf-global--BoxShadow--sm-right: pf-size-prem(4) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -76,10 +76,6 @@ $pf-global--danger-color--300:          $pf-color-red-400 !default;
 $pf-global--primary-color--light-100:   $pf-color-blue-300 !default;
 $pf-global--primary-color--dark-100:    $pf-color-blue-400 !default;
 
-// Shadows
-$pf-global--DropShadow: drop-shadow(pf-size-prem(0) pf-size-prem(.7) pf-size-prem(2.1) rgba($pf-color-black-1000, .14)); // visually comparable to $pf-global--BoxShadow
-$pf-global--DropShadow-2: drop-shadow(pf-size-prem(.7) pf-size-prem(4) pf-size-prem(7.1) rgba($pf-color-black-1000, .14));
-
 // small
 $pf-global--BoxShadow--sm: 0 pf-size-prem(1) pf-size-prem(2) 0 rgba($pf-color-black-1000, .2) !default;
 $pf-global--BoxShadow--sm-right: pf-size-prem(4) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -76,8 +76,7 @@ $pf-global--danger-color--300:          $pf-color-red-400 !default;
 $pf-global--primary-color--light-100:   $pf-color-blue-300 !default;
 $pf-global--primary-color--dark-100:    $pf-color-blue-400 !default;
 
-// shadows
-
+// Shadows
 // small
 $pf-global--BoxShadow--sm: 0 pf-size-prem(1) pf-size-prem(2) 0 rgba($pf-color-black-1000, .2) !default;
 $pf-global--BoxShadow--sm-right: pf-size-prem(4) 0 pf-size-prem(10) pf-size-prem(-4) rgba($pf-color-black-1000, .12) !default;


### PR DESCRIPTION
This issue fixes issue #737.

Removal of dormant `$pf-global--DropShadow` variable from `sass-utilities` directory and in sub file `scss-variables.scss`.