### PR TITLE
fix(button): Disable text selection within buttons

### DIFF
--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -110,11 +110,6 @@
   line-height: var(--pf-c-button--LineHeight);
   text-align: center;
   white-space: nowrap;
-  /* stylelint-disable */
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  /* stylelint-enable */
   user-select: none;
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -110,6 +110,12 @@
   line-height: var(--pf-c-button--LineHeight);
   text-align: center;
   white-space: nowrap;
+  /* stylelint-disable */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  /* stylelint-enable */
+  user-select: none;
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
 


### PR DESCRIPTION
Adds `user-select: none;` (and necessary vendor prefixes) to disable text selection within the button component and any of its sub-elements.

This closes #802.