### PR TITLE
[WIP] fix(utilities): use relative image path

### DIFF
--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -108,7 +108,7 @@ $pf-global--font-path: "./assets/fonts" !default;
 $fa-font-path: "./assets/fonts/webfonts" !default;
 
 // Imagepath
-$pf-global--image-path: "/assets/images" !default;
+$pf-global--image-path: "./assets/images" !default;
 
 // Spacers
 $pf-global--spacer--xs: pf-size-prem(4px) !default;     // Orange


### PR DESCRIPTION
Modifies pf-global--image-path to use relative path, similar to fa-font-path.

Fixes https://github.com/patternfly/patternfly-next/issues/752