### PR TITLE
fix(alignment): Update class name documentation

### DIFF
--- a/src/patternfly/utilities/Alignment/docs/code.md
+++ b/src/patternfly/utilities/Alignment/docs/code.md
@@ -13,7 +13,7 @@ Breakpoint is optional. Breakpoints: base (no breakpoint value), -on-sm, -on-md,
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-u-text-left{-on-[breakpoint]}` | `*` |  Aligns text left |
-| `.pf-u-text-center{-on-[breakpoint]}` | `*` |  Aligns text center |
-| `.pf-u-text-right{-on-[breakpoint]}` | `*` |  Aligns text right |
-| `.pf-u-text-justify{-on-[breakpoint]}` | `*` |  Aligns text justify |
+| `.pf-u-text-align-left{-on-[breakpoint]}` | `*` |  Aligns text left |
+| `.pf-u-text-align-center{-on-[breakpoint]}` | `*` |  Aligns text center |
+| `.pf-u-text-align-right{-on-[breakpoint]}` | `*` |  Aligns text right |
+| `.pf-u-text-align-justify{-on-[breakpoint]}` | `*` |  Aligns text justify |


### PR DESCRIPTION
Adds `align` to the utility class names in the documentation. Resolves #812.