### PR TITLE
fix(utilities): use relative image path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,10 +18,17 @@ gulp.task('copy-fa', () =>
 
 gulp.task('build-tmp', () =>
   gulp
-    .src('./src/patternfly/**/*.scss')
-    .pipe(sassGlob())
+    .src([
+      './src/patternfly/**/*.scss',
+      '!./src/patternfly/**/examples/*.scss',
+      '!./src/patternfly/_gatsby-variables.scss'
+    ])
+    .pipe(
+      sassGlob({
+        ignorePaths: ['**/examples/*.scss']
+      })
+    )
     .pipe(replace('@import "../../patternfly-utilities";', ''))
-    .pipe(replace('pf-global--image-path: "/assets/images"', 'pf-global--image-path: "./assets/images"'))
     .pipe(gulp.dest('./tmp'))
 );
 
@@ -44,7 +51,10 @@ gulp.task('minify-css', ['build-library'], () => {
 
 gulp.task('build-modules', () =>
   gulp
-    .src('./src/patternfly/{components,layouts,patterns,utilities}/**/*.scss')
+    .src([
+      './src/patternfly/{components,layouts,patterns,utilities}/**/*.scss',
+      '!./src/patternfly/{components,layouts,patterns,utilities}/**/examples/*.scss'
+    ])
     .pipe(sass().on('error', sass.logError))
     .pipe(gulp.dest('./dist'))
 );

--- a/src/patternfly/_gatsby-variables.scss
+++ b/src/patternfly/_gatsby-variables.scss
@@ -1,0 +1,2 @@
+// Override variables for Gatsby site
+$pf-global--image-path: "/assets/images";

--- a/src/patternfly/components/BackgroundImage/examples/index.js
+++ b/src/patternfly/components/BackgroundImage/examples/index.js
@@ -4,7 +4,7 @@ import Example from '@siteComponents/Example';
 import BackgroundImageRaw from '!raw!./background-image-example.hbs';
 import BackgroundImage from './background-image-example.hbs';
 import docs from '../docs/code.md';
-import '../styles.scss';
+import './styles.scss';
 
 export const Docs = docs;
 

--- a/src/patternfly/components/BackgroundImage/examples/styles.scss
+++ b/src/patternfly/components/BackgroundImage/examples/styles.scss
@@ -1,0 +1,2 @@
+@import "../../../_gatsby-variables";
+@import "../styles.scss";

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -108,7 +108,7 @@ $pf-global--font-path: "./assets/fonts" !default;
 $fa-font-path: "./assets/fonts/webfonts" !default;
 
 // Imagepath
-$pf-global--image-path: "/assets/images" !default;
+$pf-global--image-path: "./assets/images" !default;
 
 // Spacers
 $pf-global--spacer--xs: pf-size-prem(4px) !default;     // Orange


### PR DESCRIPTION
Unfortunately, PR https://github.com/patternfly/patternfly-next/pull/763 does not address the image path in `dist/components/BackgroundImage/styles.css` -- that's stil lusing an absolute path.

The underlying problem is that same styles.scss file is being used to build patternfly.css. The gulp build and Gatsby can't both be built with the same file because they each require unique image paths.

My solution was to create a new styles.scss file for just the BackgroundImage example. The gulp build doesn't need to distribute the example, only Gatsby needs it to run the site.

This change allows patternfly.css and `dist/components/BackgroundImage/styles.css` to use a relative `./assets/images` image path, similar to the font paths. Gatsby simply overrides this using the `$pf-global--image-path` variable.

Fixes https://github.com/patternfly/patternfly-next/issues/752