### PR TITLE
fix(progress): set max-width for progress

### DIFF
--- a/src/patternfly/components/Progress/styles.scss
+++ b/src/patternfly/components/Progress/styles.scss
@@ -139,6 +139,7 @@
   grid-row: 2 / 3;
   align-self: center;
   min-width: var(--pf-c-progress__indicator--MinWidth);
+  max-width: 100%;
   height: var(--pf-c-progress__bar--Height);
   background-color: var(--pf-c-progress__bar--BackgroundColor);
 }


### PR DESCRIPTION
Without `max-width` the progress bar could overflow out of progress container.

#### Before
![screenshot from 2018-09-24 13-55-35](https://user-images.githubusercontent.com/3439771/45950824-9c06ed00-c001-11e8-9cf4-6c1cbfe11b2d.png)

#### After
![screenshot from 2018-09-24 13-55-43](https://user-images.githubusercontent.com/3439771/45950827-9dd0b080-c001-11e8-92f3-675b4927c7bc.png)

