### PR TITLE
fix(variables): pull root variables also into patternfly-utilities

### DIFF
--- a/src/patternfly/patternfly-utilities.scss
+++ b/src/patternfly/patternfly-utilities.scss
@@ -1,1 +1,2 @@
 @import "./sass-utilities/_all";
+@import "./_variables";


### PR DESCRIPTION
Component styles such as src/patternfly/components/Avatar/styles.scss import patternfly-utilities. Before the root variables were moved into _variables.scss they were picked up and added to the dist version of /dist/components/Avatar/styles.css. After the change they were missing.
This in turn ended up breaking the styling in react-docs.
