### PR TITLE
fix(login): Add basic form and list components to demo

### DIFF
--- a/src/patternfly/components/LoginBox/login-box.scss
+++ b/src/patternfly/components/LoginBox/login-box.scss
@@ -62,13 +62,4 @@
   padding-right: var(--pf-c-login-box__footer--PaddingRight);
   padding-bottom: var(--pf-c-login-box__footer--PaddingBottom);
   padding-left: var(--pf-c-login-box__footer--PaddingLeft);
-
-  // Hover behavior
-  & a:hover {
-    text-decoration: none;
-
-    & p {
-      color: var(--pf-global--Color--200);
-    }
-  }
 }

--- a/src/patternfly/components/LoginBox/login-box.scss
+++ b/src/patternfly/components/LoginBox/login-box.scss
@@ -62,4 +62,13 @@
   padding-right: var(--pf-c-login-box__footer--PaddingRight);
   padding-bottom: var(--pf-c-login-box__footer--PaddingBottom);
   padding-left: var(--pf-c-login-box__footer--PaddingLeft);
+
+  // Hover behavior
+  & a:hover {
+    text-decoration: none;
+
+    & p {
+      color: var(--pf-global--Color--200);
+    }
+  }
 }

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -34,7 +34,7 @@
             {{/form-group}}
             {{#> form-group form-group--modifier="pf-m-action pf-u-align-items-center pf-u-display-flex-on-md"}}
               {{#> button button--modifier="pf-m-primary pf-u-mr-lg pf-u-width-full pf-u-width-initial-on-md"}}
-                Sign in
+                Log in
               {{/button}}
               {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
                 {{#> check check--modifier="pf-u-m-md"}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -37,7 +37,7 @@
                 Sign in
               {{/button}}
               {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
-                {{#> check}}
+                {{#> check check--modifier="pf-u-m-md"}}
                   {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
                   {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
                 {{/check}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -25,12 +25,12 @@
         {{#> login-box-body}}
           {{#> form }}
             {{#> form-group}}
-              {{#> form-label form-label--attribute='for="login-demo-username"' required="true"}}Username{{/form-label}}
+              {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username" aria-describedby="login-demo-username-helper"'}}{{/form-control}}
               {{#> form-helper-text form-helper-text--attribute='id="login-demo-username-helper" aria-live="polite"'}}Please provide a username{{/form-helper-text}}
             {{/form-group}}
             {{#> form-group}}
-              {{#> form-label form-label--attribute='for="login-demo-password"' required="true"}}Password{{/form-label}}
+              {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" aria-describedby="login-demo-password-helper"'}}{{/form-control}}
               {{#> form-helper-text form-helper-text--attribute='id="login-demo-password-helper" aria-live="polite"'}}Please provide a password{{/form-helper-text}}
             {{/form-group}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -60,31 +60,31 @@
           {{#> list list--modifier="pf-m-grid"}}
             <li>
               {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-google.svg" alt="Google logo" />
+                <img src="/assets/images/logo-google.svg" alt="" />
                 <p class="pf-u-ml-sm">Google</p>
               {{/display}}
             </li>
             <li>
               {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-github.svg" alt="GitHub logo" />
+                <img src="/assets/images/logo-github.svg" alt="" />
                 <p class="pf-u-ml-sm">GitHub</p>
               {{/display}}
             </li>
             <li>
               {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-dropbox.svg" alt="Dropbox logo" />
+                <img src="/assets/images/logo-dropbox.svg" alt="" />
                 <p class="pf-u-ml-sm">Dropbox</p>
               {{/display}}
             </li>
             <li>
               {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-facebook.svg" alt="Facebook logo" />
+                <img src="/assets/images/logo-facebook.svg" alt="" />
                 <p class="pf-u-ml-sm">Facebook</p>
               {{/display}}
             </li>
             <li>
               {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img class="" src="/assets/images/logo-gitlab.svg" alt="GitLab logo" />
+                <img class="" src="/assets/images/logo-gitlab.svg" alt="" />
                 <p class="pf-u-ml-sm">GitLab</p>
               {{/display}}
             </li>

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -36,14 +36,14 @@
             {{/form-group}}
             {{#> form-group form-group--modifier="pf-m-action"}}
               {{#> toolbar}}
-                {{#> toolbar-group}}
+                {{#> toolbar-group toolbar-group--modifier="pf-u-mr-lg"}}
                   {{#> toolbar-item}}
                     {{#> button button--modifier="pf-m-primary"}}
                       Sign in
                     {{/button}}
                   {{/toolbar-item}}
                 {{/toolbar-group}}
-                {{#> toolbar-group toolbar-group--modifier="pf-u-mb-sm"}}
+                {{#> toolbar-group}}
                   {{#> toolbar-item}}
                     {{#> check}}
                       {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -32,12 +32,12 @@
               {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
             {{/form-group}}
-            {{#> form-group form-group--modifier="pf-m-action pf-u-align-items-center pf-u-display-flex-on-md"}}
-              {{#> button button--modifier="pf-m-primary pf-u-mr-lg pf-u-width-full pf-u-width-initial-on-md"}}
+            {{#> form-group form-group--modifier="pf-m-action pf-u-align-items-center pf-u-display-flex pf-u-flex-direction-column pf-u-flex-direction-row-on-md"}}
+              {{#> button button--modifier="pf-c-button pf-m-primary pf-u-mr-lg-on-md pf-u-px-xl pf-u-align-self-stretch pf-u-align-self-flex-start-on-md"}}
                 Log in
               {{/button}}
               {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
-                {{#> check check--modifier="pf-u-m-md"}}
+                {{#> check check--modifier="pf-u-m-md pf-u-display-flex"}}
                   {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
                   {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
                 {{/check}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -26,11 +26,11 @@
           {{#> form }}
             {{#> form-group}}
               {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
-              {{#> form-control controlType="input" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username" aria-describedby="login-demo-username-helper"'}}{{/form-control}}
+              {{#> form-control controlType="input" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username"'}}{{/form-control}}
             {{/form-group}}
             {{#> form-group}}
               {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
-              {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" aria-describedby="login-demo-password-helper"'}}{{/form-control}}
+              {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password"'}}{{/form-control}}
             {{/form-group}}
             {{#> form-group form-group--modifier="pf-m-action pf-u-align-items-center pf-u-display-flex-on-md"}}
               {{#> button button--modifier="pf-m-primary pf-u-mr-lg pf-u-width-full pf-u-width-initial-on-md"}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -16,7 +16,7 @@
             Sign in to your account
           {{/title}}
           {{#> display display--type="inline-flex" display--modifier="pf-u-align-items-center"}}
-            {{#> dropdown id="dropdown-example-collapsed" pf-c-dropdown--HasToggleIcon="true"}}
+            {{#> dropdown id="dropdown-example-collapsed" dropdown--HasToggleIcon="true"}}
               English
             {{/dropdown}}
             <p class="pf-u-ml-md">Need an account? <a href="https://www.patternfly.org/">Sign up.</a></p>

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -16,7 +16,7 @@
             Sign in to your account
           {{/title}}
           {{#> display display--type="inline-flex" display--modifier="pf-u-align-items-center"}}
-            {{#> dropdown id="dropdown-example-collapsed" dropdown--HasToggleIcon="true"}}
+            {{#> dropdown id="dropdown-select" dropdown--IsSelect="true" dropdown--ItemIsSelected="true" dropdown--HasToggleIcon="true"}}
               English
             {{/dropdown}}
             <p class="pf-u-ml-md">Need an account? <a href="https://www.patternfly.org/">Sign up.</a></p>

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -13,7 +13,7 @@
       {{#> login-box}}
         {{#> login-box-header}}
           {{#> title titleType="h1" title--modifier="pf-m-3xl pf-u-mb-sm"}}
-            Sign in to your account
+            Log in to your account
           {{/title}}
           {{#> display display--type="inline-flex" display--modifier="pf-u-align-items-center"}}
             {{#> dropdown id="dropdown-select" dropdown--IsSelect="true" dropdown--ItemIsSelected="true" dropdown--HasToggleIcon="true"}}
@@ -32,26 +32,16 @@
               {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" aria-describedby="login-demo-password-helper"'}}{{/form-control}}
             {{/form-group}}
-            {{#> form-group form-group--modifier="pf-m-action"}}
-              {{#> toolbar toolbar--modifier="pf-u-flex-column pf-u-flex-row-on-md"}}
-                {{#> toolbar-group toolbar-group--modifier="pf-u-mr-lg"}}
-                  {{#> toolbar-item}}
-                    {{#> button button--modifier="pf-m-primary pf-m-block"}}
-                      Sign in
-                    {{/button}}
-                  {{/toolbar-item}}
-                {{/toolbar-group}}
-                {{#> toolbar-group}}
-                  {{#> toolbar-item}}
-                    {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
-                      {{#> check}}
-                        {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
-                        {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me signed in for 30 days.{{/check-label}}
-                      {{/check}}
-                    {{/alignment}}
-                  {{/toolbar-item}}
-                {{/toolbar-group}}
-              {{/toolbar}}
+            {{#> form-group form-group--modifier="pf-m-action pf-u-align-items-center pf-u-display-flex-on-md"}}
+              {{#> button button--modifier="pf-m-primary pf-m-block pf-u-display-inline-block-on-md pf-u-mr-lg"}}
+                Sign in
+              {{/button}}
+              {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
+                {{#> check}}
+                  {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
+                  {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
+                {{/check}}
+              {{/alignment}}
             {{/form-group}}
           {{/form}}
         {{/login-box-body}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -12,7 +12,7 @@
     {{#> login-main}}
       {{#> login-box}}
         {{#> login-box-header}}
-          {{#> title titleType="h1" title--modifier="pf-m-3xl pf-u-mb-md"}}
+          {{#> title titleType="h1" title--modifier="pf-m-3xl pf-u-mb-sm"}}
             Sign in to your account
           {{/title}}
           {{#> display display--type="inline-flex" display--modifier="pf-u-align-items-center"}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -61,51 +61,39 @@
           {{/title}}
           {{#> list list--modifier="pf-m-grid"}}
             <li>
-              <a href="#">
-                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                  <img src="/assets/images/logo-google.svg" alt="" />
-                  <p class="pf-u-ml-sm">Google</p>
-                {{/display}}
-              </a>
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-google.svg" alt="" />
+                <p class="pf-u-ml-sm">Google</p>
+              {{/display}}
             </li>
             <li>
-              <a href="#">
-                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                  <img src="/assets/images/logo-github.svg" alt="" />
-                  <p class="pf-u-ml-sm">GitHub</p>
-                {{/display}}
-              </a>
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-github.svg" alt="" />
+                <p class="pf-u-ml-sm">GitHub</p>
+              {{/display}}
             </li>
             <li>
-              <a href="#">
-              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
                 <img src="/assets/images/logo-dropbox.svg" alt="" />
                 <p class="pf-u-ml-sm">Dropbox</p>
               {{/display}}
-              </a>
             </li>
             <li>
-              <a href="#">
-                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                  <img src="/assets/images/logo-facebook.svg" alt="" />
-                  <p class="pf-u-ml-sm">Facebook</p>
-                {{/display}}
-              </a>
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-facebook.svg" alt="" />
+                <p class="pf-u-ml-sm">Facebook</p>
+              {{/display}}
             </li>
             <li>
-              <a href="#">
-                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                  <img class="" src="/assets/images/logo-gitlab.svg" alt="" />
-                  <p class="pf-u-ml-sm">GitLab</p>
-                {{/display}}
-              </a>
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img class="" src="/assets/images/logo-gitlab.svg" alt="" />
+                <p class="pf-u-ml-sm">GitLab</p>
+              {{/display}}
             </li>
             <li>
-              <a href="#">
-                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                  <p class="">More...</p>
-                {{/display}}
-              </a>
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm pf-m-link"}}
+                More...
+              {{/display}}
             </li>
           {{/list}}
         {{/login-box-footer}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -59,39 +59,51 @@
           <p class="pf-u-mb-md">Or log in with</p>
           {{#> list list--modifier="pf-m-grid"}}
             <li>
-              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-google.svg" alt="" />
-                <p class="pf-u-ml-sm">Google</p>
-              {{/display}}
+              <a href="#">
+                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                  <img src="/assets/images/logo-google.svg" alt="" />
+                  <p class="pf-u-ml-sm">Google</p>
+                {{/display}}
+              </a>
             </li>
             <li>
-              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-github.svg" alt="" />
-                <p class="pf-u-ml-sm">GitHub</p>
-              {{/display}}
+              <a href="#">
+                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                  <img src="/assets/images/logo-github.svg" alt="" />
+                  <p class="pf-u-ml-sm">GitHub</p>
+                {{/display}}
+              </a>
             </li>
             <li>
+              <a href="#">
               {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
                 <img src="/assets/images/logo-dropbox.svg" alt="" />
                 <p class="pf-u-ml-sm">Dropbox</p>
               {{/display}}
+              </a>
             </li>
             <li>
-              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img src="/assets/images/logo-facebook.svg" alt="" />
-                <p class="pf-u-ml-sm">Facebook</p>
-              {{/display}}
+              <a href="#">
+                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                  <img src="/assets/images/logo-facebook.svg" alt="" />
+                  <p class="pf-u-ml-sm">Facebook</p>
+                {{/display}}
+              </a>
             </li>
             <li>
-              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <img class="" src="/assets/images/logo-gitlab.svg" alt="" />
-                <p class="pf-u-ml-sm">GitLab</p>
-              {{/display}}
+              <a href="#">
+                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                  <img class="" src="/assets/images/logo-gitlab.svg" alt="" />
+                  <p class="pf-u-ml-sm">GitLab</p>
+                {{/display}}
+              </a>
             </li>
             <li>
-              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
-                <p class=""><a href="https://www.patternfly.org/">More...</a></p>
-              {{/display}}
+              <a href="#">
+                {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                  <p class="">More...</p>
+                {{/display}}
+              </a>
             </li>
           {{/list}}
         {{/login-box-footer}}
@@ -99,9 +111,9 @@
     {{/login-main}}
     {{#> login-footer}}
       {{#> list list--modifier="pf-m-inline"}}
-        <li>Terms of Use</li>
-        <li>Help</li>
-        <li>Privacy Policy</li>
+        <li><a href="#">Terms of Use</a></li>
+        <li><a href="#">Help</a></li>
+        <li><a href="#">Privacy Policy</a></li>
       {{/list}}
     {{/login-footer}}
   {{/login}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -3,7 +3,7 @@
   {{#> login}}
     {{#> login-header}}
       {{#> login-header-brand}}
-        {{#> brand brand--attribute='src="/assets/images/pf_logo_color.svg" alt="Patternfly Logo"'}}{{/brand}}
+        {{#> brand brand--attribute='src="/assets/images/pf_logo_color.svg" alt="PatternFly Logo"'}}{{/brand}}
       {{/login-header-brand}}
       {{#> content}}
         <p>This is placeholder text only. Use this area to place any information or introductory message about your application that may be relevant to users.</p>
@@ -12,20 +12,97 @@
     {{#> login-main}}
       {{#> login-box}}
         {{#> login-box-header}}
-          {{#> title titleType="h1" title--modifier="pf-m-3xl"}}
-            Login box title
+          {{#> title titleType="h1" title--modifier="pf-m-3xl pf-u-mb-md"}}
+            Sign in to your account
           {{/title}}
+          {{#> display display--type="inline-flex" display--modifier="pf-u-align-items-center"}}
+            {{#> dropdown id="dropdown-example-collapsed" pf-c-dropdown--HasToggleIcon="true"}}
+              English
+            {{/dropdown}}
+            <p class="pf-u-ml-md">Need an account? <a href="https://www.patternfly.org/">Sign up.</a></p>
+          {{/display}}
         {{/login-box-header}}
         {{#> login-box-body}}
-          Login box body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Iure labore ipsa nemo nostrum id culpa atque nulla expedita at! Explicabo aut minima alias. Officia magnam est at omnis iste eius?
+          {{#> form }}
+            {{#> form-group}}
+              {{#> form-label form-label--attribute='for="login-demo-username"' required="true"}}Username{{/form-label}}
+              {{#> form-control controlType="input" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username" aria-describedby="login-demo-username-helper"'}}{{/form-control}}
+              {{#> form-helper-text form-helper-text--attribute='id="login-demo-username-helper" aria-live="polite"'}}Please provide a username{{/form-helper-text}}
+            {{/form-group}}
+            {{#> form-group}}
+              {{#> form-label form-label--attribute='for="login-demo-password"' required="true"}}Password{{/form-label}}
+              {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" aria-describedby="login-demo-password-helper"'}}{{/form-control}}
+              {{#> form-helper-text form-helper-text--attribute='id="login-demo-password-helper" aria-live="polite"'}}Please provide a password{{/form-helper-text}}
+            {{/form-group}}
+            {{#> form-group form-group--modifier="pf-m-action"}}
+              {{#> toolbar}}
+                {{#> toolbar-group}}
+                  {{#> toolbar-item}}
+                    {{#> button button--modifier="pf-m-primary"}}
+                      Sign in
+                    {{/button}}
+                  {{/toolbar-item}}
+                {{/toolbar-group}}
+                {{#> toolbar-group toolbar-group--modifier="pf-u-mb-sm"}}
+                  {{#> toolbar-item}}
+                    {{#> check}}
+                      {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
+                      {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me signed in for 30 days.{{/check-label}}
+                    {{/check}}
+                  {{/toolbar-item}}
+                {{/toolbar-group}}
+              {{/toolbar}}
+            {{/form-group}}
+          {{/form}}
         {{/login-box-body}}
         {{#> login-box-footer}}
-          Login box footer. Lorem ipsum dolor sit amet consectetur adipisicing elit. Iure labore ipsa nemo nostrum id culpa atque nulla expedita at! Explicabo aut minima alias. Officia magnam est at omnis iste eius?
+          <p class="pf-u-mb-md">Or log in with</p>
+          {{#> list list--modifier="pf-m-grid"}}
+            <li>
+              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-google.svg" alt="Google logo" />
+                <p class="pf-u-ml-sm">Google</p>
+              {{/display}}
+            </li>
+            <li>
+              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-github.svg" alt="GitHub logo" />
+                <p class="pf-u-ml-sm">GitHub</p>
+              {{/display}}
+            </li>
+            <li>
+              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-dropbox.svg" alt="Dropbox logo" />
+                <p class="pf-u-ml-sm">Dropbox</p>
+              {{/display}}
+            </li>
+            <li>
+              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img src="/assets/images/logo-facebook.svg" alt="Facebook logo" />
+                <p class="pf-u-ml-sm">Facebook</p>
+              {{/display}}
+            </li>
+            <li>
+              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <img class="" src="/assets/images/logo-gitlab.svg" alt="GitLab logo" />
+                <p class="pf-u-ml-sm">GitLab</p>
+              {{/display}}
+            </li>
+            <li>
+              {{#> display display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+                <p class=""><a href="https://www.patternfly.org/">More...</a></p>
+              {{/display}}
+            </li>
+          {{/list}}
         {{/login-box-footer}}
       {{/login-box}}
     {{/login-main}}
     {{#> login-footer}}
-        <a href="#">Login Footer</a>
+      {{#> list list--modifier="pf-m-inline"}}
+        <li>Terms of Use</li>
+        <li>Help</li>
+        <li>Privacy Policy</li>
+      {{/list}}
     {{/login-footer}}
   {{/login}}
 {{/login-page}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -37,7 +37,7 @@
                 Log in
               {{/button}}
               {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
-                {{#> check check--modifier="pf-u-m-md pf-u-display-flex"}}
+                {{#> check check--modifier="pf-u-m-md pf-u-align-items-center pf-u-display-flex"}}
                   {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
                   {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me logged in for 30 days.{{/check-label}}
                 {{/check}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -33,7 +33,7 @@
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" aria-describedby="login-demo-password-helper"'}}{{/form-control}}
             {{/form-group}}
             {{#> form-group form-group--modifier="pf-m-action pf-u-align-items-center pf-u-display-flex-on-md"}}
-              {{#> button button--modifier="pf-m-primary pf-m-block pf-u-display-inline-block-on-md pf-u-mr-lg"}}
+              {{#> button button--modifier="pf-m-primary pf-u-mr-lg pf-u-width-full pf-u-width-initial-on-md"}}
                 Sign in
               {{/button}}
               {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -27,28 +27,28 @@
             {{#> form-group}}
               {{#> form-label form-label--attribute='for="login-demo-form-username"' required="true"}}Username{{/form-label}}
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="text" id="login-demo-form-username" name="login-demo-form-username" aria-describedby="login-demo-username-helper"'}}{{/form-control}}
-              {{#> form-helper-text form-helper-text--attribute='id="login-demo-username-helper" aria-live="polite"'}}Please provide a username{{/form-helper-text}}
             {{/form-group}}
             {{#> form-group}}
               {{#> form-label form-label--attribute='for="login-demo-form-password"' required="true"}}Password{{/form-label}}
               {{#> form-control controlType="input" form-control--attribute='required input="true" type="password" id="login-demo-form-password" name="login-demo-form-password" aria-describedby="login-demo-password-helper"'}}{{/form-control}}
-              {{#> form-helper-text form-helper-text--attribute='id="login-demo-password-helper" aria-live="polite"'}}Please provide a password{{/form-helper-text}}
             {{/form-group}}
             {{#> form-group form-group--modifier="pf-m-action"}}
-              {{#> toolbar}}
+              {{#> toolbar toolbar--modifier="pf-u-flex-column pf-u-flex-row-on-md"}}
                 {{#> toolbar-group toolbar-group--modifier="pf-u-mr-lg"}}
                   {{#> toolbar-item}}
-                    {{#> button button--modifier="pf-m-primary"}}
+                    {{#> button button--modifier="pf-m-primary pf-m-block"}}
                       Sign in
                     {{/button}}
                   {{/toolbar-item}}
                 {{/toolbar-group}}
                 {{#> toolbar-group}}
                   {{#> toolbar-item}}
-                    {{#> check}}
-                      {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
-                      {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me signed in for 30 days.{{/check-label}}
-                    {{/check}}
+                    {{#> alignment alignment--type="center" alignment--modifier="pf-u-text-align-left-on-md"}}
+                      {{#> check}}
+                        {{#> check-input check-input--attribute='type="checkbox" id="login-demo-checkbox" name="login-demo-checkbox"'}}{{/check-input}}
+                        {{#> check-label check-label--attribute='for="login-demo-checkbox"'}}Keep me signed in for 30 days.{{/check-label}}
+                      {{/check}}
+                    {{/alignment}}
                   {{/toolbar-item}}
                 {{/toolbar-group}}
               {{/toolbar}}
@@ -56,42 +56,52 @@
           {{/form}}
         {{/login-box-body}}
         {{#> login-box-footer}}
-          {{#> title titleType="h2" title--modifier="pf-m-md pf-u-mb-md"}}
+          {{#> title titleType="h2" title--modifier="pf-m-md pf-u-mb-md pf-u-text-align-center pf-u-text-align-left-on-md"}}
             Or log in with
           {{/title}}
           {{#> list list--modifier="pf-m-grid"}}
             <li>
-              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-pt-sm pf-u-pb-sm"}}
                 <img src="/assets/images/logo-google.svg" alt="" />
-                <p class="pf-u-ml-sm">Google</p>
+                {{#> display display--element="p" display--type="block-on-sm" display--modifier="pf-u-ml-sm pf-u-display-none"}}
+                  Google
+                {{/display}}
               {{/display}}
             </li>
             <li>
-              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-pt-sm pf-u-pb-sm"}}
                 <img src="/assets/images/logo-github.svg" alt="" />
-                <p class="pf-u-ml-sm">GitHub</p>
+                {{#> display display--element="p" display--type="block-on-sm" display--modifier="pf-u-ml-sm pf-u-display-none"}}
+                  GitHub
+                {{/display}}
               {{/display}}
             </li>
             <li>
-              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-pt-sm pf-u-pb-sm"}}
                 <img src="/assets/images/logo-dropbox.svg" alt="" />
-                <p class="pf-u-ml-sm">Dropbox</p>
+                {{#> display display--element="p" display--type="block-on-sm" display--modifier="pf-u-ml-sm pf-u-display-none"}}
+                  Dropbox
+                {{/display}}
               {{/display}}
             </li>
             <li>
-              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-pt-sm pf-u-pb-sm"}}
                 <img src="/assets/images/logo-facebook.svg" alt="" />
-                <p class="pf-u-ml-sm">Facebook</p>
+                {{#> display display--element="p" display--type="block-on-sm" display--modifier="pf-u-ml-sm pf-u-display-none"}}
+                  Facebook
+                {{/display}}
               {{/display}}
             </li>
             <li>
-              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm"}}
+              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-pt-sm pf-u-pb-sm"}}
                 <img class="" src="/assets/images/logo-gitlab.svg" alt="" />
-                <p class="pf-u-ml-sm">GitLab</p>
+                {{#> display display--element="p" display--type="block-on-sm" display--modifier="pf-u-ml-sm pf-u-display-none"}}
+                  GitLab
+                {{/display}}
               {{/display}}
             </li>
             <li>
-              {{#> display display--element="a" display--type="flex" display--modifier="pf-u-align-items-center pf-u-mt-sm pf-u-mb-sm pf-m-link"}}
+              {{#> display display--element="button" display--attribute='id="login-more"' display--modifier="pf-c-button pf-m-link pf-u-align-items-center pf-u-pt-sm pf-u-pb-sm"}}
                 More...
               {{/display}}
             </li>

--- a/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
+++ b/src/patternfly/demos/LoginPage/examples/login-page-simple-example.hbs
@@ -56,7 +56,9 @@
           {{/form}}
         {{/login-box-body}}
         {{#> login-box-footer}}
-          <p class="pf-u-mb-md">Or log in with</p>
+          {{#> title titleType="h2" title--modifier="pf-m-md pf-u-mb-md"}}
+            Or log in with
+          {{/title}}
           {{#> list list--modifier="pf-m-grid"}}
             <li>
               <a href="#">


### PR DESCRIPTION
Adds form and list components to the login demo. Input styling doesn’t align with the mockup, but it should in the future when the new FormControl is implemented (the current alternative input style is being ditched).

This closes #717.