### PR TITLE
fix(backgroundImage): Add variables to support background images

### DIFF
--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -1,6 +1,16 @@
 @import "../../patternfly-utilities";
 
 .pf-c-background-image {
+  --pf-c-background-image--BackgroundImageFilter: url("#{$pf-global--image-path}/background-filter.svg#image_overlay");
+  --pf-c-background-image--BackgroundImage--xs: url("#{$pf-global--image-path}/pfbg_576.jpg");
+  --pf-c-background-image--BackgroundImage--xs-2x: url("#{$pf-global--image-path}/pfbg_576@2x.jpg");
+  --pf-c-background-image--BackgroundImage--sm: url("#{$pf-global--image-path}/pfbg_768.jpg");
+  --pf-c-background-image--BackgroundImage--sm-2x: url("#{$pf-global--image-path}/pfbg_768@2x.jpg");
+  --pf-c-background-image--BackgroundImage--md: url("#{$pf-global--image-path}/pfbg_992.jpg");
+  --pf-c-background-image--BackgroundImage--md-2x: url("#{$pf-global--image-path}/pfbg_992@2x.jpg");
+  --pf-c-background-image--BackgroundImage--lg: url("#{$pf-global--image-path}/pfbg_1200.jpg");
+  --pf-c-background-image--BackgroundImage--xl: url("#{$pf-global--image-path}/pfbg_2000.jpg");
+
   position: fixed;
   top: 0;
   left: 0;
@@ -8,46 +18,46 @@
   width: 100%;
   height: 100%;
   background-color: var(--pf-global--BackgroundColor--dark-200);
-  background-image: url("#{$pf-global--image-path}/pfbg_576.jpg");
-  filter: url("#{$pf-global--image-path}/background-filter.svg#image_overlay");
+  background-image: var(--pf-c-background-image--BackgroundImage--xs);
+  filter: var(--pf-c-background-image--BackgroundImageFilter);
   background-repeat: no-repeat;
   background-size: cover;
 
   /* stylelint-disable */
   @media (max-width: $pf-global--breakpoint--sm) and (-webkit-min-device-pixel-ratio: 2),
     (max-width: $pf-global--breakpoint--sm) and (min-resolution: 192dpi) {
-    background-image: url("#{$pf-global--image-path}/pfbg_576@2x.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--xs-2x);
   }
 
   @media (min-width: $pf-global--breakpoint--sm) {
-    background-image: url("#{$pf-global--image-path}/pfbg_768.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--sm);
   }
 
   @media (min-width: $pf-global--breakpoint--sm) and (-webkit-min-device-pixel-ratio: 2),
     (min-width: $pf-global--breakpoint--sm) and (min-resolution: 192dpi) {
-    background-image: url("#{$pf-global--image-path}/pfbg_768@2x.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--sm-2x);
   }
 
   @media (min-width: $pf-global--breakpoint--md) {
-    background-image: url("#{$pf-global--image-path}/pfbg_992.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--md);
   }
 
   @media (min-width: $pf-global--breakpoint--md) and (-webkit-min-device-pixel-ratio: 2),
     (min-width: $pf-global--breakpoint--md) and (min-resolution: 192dpi) {
-    background-image: url("#{$pf-global--image-path}/pfbg_992@2x.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--md-2x);
   }
 
   @media (min-width: $pf-global--breakpoint--lg) {
-    background-image: url("#{$pf-global--image-path}/pfbg_1200.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--lg);
   }
 
   @media (min-width: $pf-global--breakpoint--lg) and (-webkit-min-device-pixel-ratio: 2),
     (min-width: $pf-global--breakpoint--lg) and (min-resolution: 192dpi) {
-    background-image: url("#{$pf-global--image-path}/pfbg_2000.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--xl);
   }
   /* stylelint-enable */
 
   @media (min-width: $pf-global--breakpoint--xl) {
-    background-image: url("#{$pf-global--image-path}/pfbg_2000.jpg");
+    background-image: var(--pf-c-background-image--BackgroundImage--xl);
   }
 }

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -1,7 +1,6 @@
 @import "../../patternfly-utilities";
 
 .pf-c-background-image {
-  --pf-c-background-image--BackgroundImageFilter: url("#{$pf-global--image-path}/background-filter.svg#image_overlay");
   --pf-c-background-image--BackgroundImage--xs: url("#{$pf-global--image-path}/pfbg_576.jpg");
   --pf-c-background-image--BackgroundImage--xs-2x: url("#{$pf-global--image-path}/pfbg_576@2x.jpg");
   --pf-c-background-image--BackgroundImage--sm: url("#{$pf-global--image-path}/pfbg_768.jpg");
@@ -10,6 +9,7 @@
   --pf-c-background-image--BackgroundImage--md-2x: url("#{$pf-global--image-path}/pfbg_992@2x.jpg");
   --pf-c-background-image--BackgroundImage--lg: url("#{$pf-global--image-path}/pfbg_1200.jpg");
   --pf-c-background-image--BackgroundImage--xl: url("#{$pf-global--image-path}/pfbg_2000.jpg");
+  --pf-c-background-image--Filter: url("#{$pf-global--image-path}/background-filter.svg#image_overlay");
 
   position: fixed;
   top: 0;
@@ -19,7 +19,7 @@
   height: 100%;
   background-color: var(--pf-global--BackgroundColor--dark-200);
   background-image: var(--pf-c-background-image--BackgroundImage--xs);
-  filter: var(--pf-c-background-image--BackgroundImageFilter);
+  filter: var(--pf-c-background-image--Filter);
   background-repeat: no-repeat;
   background-size: cover;
 

--- a/src/patternfly/components/BackgroundImage/examples/examples.scss
+++ b/src/patternfly/components/BackgroundImage/examples/examples.scss
@@ -1,3 +1,3 @@
-// Override variables for Gatsby site
-@import "../../../../site/gatsby-variables";
+// Patternfly overrides for Gatsby site
+@import "../../../../site/gatsby-variables.scss";
 @import "../background-image.scss";

--- a/src/site/gatsby-variables.scss
+++ b/src/site/gatsby-variables.scss
@@ -1,2 +1,4 @@
-// Override variables for Gatsby site
+// Patternfly overrides for Gatsby site
+$fa-font-path: "/assets/fonts/webfonts";
+$pf-global--font-path: "/assets/fonts";
 $pf-global--image-path: "/assets/images";


### PR DESCRIPTION
This change allows CSS image paths to be overridden via variables. For example, when the CSS is imported by react-core components and/or when the same SASS files are compiled for different image paths associated with the Gatsby site.

The $pf-global--image-path is overridden via the Gatsby build.

Fixes https://github.com/patternfly/patternfly-react/issues/682