### PR TITLE
refactor(layouts): margin changes for toolbar sub divs

### DIFF
--- a/src/patternfly/layouts/Toolbar/styles.scss
+++ b/src/patternfly/layouts/Toolbar/styles.scss
@@ -2,21 +2,22 @@
 
 // The value of component scoped variables is always defined by a global variable:
 .pf-l-toolbar {
+  padding: 0 0 2em 2em;
+
   // Toolbar Section
-  --pf-l-toolbar__section--MarginTop: var(--pf-global--spacer--md);
+  --pf-l-toolbar__section--MarginTop: var(--pf-global--spacer--xl);
 
   // Toolbar Group
+  --pf-l-toolbar__group--Padding: var(--pf-global--spacer--xl);
+  --pf-l-toolbar__group--Margin: var(--pf-global--spacer--md);
   --pf-l-toolbar__group--MarginRight: var(--pf-global--spacer--xl);
-  --pf-l-toolbar__group--MarginLeft: var(--pf-global--spacer--xl);
 
   // Toolbar Item
+  --pf-l-toolbar__item--MarginTop: var(--pf-global--spacer--md);
   --pf-l-toolbar__item--MarginRight: var(--pf-global--spacer--md);
-  --pf-l-toolbar__item--MarginLeft: var(--pf-global--spacer--md);
 
-  // immediate descendant selector for toolbar should provide margin by default
-  .pf-l-toolbar__group,
-  .pf-l-toolbar__item {
-    margin-top: 10px;
+  .pf-l-toolbar__group {
+    margin-right: var(--pf-l-toolbar__group--MarginRight);
   }
 }
 
@@ -32,15 +33,15 @@
 // Section
 .pf-l-toolbar__section {
   flex-basis: 100%;
-
-  // Add margin-top for stacked sections
-  &:not(:first-child) {
-    margin-top: var(--pf-l-toolbar__section--MarginTop);
-  }
 }
 
 // Group
 .pf-l-toolbar__group {
+  padding: var(--pf-global--spacer--xl);
+
+  // Add margin-top for stacked groups
+  margin-top: var(--pf-l-toolbar__section--MarginTop);
+
   // Set margin-right so groups will align when wrapped
   .pf-l-toolbar__group:not(:last-child) {
     margin-right: var(--pf-l-toolbar__group--MarginRight);
@@ -49,6 +50,8 @@
 
 // Item
 .pf-l-toolbar__item {
+  margin: 0;
+
   // Set margin-right so items will align when wrapped
   .pf-l-toolbar:not(:last-child) {
     margin-right: var(--pf-l-toolbar__item--MarginRight);

--- a/src/patternfly/layouts/Toolbar/styles.scss
+++ b/src/patternfly/layouts/Toolbar/styles.scss
@@ -2,27 +2,44 @@
 
 // The value of component scoped variables is always defined by a global variable:
 .pf-l-toolbar {
-  // Toolbar Layout
-  // adds negative margin to toolbar to offset the top margin given on all group divs
-  margin-top: calc(var(--pf-l-toolbar__group--MarginTop) * -1);
+  --pf-l-toolbar--MarginTop: var(--pf-global--spacer--sm);
 
   // Toolbar Section
   --pf-l-toolbar__section--MarginTop: var(--pf-global--spacer--md);
 
   // Toolbar Group
-  --pf-l-toolbar__group--MarginTop: var(--pf-global--spacer--xl);
-  --pf-l-toolbar__group--MarginBottom: var(--pf-global--spacer--xl);
+  --pf-l-toolbar__group--MarginTop: var(--pf-global--spacer--sm);
+  --pf-l-toolbar__group--MarginBottom: var(--pf-global--spacer--sm);
   --pf-l-toolbar__group--MarginRight: var(--pf-global--spacer--xl);
+  --pf-l-toolbar__group--MarginRight-Zero: var(0);
   --pf-l-toolbar__group--MarginLeft: var(--pf-global--spacer--xl);
 
   // Toolbar Item
-  --pf-l-toolbar__item--MarginTop: var(--pf-global--spacer--md);
+  --pf-l-toolbar__item--MarginTop: var(--pf-global--spacer--sm);
   --pf-l-toolbar__item--MarginRight: var(--pf-global--spacer--md);
   --pf-l-toolbar__item--MarginLeft: var(--pf-global--spacer--md);
-}
+  --pf-l-toolbar__item--MarginRight-Zero: var(0);
+  --pf-l-toolbar__group-item--MarginRight-Zero: var(0);
+  --pf-l-toolbar__group-item--MarginTop: var(--pf-global--spacer--sm);
+  --pf-l-toolbar__group-item--MarginRight: var(--pf-global--spacer--sm);
 
-.pf-l-toolbar > .pf-l-toolbar__item {
-  margin-top: calc(var(--pf-l-toolbar__group--MarginTop) * 1);
+  // Toolbar Layout
+  // adds negative margin to toolbar to offset the top margin given on all group divs
+  margin-top: calc(var(--pf-l-toolbar--MarginTop) * -1);
+
+  // direct descendent of toolbar for groups
+  & > .pf-l-toolbar__group {
+    margin-top: calc(var(--pf-l-toolbar__group--MarginTop) * 1);
+  }
+
+  & > .pf-l-toolbar__group:last-child {
+    margin-right: var(--pf-l-toolbar__group--MarginRight-Zero);
+  }
+
+  // direct descendent of toolbar for items
+  & > .pf-l-toolbar__item {
+    margin-top: calc(var(--pf-l-toolbar__group-item--MarginTop) * 1);
+  }
 }
 
 // toolbar, toolbar__group, toolbar__section shared styles
@@ -51,8 +68,12 @@
   margin-right: var(--pf-l-toolbar__group--MarginRight);
 
   .pf-l-toolbar__item {
-    margin-top: 0;
-    margin-right: 0;
+    margin-top: var(--pf-l-toolbar__group-item--MarginRight-Zero);
+    margin-right: var(--pf-l-toolbar__group-item--MarginRight-Zero);
+  }
+
+  .pf-l-toolbar__item:last-child {
+    margin-right: var(--pf-l-toolbar__group-item--MarginRight-Zero);
   }
 }
 
@@ -60,9 +81,4 @@
 .pf-l-toolbar__item {
   margin-top: var(--pf-l-toolbar__item--MarginTop);
   margin-right: var(--pf-l-toolbar__item--MarginRight);
-
-  // Set margin-right so items will align when wrapped
-  .pf-l-toolbar__item:not(:last-child) {
-    margin-right: var(--pf-l-toolbar__item--MarginRight);
-  }
 }

--- a/src/patternfly/layouts/Toolbar/styles.scss
+++ b/src/patternfly/layouts/Toolbar/styles.scss
@@ -2,24 +2,29 @@
 
 // The value of component scoped variables is always defined by a global variable:
 .pf-l-toolbar {
-  padding: 0 0 2em 2em;
+  // Toolbar Layout
+  // adds negative margin to toolbar to offset the top margin given on all group divs
+  margin-top: calc(var(--pf-l-toolbar__group--MarginTop) * -1);
 
   // Toolbar Section
-  --pf-l-toolbar__section--MarginTop: var(--pf-global--spacer--xl);
+  --pf-l-toolbar__section--MarginTop: var(--pf-global--spacer--md);
 
   // Toolbar Group
-  --pf-l-toolbar__group--Padding: var(--pf-global--spacer--xl);
-  --pf-l-toolbar__group--Margin: var(--pf-global--spacer--md);
+  --pf-l-toolbar__group--MarginTop: var(--pf-global--spacer--xl);
+  --pf-l-toolbar__group--MarginBottom: var(--pf-global--spacer--xl);
   --pf-l-toolbar__group--MarginRight: var(--pf-global--spacer--xl);
+  --pf-l-toolbar__group--MarginLeft: var(--pf-global--spacer--xl);
 
   // Toolbar Item
   --pf-l-toolbar__item--MarginTop: var(--pf-global--spacer--md);
   --pf-l-toolbar__item--MarginRight: var(--pf-global--spacer--md);
-
-  .pf-l-toolbar__group {
-    margin-right: var(--pf-l-toolbar__group--MarginRight);
-  }
+  --pf-l-toolbar__item--MarginLeft: var(--pf-global--spacer--md);
 }
+
+.pf-l-toolbar > .pf-l-toolbar__item {
+  margin-top: calc(var(--pf-l-toolbar__group--MarginTop) * 1);
+}
+
 
 // toolbar, toolbar__group, toolbar__section shared styles
 .pf-l-toolbar,
@@ -33,27 +38,32 @@
 // Section
 .pf-l-toolbar__section {
   flex-basis: 100%;
+
+  // Add margin-top for stacked sections
+  &:not(:first-child) {
+    margin-top: var(--pf-l-toolbar__section--MarginTop);
+  }
 }
 
 // Group
 .pf-l-toolbar__group {
-  padding: var(--pf-global--spacer--xl);
+  // adds top margin to all group divs
+  margin-top: var(--pf-l-toolbar__group--MarginTop);
+  margin-right: var(--pf-l-toolbar__group--MarginRight);
 
-  // Add margin-top for stacked groups
-  margin-top: var(--pf-l-toolbar__section--MarginTop);
-
-  // Set margin-right so groups will align when wrapped
-  .pf-l-toolbar__group:not(:last-child) {
-    margin-right: var(--pf-l-toolbar__group--MarginRight);
+  .pf-l-toolbar__item {
+    margin-top: 0;
+    margin-right: 0;
   }
 }
 
 // Item
 .pf-l-toolbar__item {
-  margin: 0;
+  margin-top: var(--pf-l-toolbar__item--MarginTop);
+  margin-right: var(--pf-l-toolbar__item--MarginRight);
 
   // Set margin-right so items will align when wrapped
-  .pf-l-toolbar:not(:last-child) {
+  .pf-l-toolbar__item:not(:last-child) {
     margin-right: var(--pf-l-toolbar__item--MarginRight);
   }
 }

--- a/src/patternfly/layouts/Toolbar/styles.scss
+++ b/src/patternfly/layouts/Toolbar/styles.scss
@@ -12,6 +12,12 @@
   // Toolbar Item
   --pf-l-toolbar__item--MarginRight: var(--pf-global--spacer--md);
   --pf-l-toolbar__item--MarginLeft: var(--pf-global--spacer--md);
+
+  // immediate descendant selector for toolbar should provide margin by default
+  .pf-l-toolbar__group,
+  .pf-l-toolbar__item {
+    margin-top: 10px;
+  }
 }
 
 // toolbar, toolbar__group, toolbar__section shared styles
@@ -34,8 +40,11 @@
 }
 
 // Group
-.pf-l-toolbar__group:not(:last-child) {
-  margin-right: var(--pf-l-toolbar__group--MarginRight);
+.pf-l-toolbar__group {
+  // Set margin-right so groups will align when wrapped
+  .pf-l-toolbar__group:not(:last-child) {
+    margin-right: var(--pf-l-toolbar__group--MarginRight);
+  }
 }
 
 // Item

--- a/src/patternfly/layouts/Toolbar/styles.scss
+++ b/src/patternfly/layouts/Toolbar/styles.scss
@@ -25,7 +25,6 @@
   margin-top: calc(var(--pf-l-toolbar__group--MarginTop) * 1);
 }
 
-
 // toolbar, toolbar__group, toolbar__section shared styles
 .pf-l-toolbar,
 .pf-l-toolbar__section,


### PR DESCRIPTION
PR fixes #740.

- Added margin-top for immediate descendant selectors from `.pf-l-toolbar`. Visually this added spacing between content when viewed on mobile devices.
- For `.pf-l-toolbar__item`, if parent selector is `.pf-l-toolbar__group`, default margin units are set to zero unit. 