### PR TITLE
Dropdown select 708

### DIFF
--- a/src/patternfly/components/Check/check.hbs
+++ b/src/patternfly/components/Check/check.hbs
@@ -1,4 +1,4 @@
-<div class="pf-c-check{{#if check--modifier}} {{check--modifier}}{{/if}}"
+<div class="pf-c-check{{#if check--modifier}} {{check--modifier}}{{/if}}">
   {{#if check--attribute}}
     {{{check--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Check/check.hbs
+++ b/src/patternfly/components/Check/check.hbs
@@ -1,4 +1,4 @@
-<div class="pf-c-check{{#if check--modifier}} {{check--modifier}}{{/if}}">
+<div class="pf-c-check{{#if check--modifier}} {{check--modifier}}{{/if}}"
   {{#if check--attribute}}
     {{{check--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Dropdown/docs/code.md
+++ b/src/patternfly/components/Dropdown/docs/code.md
@@ -10,9 +10,10 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `aria-expanded="true"` | `.pf-c-dropdown__toggle` |  Indicates that the menu is visible |
 | `aria-label="Actions"` | `.pf-c-dropdown__toggle` | Provides an accessible name for the dropdown when an icon is used instead of text. **Required when icon is used with no supporting text** |
 | `aria-hidden="true"` | `.pf-c-dropdown__toggle-icon` | Hides the icon from assistive technologies |
-| `hidden="hidden"` | `.pf-c-dropdown__menu` | Indicates that the menu is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies |
+| `hidden` | `.pf-c-dropdown__menu` | Indicates that the menu is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies |
 | `aria-expanded="true"` | `.pf-c-dropdown__menu` | Indicates that the menu is visible |
 | `aria-activedescendant="ID_REF"` | `.pf-c-dropdown__menu` | **Select and Multi-select variations only** This attribute should be programmatically set to indicate the element with focus |
+| `role="separator"` | `.pf-c-dropdown__separator` | Indicates that the separator is a separator |
 | `disabled` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus |
 | `aria-disabled="true"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, indicates that it is unavailable |
 | `tabindex="-1"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, removes it from keyboard focus |

--- a/src/patternfly/components/Dropdown/docs/code.md
+++ b/src/patternfly/components/Dropdown/docs/code.md
@@ -6,18 +6,13 @@ The dropdown menu can contain either links or buttons, depending on the expected
 
 | Attribute | Applied | Outcome |
 | -- | -- | -- |
-| `aria-haspopup="listbox"` | `.pf-c-dropdown__toggle` | **Select variation only** Indicates the button has a popup menu. |
 | `aria-expanded="false"` | `.pf-c-dropdown__toggle` |  Indicates that the menu is hidden |
 | `aria-expanded="true"` | `.pf-c-dropdown__toggle` |  Indicates that the menu is visible |
 | `aria-label="Actions"` | `.pf-c-dropdown__toggle` | Provides an accessible name for the dropdown when an icon is used instead of text. **Required when icon is used with no supporting text** |
 | `aria-hidden="true"` | `.pf-c-dropdown__toggle-icon` | Hides the icon from assistive technologies |
-| `role="menu"` | `.pf-c-dropdown__menu` | **Action/link menu only** Indicates that the menu is a menu |
-| `role="dialog"` | `.pf-c-dropdown__menu` | **Multi-select variation only** Indicates that the menu is a menu |
 | `hidden="hidden"` | `.pf-c-dropdown__menu` | Indicates that the menu is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies |
 | `aria-expanded="true"` | `.pf-c-dropdown__menu` | Indicates that the menu is visible |
 | `aria-activedescendant="ID_REF"` | `.pf-c-dropdown__menu` | **Select and Multi-select variations only** This attribute should be programmatically set to indicate the element with focus |
-| `role="menuitem"` | `.pf-c-dropdown__menu-item` | Indicates that the menu item is a menu item |
-| `role="separator"` | `.pf-c-dropdown__separator` | Indicates that the separator is a separator |
 | `disabled` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus |
 | `aria-disabled="true"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, indicates that it is unavailable |
 | `tabindex="-1"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, removes it from keyboard focus |

--- a/src/patternfly/components/Dropdown/docs/code.md
+++ b/src/patternfly/components/Dropdown/docs/code.md
@@ -6,14 +6,16 @@ The dropdown menu can contain either links or buttons, depending on the expected
 
 | Attribute | Applied | Outcome |
 | -- | -- | -- |
-| `aria-haspopup="true"` | `.pf-c-dropdown__toggle` | Indicates the button has a popup menu. |
+| `aria-haspopup="listbox"` | `.pf-c-dropdown__toggle` | **Select variation only** Indicates the button has a popup menu. |
 | `aria-expanded="false"` | `.pf-c-dropdown__toggle` |  Indicates that the menu is hidden |
 | `aria-expanded="true"` | `.pf-c-dropdown__toggle` |  Indicates that the menu is visible |
 | `aria-label="Actions"` | `.pf-c-dropdown__toggle` | Provides an accessible name for the dropdown when an icon is used instead of text. **Required when icon is used with no supporting text** |
 | `aria-hidden="true"` | `.pf-c-dropdown__toggle-icon` | Hides the icon from assistive technologies |
-| `role="menu"` | `.pf-c-dropdown__menu` | Indicates that the menu is a menu |
+| `role="menu"` | `.pf-c-dropdown__menu` | **Action/link menu only** Indicates that the menu is a menu |
+| `role="dialog"` | `.pf-c-dropdown__menu` | **Multi-select variation only** Indicates that the menu is a menu |
 | `hidden="hidden"` | `.pf-c-dropdown__menu` | Indicates that the menu is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies |
 | `aria-expanded="true"` | `.pf-c-dropdown__menu` | Indicates that the menu is visible |
+| `aria-activedescendant="ID_REF"` | `.pf-c-dropdown__menu` | **Select and Multi-select variations only** This attribute should be programmatically set to indicate the element with focus |
 | `role="menuitem"` | `.pf-c-dropdown__menu-item` | Indicates that the menu item is a menu item |
 | `role="separator"` | `.pf-c-dropdown__separator` | Indicates that the separator is a separator |
 | `disabled` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus |

--- a/src/patternfly/components/Dropdown/docs/code.md
+++ b/src/patternfly/components/Dropdown/docs/code.md
@@ -12,11 +12,11 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `aria-hidden="true"` | `.pf-c-dropdown__toggle-icon` | Hides the icon from assistive technologies |
 | `hidden` | `.pf-c-dropdown__menu` | Indicates that the menu is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies |
 | `aria-expanded="true"` | `.pf-c-dropdown__menu` | Indicates that the menu is visible |
-| `aria-activedescendant="ID_REF"` | `.pf-c-dropdown__menu` | **Select and Multi-select variations only** This attribute should be programmatically set to indicate the element with focus |
 | `role="separator"` | `.pf-c-dropdown__separator` | Indicates that the separator is a separator |
 | `disabled` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus |
 | `aria-disabled="true"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, indicates that it is unavailable |
 | `tabindex="-1"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, removes it from keyboard focus |
+| `aria-pressed="true"` | `button.pf-c-dropdown__menu-item` | **Select only** The attribute `aria-pressed="true"` should be set programmatically to the active item. Value should be false when not selected.|
 
 ## Usage
 

--- a/src/patternfly/components/Dropdown/docs/dropdown-basic.md
+++ b/src/patternfly/components/Dropdown/docs/dropdown-basic.md
@@ -1,0 +1,1 @@
+The Basic Dropdown is provided for flexibility in allowing various content within a dropdown. 

--- a/src/patternfly/components/Dropdown/docs/dropdown-multi-select.md
+++ b/src/patternfly/components/Dropdown/docs/dropdown-multi-select.md
@@ -1,0 +1,1 @@
+The Dropdown Multi Select should be used when the user is selecting multiple items from a list. Although the presentation is similar to the basic dropdown, the underlying HTML and Aria tag structure is specific to a select list.

--- a/src/patternfly/components/Dropdown/docs/dropdown-select.md
+++ b/src/patternfly/components/Dropdown/docs/dropdown-select.md
@@ -1,3 +1,3 @@
-The Dropdown Select should be used when the user is selecting an optoin from a list of items. Although the presentation is similar to the basic dropdown, the underlying HTML and Aria tag structure is specific to a select list.
+The Dropdown Select should be used when the user is selecting an option from a list of items. Although the presentation is similar to the basic dropdown, the underlying HTML and Aria tag structure is specific to a select list.
 
 *Note:* The attribute `aria-activedescendant` should be set programmatically to the active item.

--- a/src/patternfly/components/Dropdown/docs/dropdown-select.md
+++ b/src/patternfly/components/Dropdown/docs/dropdown-select.md
@@ -1,3 +1,3 @@
 The Dropdown Select should be used when the user is selecting an option from a list of items. Although the presentation is similar to the basic dropdown, the underlying HTML and Aria tag structure is specific to a select list.
 
-*Note:* The attribute `aria-pressed` should be set programmatically to the active item.
+*Note:* The attribute `aria-pressed="true"` should be set programmatically to the active item.

--- a/src/patternfly/components/Dropdown/docs/dropdown-select.md
+++ b/src/patternfly/components/Dropdown/docs/dropdown-select.md
@@ -1,0 +1,3 @@
+The Dropdown Select should be used when the user is selecting an optoin from a list of items. Although the presentation is similar to the basic dropdown, the underlying HTML and Aria tag structure is specific to a select list.
+
+*Note:* The attribute `aria-activedescendant` should be set programmatically to the active item.

--- a/src/patternfly/components/Dropdown/docs/dropdown-select.md
+++ b/src/patternfly/components/Dropdown/docs/dropdown-select.md
@@ -1,3 +1,3 @@
 The Dropdown Select should be used when the user is selecting an option from a list of items. Although the presentation is similar to the basic dropdown, the underlying HTML and Aria tag structure is specific to a select list.
 
-*Note:* The attribute `aria-activedescendant` should be set programmatically to the active item.
+*Note:* The attribute `aria-pressed` should be set programmatically to the active item.

--- a/src/patternfly/components/Dropdown/dropdown-basic.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-basic.hbs
@@ -1,3 +1,3 @@
-<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}-button" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
+<div class="pf-c-dropdown__menu" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
 
 </div>

--- a/src/patternfly/components/Dropdown/dropdown-basic.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-basic.hbs
@@ -1,0 +1,3 @@
+<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
+
+</div>

--- a/src/patternfly/components/Dropdown/dropdown-basic.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-basic.hbs
@@ -1,3 +1,3 @@
-<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
+<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}-button" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
 
 </div>

--- a/src/patternfly/components/Dropdown/dropdown-menu.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu.hbs
@@ -1,11 +1,11 @@
-<div class="pf-c-dropdown__menu{{#if dropdown-menu--modifier}} {{dropdown-menu--modifier}}{{/if}}" role="menu" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}
+<div class="pf-c-dropdown__menu{{#if dropdown-menu--modifier}} {{dropdown-menu--modifier}}{{/if}}" role="menu" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
   {{#if dropdown-menu--attribute}}
 	  {{{dropdown-menu--attribute}}}
   {{/if}}>
-  <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Link</a>
-  <button class="pf-c-dropdown__menu-item" role="menuitem">Action</button>
-  <a class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
-  <button class="pf-c-dropdown__menu-item" role="menuitem" disabled>Disabled Action</button>
-  <div class="pf-c-dropdown__separator" role="separator"></div>
-  <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Separated Link</a>
+    <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Link</a>
+    <button class="pf-c-dropdown__menu-item" role="menuitem">Action</button>
+    <a class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
+    <button class="pf-c-dropdown__menu-item" role="menuitem" disabled>Disabled Action</button>
+    <div class="pf-c-dropdown__separator" role="separator"></div>
+    <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Separated Link</a>
 </div>

--- a/src/patternfly/components/Dropdown/dropdown-menu.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu.hbs
@@ -1,11 +1,11 @@
-<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}-button" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
+<ul class="pf-c-dropdown__menu" aria-labelledby="{{id}}-button" {{#unless dropdown--IsExpanded}}hidden{{/unless}}
   {{#if dropdown-menu--attribute}}
 	  {{{dropdown-menu--attribute}}}
   {{/if}}>
-    <a class="pf-c-dropdown__menu-item" href="#">Link</a>
-    <button class="pf-c-dropdown__menu-item">Action</button>
-    <a class="pf-c-dropdown__menu-item pf-m-disabled" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
-    <button class="pf-c-dropdown__menu-item" disabled>Disabled Action</button>
-    <div class="pf-c-dropdown__separator" role="separator"></div>
-    <a class="pf-c-dropdown__menu-item" href="#">Separated Link</a>
-</div>
+    <li><a class="pf-c-dropdown__menu-item" href="#">Link</a></li>
+    <li><button class="pf-c-dropdown__menu-item">Action</button></li>
+    <li><a class="pf-c-dropdown__menu-item pf-m-disabled" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a></li>
+    <li><button class="pf-c-dropdown__menu-item" disabled>Disabled Action</button></li>
+    <li class="pf-c-dropdown__separator" role="separator"></li>
+    <li><a class="pf-c-dropdown__menu-item" href="#">Separated Link</a></li>
+</ul>

--- a/src/patternfly/components/Dropdown/dropdown-menu.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu.hbs
@@ -1,11 +1,11 @@
-<div class="pf-c-dropdown__menu{{#if dropdown-menu--modifier}} {{dropdown-menu--modifier}}{{/if}}" role="menu" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
+<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}-button" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
   {{#if dropdown-menu--attribute}}
 	  {{{dropdown-menu--attribute}}}
   {{/if}}>
-    <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Link</a>
-    <button class="pf-c-dropdown__menu-item" role="menuitem">Action</button>
-    <a class="pf-c-dropdown__menu-item pf-m-disabled" role="menuitem" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
-    <button class="pf-c-dropdown__menu-item" role="menuitem" disabled>Disabled Action</button>
+    <a class="pf-c-dropdown__menu-item" href="#">Link</a>
+    <button class="pf-c-dropdown__menu-item">Action</button>
+    <a class="pf-c-dropdown__menu-item pf-m-disabled" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a>
+    <button class="pf-c-dropdown__menu-item" disabled>Disabled Action</button>
     <div class="pf-c-dropdown__separator" role="separator"></div>
-    <a class="pf-c-dropdown__menu-item" role="menuitem" href="#">Separated Link</a>
+    <a class="pf-c-dropdown__menu-item" href="#">Separated Link</a>
 </div>

--- a/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
@@ -1,7 +1,6 @@
-<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}-label" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
+<div class="pf-c-dropdown__menu" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
     <form class="pf-c-form">
-    <fieldset class="pf-c-form__fieldset">
-        <legend class="pf-u-sr-only">Choose one or more items</legend>
+    <fieldset class="pf-c-form__fieldset" aria-labelledby="{{id}}-label">
         {{#> check check--modifier="pf-c-dropdown__menu-item"}}
             {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-apples" name="fruit"') }}{{/check-input}}
             {{#> check-label check-label--attribute=(concat 'for="' id '-apples"') }}Apples{{/check-label}}

--- a/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
@@ -1,23 +1,23 @@
-<div class="pf-c-dropdown__menu" role="dialog" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
+<div class="pf-c-dropdown__menu" aria-labelledby="{{id}}-label" {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
     <form class="pf-c-form">
     <fieldset class="pf-c-form__fieldset">
         <legend class="pf-u-sr-only">Choose one or more items</legend>
         {{#> check check--modifier="pf-c-dropdown__menu-item"}}
-            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-apples" name="apples"'}}{{/check-input}}
-            {{#> check-label check-label--attribute='for="checkbox-apples"'}}Apples{{/check-label}}
+            {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-apples" name="fruit"') }}{{/check-input}}
+            {{#> check-label check-label--attribute=(concat 'for="' id '-apples"') }}Apples{{/check-label}}
         {{/check}}
         {{#> check check--modifier="pf-c-dropdown__menu-item"}}
-            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-oranges" name="oranges" checked'}}{{/check-input}}
-            {{#> check-label check-label--attribute='for="checkbox-apples"'}}Oranges{{/check-label}}
+            {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-oranges" name="fruit" checked')}}{{/check-input}}
+            {{#> check-label check-label--attribute=(concat 'for="' id '-oranges"')}}Oranges{{/check-label}}
         {{/check}}
         {{#> check check--modifier="pf-c-dropdown__menu-item"}}
-            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-bananas" name="bananas"'}}{{/check-input}}
-            {{#> check-label check-label--attribute='for="checkbox-bananas"'}}Bananas{{/check-label}}
+            {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-bananas" name="fruit" aria-disabled="true" disabled')}}{{/check-input}}
+            {{#> check-label check-label--attribute=(concat 'for="' id '-bananas"')}}Bananas{{/check-label}}
         {{/check}}
         <div class="pf-c-dropdown__separator" role="separator"></div>
         {{#> check check--modifier="pf-c-dropdown__menu-item"}}
-            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-apples" name="carrots" aria-disabled="true" disabled'}}{{/check-input}}
-            {{#> check-label check-label--attribute='for="checkbox-carrots"'}}Carrots{{/check-label}}
+            {{#> check-input check-input--attribute=(concat 'type="checkbox" id="' id '-carrots" name="fruit"')}}{{/check-input}}
+            {{#> check-label check-label--attribute=(concat 'for="' id '-carrots"')}}Carrots{{/check-label}}
         {{/check}}
     </fieldset>
   </form>

--- a/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
@@ -1,0 +1,19 @@
+<div class="pf-c-dropdown__menu" role="dialog" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
+    <form class="pf-c-form">
+    <fieldset class="pf-c-form__fieldset">
+        <label class="pf-c-form__label  pf-c-dropdown__menu-item" for="checkbox-apples">
+            <input class="pf-c-check" type="checkbox" name="apples" id="checkbox-apples" checked> Apples
+        </label>
+        <label class="pf-c-form__label pf-c-dropdown__menu-item" for="checkbox-oranges">
+            <input class="pf-c-check" type="checkbox" name="oranges" id="checkbox-oranges" checked> Oranges
+        </label>
+        <label class="pf-c-form__label  pf-c-dropdown__menu-item pf-m-disabled" for="checkbox-bananas"> 
+            <input class="pf-c-check" type="checkbox" name="bananas" id="checkbox-bananas" disabled> Bananas
+        </label>
+        <div class="pf-c-dropdown__separator" role="separator"></div>
+        <label class="pf-c-form__label  pf-c-dropdown__menu-item" for="checkbox-grapes">
+            <input class="pf-c-check" type="checkbox" name="carrots" id="checkbox-grapes"> Carrots
+        </label>
+    </fieldset>
+  </form>
+</div>

--- a/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-multi-select.hbs
@@ -1,19 +1,24 @@
 <div class="pf-c-dropdown__menu" role="dialog" aria-labelledby="{{id}}" {{#unless dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
     <form class="pf-c-form">
     <fieldset class="pf-c-form__fieldset">
-        <label class="pf-c-form__label  pf-c-dropdown__menu-item" for="checkbox-apples">
-            <input class="pf-c-check" type="checkbox" name="apples" id="checkbox-apples" checked> Apples
-        </label>
-        <label class="pf-c-form__label pf-c-dropdown__menu-item" for="checkbox-oranges">
-            <input class="pf-c-check" type="checkbox" name="oranges" id="checkbox-oranges" checked> Oranges
-        </label>
-        <label class="pf-c-form__label  pf-c-dropdown__menu-item pf-m-disabled" for="checkbox-bananas"> 
-            <input class="pf-c-check" type="checkbox" name="bananas" id="checkbox-bananas" disabled> Bananas
-        </label>
+        <legend class="pf-u-sr-only">Choose one or more items</legend>
+        {{#> check check--modifier="pf-c-dropdown__menu-item"}}
+            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-apples" name="apples"'}}{{/check-input}}
+            {{#> check-label check-label--attribute='for="checkbox-apples"'}}Apples{{/check-label}}
+        {{/check}}
+        {{#> check check--modifier="pf-c-dropdown__menu-item"}}
+            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-oranges" name="oranges" checked'}}{{/check-input}}
+            {{#> check-label check-label--attribute='for="checkbox-apples"'}}Oranges{{/check-label}}
+        {{/check}}
+        {{#> check check--modifier="pf-c-dropdown__menu-item"}}
+            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-bananas" name="bananas"'}}{{/check-input}}
+            {{#> check-label check-label--attribute='for="checkbox-bananas"'}}Bananas{{/check-label}}
+        {{/check}}
         <div class="pf-c-dropdown__separator" role="separator"></div>
-        <label class="pf-c-form__label  pf-c-dropdown__menu-item" for="checkbox-grapes">
-            <input class="pf-c-check" type="checkbox" name="carrots" id="checkbox-grapes"> Carrots
-        </label>
+        {{#> check check--modifier="pf-c-dropdown__menu-item"}}
+            {{#> check-input check-input--attribute='type="checkbox" id="checkbox-apples" name="carrots" aria-disabled="true" disabled'}}{{/check-input}}
+            {{#> check-label check-label--attribute='for="checkbox-carrots"'}}Carrots{{/check-label}}
+        {{/check}}
     </fieldset>
   </form>
 </div>

--- a/src/patternfly/components/Dropdown/dropdown-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-select.hbs
@@ -1,11 +1,9 @@
 <ul class="pf-c-dropdown__menu" 
-role="listbox" 
-aria-labelledby="{{id}}" 
-aria-activedescendant="ID_REF" 
-{{#unless pf-c-dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
-    <li class="pf-c-dropdown__menu-item" role="option" tabindex="0">Apples</li>
-    <li class="pf-c-dropdown__menu-item" role="option" tabindex="0">Oranges</li>
-    <li class="pf-c-dropdown__menu-item pf-m-disabled" role="option" >Bananas</li>
+aria-labelledby="{{id}}-label" 
+{{#unless pf-c-dropdown--IsExpanded}}hidden{{/unless}}>
+    <li><button class="pf-c-dropdown__menu-item" {{#if pf-c-dropdown--ItemIsSelected}} aria-pressed="true"{{else}} aria-pressed="false"{{/if}}>Apples</button></li>
+    <li><button class="pf-c-dropdown__menu-item" aria-pressed="false">Oranges</button></li>
+    <li><button class="pf-c-dropdown__menu-item" aria-pressed="false" disabled>Bananas</button></li>
     <li class="pf-c-dropdown__separator" role="separator"></li>
-    <li class="pf-c-dropdown__menu-item" role="option" tabindex="0">Carrots</li>
+    <li><button class="pf-c-dropdown__menu-item" aria-pressed="false">Carrots</button></li>
 </ul>

--- a/src/patternfly/components/Dropdown/dropdown-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-select.hbs
@@ -1,0 +1,11 @@
+<ul class="pf-c-dropdown__menu" 
+role="listbox" 
+aria-labelledby="{{id}}" 
+aria-activedescendant="ID_REF" 
+{{#unless pf-c-dropdown--IsExpanded}}hidden="hidden"{{/unless}}>
+    <li class="pf-c-dropdown__menu-item" role="option" tabindex="0">Apples</li>
+    <li class="pf-c-dropdown__menu-item" role="option" tabindex="0">Oranges</li>
+    <li class="pf-c-dropdown__menu-item pf-m-disabled" role="option" >Bananas</li>
+    <li class="pf-c-dropdown__separator" role="separator"></li>
+    <li class="pf-c-dropdown__menu-item" role="option" tabindex="0">Carrots</li>
+</ul>

--- a/src/patternfly/components/Dropdown/dropdown-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-select.hbs
@@ -1,6 +1,6 @@
 <ul class="pf-c-dropdown__menu" 
 aria-labelledby="{{id}}-label" 
-{{#unless pf-c-dropdown--IsExpanded}}hidden{{/unless}}>
+{{#unless dropdown--IsExpanded}}hidden{{/unless}}>
     <li><button class="pf-c-dropdown__menu-item" {{#if pf-c-dropdown--ItemIsSelected}} aria-pressed="true"{{else}} aria-pressed="false"{{/if}}>Apples</button></li>
     <li><button class="pf-c-dropdown__menu-item" aria-pressed="false">Oranges</button></li>
     <li><button class="pf-c-dropdown__menu-item" aria-pressed="false" disabled>Bananas</button></li>

--- a/src/patternfly/components/Dropdown/dropdown-select.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-select.hbs
@@ -1,7 +1,7 @@
 <ul class="pf-c-dropdown__menu" 
 aria-labelledby="{{id}}-label" 
 {{#unless dropdown--IsExpanded}}hidden{{/unless}}>
-    <li><button class="pf-c-dropdown__menu-item" {{#if pf-c-dropdown--ItemIsSelected}} aria-pressed="true"{{else}} aria-pressed="false"{{/if}}>Apples</button></li>
+    <li><button class="pf-c-dropdown__menu-item" {{#if dropdown--ItemIsSelected}} aria-pressed="true"{{else}} aria-pressed="false"{{/if}}>Apples</button></li>
     <li><button class="pf-c-dropdown__menu-item" aria-pressed="false">Oranges</button></li>
     <li><button class="pf-c-dropdown__menu-item" aria-pressed="false" disabled>Bananas</button></li>
     <li class="pf-c-dropdown__separator" role="separator"></li>

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -1,7 +1,16 @@
 <div class="pf-c-dropdown{{#if dropdown--IsExpanded}} pf-m-expanded{{/if}}{{#if dropdown--modifier}} {{dropdown--modifier}}{{/if}}">
-    <button id="{{id}}"
-        class="pf-c-dropdown__toggle"
-        {{#if dropdown--IsSelect}}aria-haspopup="listbox"{{/if}}
+    {{#if dropdown--IsSelect}}
+        <span id="{{id}}-label" hidden>Select a fruit</span>
+    {{else if dropdown--IsMultiSelect}}
+        <span id="{{id}}-label" hidden>Select a fruit</span>
+    {{/if}}
+   <button id="{{id}}-button"
+        class="dropdown__toggle"
+    {{#if dropdown--IsSelect}}
+        aria-labelledby="{{id}}-label {{id}}-button"
+    {{else if dropdown--IsMultiSelect}}
+        aria-labelledby="{{id}}-label {{id}}-button"
+    {{/if}}
         aria-expanded="{{#if dropdown--IsExpanded}}true{{else}}false{{/if}}"
         {{#if aria-label}} aria-label="{{aria-label}}" {{/if}}>
         {{> @partial-block}}

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -2,10 +2,10 @@
     {{#if dropdown--IsSelect}}
         <span id="{{id}}-label" hidden>Select a fruit</span>
     {{else if dropdown--IsMultiSelect}}
-        <span id="{{id}}-label" hidden>Select a fruit</span>
+        <span id="{{id}}-label" hidden>Select one or more fruits</span>
     {{/if}}
    <button id="{{id}}-button"
-        class="dropdown__toggle"
+        class="pf-c-dropdown__toggle"
     {{#if dropdown--IsSelect}}
         aria-labelledby="{{id}}-label {{id}}-button"
     {{else if dropdown--IsMultiSelect}}
@@ -17,7 +17,7 @@
         {{#if dropdown--HasToggleIcon}}
         {{> dropdown-toggle-icon}}
         {{/if}}
-        {{#if dropdown__kebab-icon}}
+        {{#if dropdown--HasKebabIcon}}
         {{> kebab-icon}}
         {{/if}}
 

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -1,7 +1,26 @@
-<div class="pf-c-dropdown{{#if dropdown--IsExpanded}} pf-m-expanded{{/if}} {{#if dropdown--modifier}} {{dropdown--modifier}}{{/if}}"
-  {{#if dropdown--attribute}}
-    {{{dropdown--attribute}}}
-  {{/if}}>
-	{{> dropdown-toggle}}
-  {{> dropdown-menu}}
+<div class="pf-c-dropdown{{#if dropdown--IsExpanded}} pf-m-expanded{{/if}}{{#if dropdown--modifier}} {{dropdown--modifier}}{{/if}}">
+    <button id="{{id}}"
+        class="pf-c-dropdown__toggle"
+        {{#if dropdown--IsSelect}}aria-haspopup="listbox"{{/if}}
+        aria-expanded="{{#if dropdown--IsExpanded}}true{{else}}false{{/if}}"
+        {{#if aria-label}} aria-label="{{aria-label}}" {{/if}}>
+        {{> @partial-block}}
+        {{#if dropdown--HasToggleIcon}}
+        {{> dropdown-toggle-icon}}
+        {{/if}}
+        {{#if dropdown__kebab-icon}}
+        {{> kebab-icon}}
+        {{/if}}
+
+    </button>
+    {{#if dropdown--IsSelect}}
+        {{> dropdown-select}}
+    {{else if dropdown--IsMultiSelect}}
+        {{> dropdown-multi-select}}
+    {{else if dropdown--IsActionMenu}}
+        {{> dropdown-menu}}
+    {{else}}
+        {{> dropdown-basic}}
+    {{/if}}
+
 </div>

--- a/src/patternfly/components/Dropdown/examples/dropdown-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-align-right-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-example-rightAligned" dropdown--IsExpanded="true" dropdown--modifier="pf-m-align-right" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-rightAligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--Modifier="pf-m-align-right" dropdown--HasToggleIcon="true"}}
   Right
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-align-right-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-example-rightAligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--Modifier="pf-m-align-right" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-rightAligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-align-right" dropdown--HasToggleIcon="true"}}
   Right
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-basic-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-basic-expanded-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-example-expanded" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+  Expanded Dropdown
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-basic-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-basic-expanded-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-example-expanded" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-basic-example-expanded" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   Expanded Dropdown
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-collapsed-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-collapsed-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-example-collapsed" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-collapsed" dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true"}}
   Collapsed Dropdown
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-expanded-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-example-expanded" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-expanded" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   Expanded Dropdown
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
@@ -1,2 +1,2 @@
-{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+{{#> dropdown id="dropdown-example-kebab-right-aligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--Modifier="pf-m-plain pf-m-align-right" dropdown__kebab-icon="true" aria-label="Actions"}}
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
@@ -1,2 +1,2 @@
-{{#> dropdown id="dropdown-example-kebab-right-aligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--Modifier="pf-m-plain pf-m-align-right" dropdown__kebab-icon="true" aria-label="Actions"}}
+{{#> dropdown id="dropdown-example-kebab-right-aligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
@@ -1,2 +1,2 @@
-{{#> dropdown id="dropdown-example-kebab" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-example.hbs
@@ -1,1 +1,1 @@
-{{#> dropdown id="dropdown-example-kebab" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain" pf-c-dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-example.hbs
@@ -1,1 +1,1 @@
-{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain" pf-c-dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-right-aligned-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-right-aligned-example.hbs
@@ -1,1 +1,1 @@
-{{#> dropdown id="dropdown-example-kebab" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-multi-select-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-multi-select-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-select-example" dropdown--IsMultiSelect="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-multi-select-example" dropdown--IsMultiSelect="true" dropdown--HasToggleIcon="true"}}
   Apples, Oranges
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-multi-select-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-multi-select-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-select-example" dropdown--IsMultiSelect="true" dropdown--HasToggleIcon="true"}}
+  Apples, Oranges
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-multi-select-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-multi-select-expanded-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-select-example-expanded" dropdown--IsMultiSelect="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-multi-select-example-expanded" dropdown--IsMultiSelect="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   Choose many
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-multi-select-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-multi-select-expanded-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-select-example-expanded" dropdown--IsMultiSelect="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+  Choose many
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-select-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-select-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-select-example" dropdown--IsSelect="true" dropdown--HasToggleIcon="true"}}
+  Apples
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-select-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-select-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-select-example" dropdown--IsSelect="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-select-example" dropdown--IsSelect="true" dropdown--ItemIsSelected="true" dropdown--HasToggleIcon="true"}}
   Apples
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-select-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-select-expanded-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-select-example-expanded" dropdown--IsSelect="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+  Choose one
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-select-expanded-selected-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-select-expanded-selected-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-select-example-expanded-selected" pf-c-dropdown--IsSelect="true" pf-c-dropdown--IsExpanded="true" pf-c-dropdown--ItemIsSelected="true" pf-c-dropdown--HasToggleIcon="true"}}
+  Apples
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-select-expanded-selected-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-select-expanded-selected-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-select-example-expanded-selected" pf-c-dropdown--IsSelect="true" pf-c-dropdown--IsExpanded="true" pf-c-dropdown--ItemIsSelected="true" pf-c-dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-select-example-expanded-selected" dropdown--IsSelect="true" dropdown--IsExpanded="true" dropdown--ItemIsSelected="true" dropdown--HasToggleIcon="true"}}
   Apples
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-top-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-top-example.hbs
@@ -1,6 +1,6 @@
-{{#> dropdown id="dropdown-example-top-collapsed" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-top-collapsed" dropdown--IsActionMenu="true" dropdown--modifier="pf-m-top" pf-c-dropdown--HasToggleIcon="true"}}
   Top
 {{/dropdown}}
-{{#> dropdown id="dropdown-example-top-expanded" dropdown--IsExpanded="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-top-expanded" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
   Top
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/index.js
+++ b/src/patternfly/components/Dropdown/examples/index.js
@@ -4,6 +4,7 @@ import Example from '@siteComponents/Example';
 import DropdownExpandedRaw from '!raw!./dropdown-expanded-example.hbs';
 import DropdownBasicExpandedRaw from '!raw!./dropdown-basic-expanded-example.hbs';
 import DropdownSelectExpandedRaw from '!raw!./dropdown-select-expanded-example.hbs';
+import DropdownSelectExpandedSelectedRaw from '!raw!./dropdown-select-expanded-selected-example.hbs';
 import DropdownSelectRaw from '!raw!./dropdown-select-example.hbs';
 import DropdownMultiSelectRaw from '!raw!./dropdown-multi-select-example.hbs';
 import DropdownMultiSelectExpandedRaw from '!raw!./dropdown-multi-select-expanded-example.hbs';
@@ -15,6 +16,7 @@ import DropdownTopRaw from '!raw!./dropdown-top-example.hbs';
 import DropdownExpanded from './dropdown-expanded-example.hbs';
 import DropdownBasicExpanded from './dropdown-basic-expanded-example.hbs';
 import DropdownSelectExpanded from './dropdown-select-expanded-example.hbs';
+import DropdownSelectExpandedSelected from './dropdown-select-expanded-selected-example.hbs';
 import DropdownSelect from './dropdown-select-example.hbs';
 import DropdownMultiSelect from './dropdown-multi-select-example.hbs';
 import DropdownMultiSelectExpanded from './dropdown-multi-select-expanded-example.hbs';
@@ -35,6 +37,7 @@ export default () => {
   const dropdownExpanded = DropdownExpanded();
   const dropdownBasicExpanded = DropdownBasicExpanded();
   const dropdownSelectExpanded = DropdownSelectExpanded();
+  const dropdownSelectExpandedSelected = DropdownSelectExpandedSelected();
   const dropdownSelect = DropdownSelect();
   const dropdownMultiSelect = DropdownMultiSelect();
   const dropdownMultiSelectExpanded = DropdownMultiSelectExpanded();
@@ -66,9 +69,16 @@ export default () => {
         docs={DropdownSelectDoc}>
         {dropdownSelectExpanded}
       </Example>
+      <Example className="is-expanded-dropdown" 
+        heading="Dropdown Select (expanded, first item selected)" 
+        handlebars={DropdownSelectExpandedSelectedRaw}
+        docs={DropdownSelectDoc}>
+        {dropdownSelectExpandedSelected}
+      </Example>
       <Example 
         heading="Dropdown Select (collapsed)" 
-        handlebars={DropdownSelectRaw}>
+        handlebars={DropdownSelectRaw} 
+        docs={DropdownSelectDoc}>
         {dropdownSelect}
       </Example>
       <Example className="is-expanded-dropdown" heading="Dropdown Multi-Select (expanded)" handlebars={DropdownMultiSelectExpandedRaw} docs={DropdownMultiSelectDoc}>

--- a/src/patternfly/components/Dropdown/examples/index.js
+++ b/src/patternfly/components/Dropdown/examples/index.js
@@ -2,17 +2,30 @@ import React from 'react';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
 import DropdownExpandedRaw from '!raw!./dropdown-expanded-example.hbs';
+import DropdownBasicExpandedRaw from '!raw!./dropdown-basic-expanded-example.hbs';
+import DropdownSelectExpandedRaw from '!raw!./dropdown-select-expanded-example.hbs';
+import DropdownSelectRaw from '!raw!./dropdown-select-example.hbs';
+import DropdownMultiSelectRaw from '!raw!./dropdown-multi-select-example.hbs';
+import DropdownMultiSelectExpandedRaw from '!raw!./dropdown-multi-select-expanded-example.hbs';
 import DropdownCollapsedRaw from '!raw!./dropdown-collapsed-example.hbs';
 import DropdownKebabRaw from '!raw!./dropdown-kebab-example.hbs';
 import DropdownKebabAlignRightRaw from '!raw!./dropdown-kebab-align-right-example.hbs';
 import DropdownAlignRightRaw from '!raw!./dropdown-align-right-example.hbs';
 import DropdownTopRaw from '!raw!./dropdown-top-example.hbs';
 import DropdownExpanded from './dropdown-expanded-example.hbs';
+import DropdownBasicExpanded from './dropdown-basic-expanded-example.hbs';
+import DropdownSelectExpanded from './dropdown-select-expanded-example.hbs';
+import DropdownSelect from './dropdown-select-example.hbs';
+import DropdownMultiSelect from './dropdown-multi-select-example.hbs';
+import DropdownMultiSelectExpanded from './dropdown-multi-select-expanded-example.hbs';
 import DropdownCollapsed from './dropdown-collapsed-example.hbs';
 import DropdownKebab from './dropdown-kebab-example.hbs';
 import DropdownKebabAlignRight from './dropdown-kebab-align-right-example.hbs';
 import DropdownAlignRight from './dropdown-align-right-example.hbs';
 import DropdownTop from './dropdown-top-example.hbs';
+import DropdownBasicDoc from '../docs/dropdown-basic.md';
+import DropdownSelectDoc from '../docs/dropdown-select.md';
+import DropdownMultiSelectDoc from '../docs/dropdown-multi-select.md';
 import docs from '../docs/code.md';
 import '../dropdown.scss';
 
@@ -20,6 +33,11 @@ export const Docs = docs;
 
 export default () => {
   const dropdownExpanded = DropdownExpanded();
+  const dropdownBasicExpanded = DropdownBasicExpanded();
+  const dropdownSelectExpanded = DropdownSelectExpanded();
+  const dropdownSelect = DropdownSelect();
+  const dropdownMultiSelect = DropdownMultiSelect();
+  const dropdownMultiSelectExpanded = DropdownMultiSelectExpanded();
   const dropdownCollapsed = DropdownCollapsed();
   const dropdownKebab = DropdownKebab();
   const dropdownKebabAlignRight = DropdownKebabAlignRight();
@@ -33,11 +51,31 @@ export default () => {
 
   return (
     <Documentation style={styles} docs={Docs} heading={headingText}>
-      <Example className="is-expanded-dropdown" heading="Dropdown Expanded" handlebars={DropdownExpandedRaw}>
+      <Example className="is-expanded-dropdown" heading="Basic Dropdown (expanded)" handlebars={DropdownBasicExpandedRaw} docs={DropdownBasicDoc}>
+        {dropdownBasicExpanded}
+      </Example>
+      <Example className="is-expanded-dropdown" heading="Dropdown with links and actions (expanded)" handlebars={DropdownExpandedRaw}>
         {dropdownExpanded}
       </Example>
-      <Example heading="Dropdown Collapsed" handlebars={DropdownCollapsedRaw}>
+      <Example heading="Dropdown (collapsed)" handlebars={DropdownCollapsedRaw}>
         {dropdownCollapsed}
+      </Example>
+      <Example className="is-expanded-dropdown" 
+        heading="Dropdown Select (expanded)" 
+        handlebars={DropdownSelectExpandedRaw}
+        docs={DropdownSelectDoc}>
+        {dropdownSelectExpanded}
+      </Example>
+      <Example 
+        heading="Dropdown Select (collapsed)" 
+        handlebars={DropdownSelectRaw}>
+        {dropdownSelect}
+      </Example>
+      <Example className="is-expanded-dropdown" heading="Dropdown Multi-Select (expanded)" handlebars={DropdownMultiSelectExpandedRaw} docs={DropdownMultiSelectDoc}>
+        {dropdownMultiSelectExpanded}
+      </Example>
+      <Example heading="Dropdown Multi-Select (collapsed)" handlebars={DropdownMultiSelectRaw} >
+        {dropdownMultiSelect}
       </Example>
       <Example className="is-expanded-dropdown" heading="Kebab" handlebars={DropdownKebabRaw}>
         {dropdownKebab}


### PR DESCRIPTION
Differentiates a select-type dropdown and multi-select dropdown from the existing action/link dropdown and puts in appropriate a11y.
NOTE: Multi-select needs the chip component in order to display the selected items properly. This should be done in a future issue.

Fixes #708 