### PR TITLE
Documentation for Card Upgrade Example revised

### DIFF
--- a/src/patternfly/upgrade-examples/CardUpgradeExamples/card-upgrade-examples.hbs
+++ b/src/patternfly/upgrade-examples/CardUpgradeExamples/card-upgrade-examples.hbs
@@ -1,4 +1,4 @@
-<div class="pf-d-card-upgrade-examples {{pf-d-card-upgrade-examples--modifier}}"
+<div class="pf-d-card-upgrade-examples{{#if card-upgrade-examples--modifier}} {{card-upgrade-examples--modifier}}{{/if}}"
   {{#if pf-d-upgrade-examples__id}}
     id="{{pf-d-card-upgrade-examples__id}}"
   {{/if}}>

--- a/src/patternfly/upgrade-examples/CardUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/CardUpgradeExamples/docs/code.md
@@ -6,7 +6,7 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 
 | PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
 | -- | -- | -- | -- | -- |
-| `cards-pf` | `<body>` | `.pf-c-card` | `<div>` | Creates a card containing content. |
-| `card-pf-heading` | `<div>` | `.pf-c-card__header` | `.pf-c-card` | Creates the header of a card. |    
-| `card-pf-body` | `<div>` | `.pf-c-card__body` | `.pf-c-card` | Creates the body of a card. Required. | 
-| `card-pf-footer` | `<div>` | `.pf-c-card__footer` | `.pf-c-card` | Creates the footer of a card. | 
+| `.card-pf` | `<div>` | `.pf-c-card` | `<div>` | Creates a card containing content. |
+| `.card-pf-heading` | `<div>` | `.pf-c-card__header` | `.pf-c-card` | Creates the header of a card. |    
+| `.card-pf-body` | `<div>` | `.pf-c-card__body` | `.pf-c-card` | Creates the body of a card. Required. | 
+| `.card-pf-footer` | `<div>` | `.pf-c-card__footer` | `.pf-c-card` | Creates the footer of a card. | 

--- a/src/patternfly/upgrade-examples/CardUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/CardUpgradeExamples/docs/code.md
@@ -4,10 +4,9 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 
 ## Usage
 
-| PatternFly 3 | Replaced By | PatternFly 4 |
-| -- | -- | -- |
-| `<div class="container-fluid container-cards-pf">` |  | `<div class="pf-l-grid pf-m-gutter">` |
-| `<div class="col-sm-3">` |  | `<div class="pf-l-grid__item pf-m-3-col">` |
-| `<div class="card-pf">` |  | `<div class="pf-c-card">` |
-| `<div class="card-pf-heading">` `<h2 class="card-pf-title"></h2>` |  | `<div class="pf-c-card__header">` |
-| `<div class="card-pf-body">` |  | `<div class="pf-c-card__body">`|
+| PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
+| -- | -- | -- | -- | -- |
+| `cards-pf` | `<body>` | `.pf-c-card` | `<div>` | Creates a card containing content. |
+| `card-pf-heading` | `<div>` | `.pf-c-card__header` | `.pf-c-card` | Creates the header of a card. |    
+| `card-pf-body` | `<div>` | `.pf-c-card__body` | `.pf-c-card` | Creates the body of a card. Required. | 
+| `card-pf-footer` | `<div>` | `.pf-c-card__footer` | `.pf-c-card` | Creates the footer of a card. | 

--- a/src/patternfly/upgrade-examples/CardUpgradeExamples/examples/card-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/CardUpgradeExamples/examples/card-upgrade-examples-example2.hbs
@@ -1,13 +1,13 @@
 {{#> card-upgrade-examples}}
-{{#> card pf-c-card-modifier="" }}
-  {{#> card-header pf-c-card__header-modifier="" }}
-    Header
-  {{/card-header}}
-  {{#> card-body pf-c-card__content-modifier="" }}
-    Body
-  {{/card-body}}
-  {{#> card-footer pf-c-card__footer-modifier="" }}
-    Footer
-  {{/card-footer}}
-{{/card}}
+  {{#> card pf-c-card-modifier="" }}
+    {{#> card-header pf-c-card__header-modifier="" }}
+      Header
+    {{/card-header}}
+    {{#> card-body pf-c-card__content-modifier="" }}
+      Body
+    {{/card-body}}
+    {{#> card-footer pf-c-card__footer-modifier="" }}
+      Footer
+    {{/card-footer}}
+  {{/card}}
 {{/card-upgrade-examples}}

--- a/src/patternfly/upgrade-examples/CardUpgradeExamples/examples/card-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/CardUpgradeExamples/examples/card-upgrade-examples-example2.hbs
@@ -1,24 +1,13 @@
 {{#> card-upgrade-examples}}
-<div class="pf-l-grid pf-m-gutter">
-  <div class="pf-l-grid__item pf-m-3-col">
-    <div class="pf-c-card">
-      <div class="pf-c-card__header">
-        Header
-      </div>
-      <div class="pf-c-card__body">
-        Body
-      </div>
-    </div>
-  </div>
-  <div class="pf-l-grid__item pf-m-3-col">
-    <div class="pf-c-card">
-      <div class="pf-c-card__header">
-        Header
-      </div>
-      <div class="pf-c-card__body">
-        Body
-      </div>
-    </div>
-  </div>
-</div>
+{{#> card pf-c-card-modifier="" }}
+  {{#> card-header pf-c-card__header-modifier="" }}
+    Header
+  {{/card-header}}
+  {{#> card-body pf-c-card__content-modifier="" }}
+    Body
+  {{/card-body}}
+  {{#> card-footer pf-c-card__footer-modifier="" }}
+    Footer
+  {{/card-footer}}
+{{/card}}
 {{/card-upgrade-examples}}


### PR DESCRIPTION
This PR closes #760. 

The card upgrade example documentation now aligns with the documentation for other components and also compares pf3 and pf4: 

| PF3 Class | Applied To | PF4 Class | Applied To | Outcome |

Also edit the pf4 card to update with the latest handlebars params.