### PR TITLE
Masthead scroll

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-  "prettier.stylelintIntegration": true
+  "prettier.stylelintIntegration": true,
+  "files.autoSave": "afterDelay"
 }
   

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "prettier.stylelintIntegration": true,
-  "files.autoSave": "afterDelay"
-}
-  

--- a/src/patternfly/components/Nav/docs/code.md
+++ b/src/patternfly/components/Nav/docs/code.md
@@ -29,7 +29,7 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__link`                     | `<a>`                                   | Initiates default nav list link |
 | `.pf-c-nav__section`                  | `<section>`                             | Initiates a nav section element |
 | `.pf-c-nav__section-title`            | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`                        | Initiates a nav section title |
-| `.pf-c-nav__toggl`                    | `<span>`                                | Initiates a chevron indicating expandability of a `pf-c-nav__list-link` |
+| `.pf-c-nav__toggle`                    | `<span>`                                | Initiates a chevron indicating expandability of a `pf-c-nav__list-link` |
 | `.pf-m-expandable`                    | `.pf-c-nav__item`                       | Modifies for the expandable state |
 | `.pf-m-expanded`                      | `.pf-c-nav__item`                       | Modifies for the expanded state |
 | `.pf-m-hover`                         | `.pf-c-nav__link`                       | Modifies to display the link as hovered |

--- a/src/patternfly/components/Nav/nav.hbs
+++ b/src/patternfly/components/Nav/nav.hbs
@@ -1,28 +1,4 @@
 <nav class="pf-c-nav{{#if nav--modifier}} {{nav--modifier}}{{/if}}"
-  {{#if nav--interactive}}
-    onClick="(function(){
-      const target = event.target;
-      const parent = target.parentNode;
-      const child = parent.children[1];
-
-      if (target.classList.contains('pf-c-nav__link')) {
-        if (parent.classList.contains('pf-m-expanded')) {
-          parent.classList.remove('pf-m-expanded');
-          setTimeout(() => {
-            child.setAttribute('aria-expanded', 'false');
-            child.setAttribute('hidden', '');
-          }, 600);
-        } else {
-          child.removeAttribute('hidden');
-          setTimeout(() => {
-            parent.classList.add('pf-m-expanded');
-            child.setAttribute('aria-expanded', 'true');
-          }, 50);
-        }
-      }
-      return false;
-    })();return false;"
-  {{/if}}
   {{#if nav--attribute}}
     {{{nav--attribute}}}
   {{/if}}>

--- a/src/patternfly/demos/PageLayout/examples/page-layout-default-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-default-nav-example.hbs
@@ -1,51 +1,51 @@
 {{#> background-image}}
 {{/background-image}}
-{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-default-nav"'}}
-{{#> page-header page-header--modifier="pf-m-condensed"}}
-{{!-- Brand --}}
-{{#> page-header-brand}}
-{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-{{/page-template-header-brand-elements}}
-{{/page-header-brand}}
-{{#> page-template-header-tools-elements}}
-{{/page-template-header-tools-elements}}
-{{/page-header}}
-{{!-- Nav --}}
-{{#> page-sidebar}}
-{{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav Default Example"'}}
-{{#> nav-list}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#" nav-link--current="true"}}
-System Panel
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Policy
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Authentication
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Network Services
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Server
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav}}
-{{/page-sidebar}}
-{{#> page-main}}
-{{#> page-template-title}}
-{{/page-template-title}}
-{{#> page-template-gallery}}
-{{/page-template-gallery}}
-{{/page-main}}
+{{#> page page--attribute='id="page-layout-default-nav"'}}
+  {{#> page-header}}
+    {{!-- Brand --}}
+    {{#> page-header-brand}}
+      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+      {{/page-template-header-brand-elements}}
+    {{/page-header-brand}}
+    {{#> page-template-header-tools-elements}}
+    {{/page-template-header-tools-elements}}
+  {{/page-header}}
+  {{!-- Nav --}}
+  {{#> page-sidebar}}  
+    {{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav Default Example"'}}
+      {{#> nav-list}}
+        {{#> nav-item}}
+          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+            System Panel
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item}}
+          {{#> nav-link nav-link--href="#"}}
+            Policy
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item}}
+          {{#> nav-link nav-link--href="#"}}
+            Authentication
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item}}
+          {{#> nav-link nav-link--href="#"}}
+            Network Services
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item}}
+          {{#> nav-link nav-link--href="#"}}
+            Server
+          {{/nav-link}}
+        {{/nav-item}}
+      {{/nav-list}}
+    {{/nav}}
+  {{/page-sidebar}}
+  {{#> page-main}}
+    {{#> page-template-title}}
+    {{/page-template-title}}
+    {{#> page-template-gallery}}
+    {{/page-template-gallery}}
+  {{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-default-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-default-nav-example.hbs
@@ -1,51 +1,51 @@
 {{#> background-image}}
 {{/background-image}}
-{{#> page page--attribute='id="page"'}}
-  {{#> page-header}}
-    {{!-- Brand --}}
-    {{#> page-header-brand}}
-      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-      {{/page-template-header-brand-elements}}
-    {{/page-header-brand}}
-    {{#> page-template-header-tools-elements}}
-    {{/page-template-header-tools-elements}}
-  {{/page-header}}
-  {{!-- Nav --}}
-  {{#> page-sidebar}}  
-    {{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav Default Example"'}}
-      {{#> nav-list}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-            System Panel
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Policy
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Authentication
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Network Services
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item}}
-          {{#> nav-link nav-link--href="#"}}
-            Server
-          {{/nav-link}}
-        {{/nav-item}}
-      {{/nav-list}}
-    {{/nav}}
-  {{/page-sidebar}}
-  {{#> page-main}}
-    {{#> page-template-title}}
-    {{/page-template-title}}
-    {{#> page-template-gallery}}
-    {{/page-template-gallery}}
-  {{/page-main}}
+{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-default-nav"'}}
+{{#> page-header page-header--modifier="pf-m-condensed"}}
+{{!-- Brand --}}
+{{#> page-header-brand}}
+{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+{{/page-template-header-brand-elements}}
+{{/page-header-brand}}
+{{#> page-template-header-tools-elements}}
+{{/page-template-header-tools-elements}}
+{{/page-header}}
+{{!-- Nav --}}
+{{#> page-sidebar}}
+{{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav Default Example"'}}
+{{#> nav-list}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#" nav-link--current="true"}}
+System Panel
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Policy
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Authentication
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Network Services
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Server
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav}}
+{{/page-sidebar}}
+{{#> page-main}}
+{{#> page-template-title}}
+{{/page-template-title}}
+{{#> page-template-gallery}}
+{{/page-template-gallery}}
+{{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-expandable-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-expandable-nav-example.hbs
@@ -1,135 +1,135 @@
 {{#> background-image}}
 {{/background-image}}
 
-{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-expandable-nav"'}}
-{{#> page-header}}
-{{!-- Brand --}}
-{{#> page-header-brand}}
-{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-{{/page-template-header-brand-elements}}
-{{/page-header-brand}}
-{{#> page-template-header-tools-elements}}
-{{/page-template-header-tools-elements}}
-{{/page-header}}
+{{#> page page--attribute='id="page-layout-expandable-nav"'}}
+  {{#> page-header}}
+    {{!-- Brand --}}
+    {{#> page-header-brand}}
+      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+      {{/page-template-header-brand-elements}}
+    {{/page-header-brand}}
+    {{#> page-template-header-tools-elements}}
+    {{/page-template-header-tools-elements}}
+  {{/page-header}}
 
-{{#> page-sidebar}}
-{{#> nav nav--expandable="true" nav--attribute='id="primary-nav" aria-label="Primary Nav Expandable Example"'}}
-{{#> nav-list}}
-{{#> nav-item nav-item--expandable="true" nav-item--expanded="true" nav-item--current="true"}}
-{{#> nav-link nav-link--href="#" nav-link--attribute='id="link1"'}}
-System Panel
-{{/nav-link}}
-{{#> nav-subnav nav-subnav--attribute='aria-labelledby="link1"'}}
-{{#> nav-list nav-list--type="simple"}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Overview
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#" nav-link--current="true"}}
-Resource Usage
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Hypervisors
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Instances
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Volumes
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Networks
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav-subnav}}
-{{/nav-item}}
-{{#> nav-item nav-item--expandable="true"}}
-{{#> nav-link nav-link--href="#" nav-link--attribute='id="link2"'}}
-Policy
-{{/nav-link}}
-{{#> nav-subnav nav-subnav--attribute='aria-labelledby="link2"'}}
-{{#> nav-list nav-list--type="simple"}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Subnav link 1
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Subnav link 2
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav-subnav}}
-{{/nav-item}}
-{{#> nav-item nav-item--expandable="true"}}
-{{#> nav-link nav-link--href="#" nav-link--attribute='id="link3"'}}
-Authentication
-{{/nav-link}}
-{{#> nav-subnav nav-subnav--attribute='aria-labelledby="link3"'}}
-{{#> nav-list nav-list--type="simple"}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Subnav link 1
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Subnav link 2
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav-subnav}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav}}
-{{/page-sidebar}}
-{{#> page-main}}
-{{#> page-main-nav}}
-{{#> nav nav--attribute='aria-label="Tertiary Example"' aria-labelledby="primary-nav"}}
-{{#> nav-list nav-list--type="tertiary"}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#" nav-link--current="true"}}
-Nav Item 1
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Nav Item 2
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Nav Item 3
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Nav Item 4
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Nav Item 5
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav}}
-{{/page-main-nav}}
-{{#> page-template-title}}
-{{/page-template-title}}
-{{#> page-template-gallery}}
-{{/page-template-gallery}}
-{{/page-main}}
+  {{#> page-sidebar}}  
+    {{#> nav nav--expandable="true" nav--attribute='id="primary-nav" aria-label="Primary Nav Expandable Example"'}}
+      {{#> nav-list}}
+        {{#> nav-item nav-item--expandable="true" nav-item--expanded="true" nav-item--current="true"}}
+          {{#> nav-link nav-link--href="#" nav-link--attribute='id="link1"'}}
+            System Panel
+          {{/nav-link}}
+          {{#> nav-subnav nav-subnav--attribute='aria-labelledby="link1"'}}
+            {{#> nav-list nav-list--type="simple"}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Overview
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+                  Resource Usage
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Hypervisors
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Instances
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Volumes
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Networks
+                {{/nav-link}}
+              {{/nav-item}}
+            {{/nav-list}}
+          {{/nav-subnav}}
+        {{/nav-item}}
+        {{#> nav-item nav-item--expandable="true"}}
+          {{#> nav-link nav-link--href="#" nav-link--attribute='id="link2"'}}
+            Policy
+          {{/nav-link}}
+          {{#> nav-subnav nav-subnav--attribute='aria-labelledby="link2"'}}
+            {{#> nav-list nav-list--type="simple"}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Subnav link 1
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Subnav link 2
+                {{/nav-link}}
+              {{/nav-item}}
+            {{/nav-list}}
+          {{/nav-subnav}}
+        {{/nav-item}}
+        {{#> nav-item nav-item--expandable="true"}}
+          {{#> nav-link nav-link--href="#" nav-link--attribute='id="link3"'}}
+            Authentication
+          {{/nav-link}}
+          {{#> nav-subnav nav-subnav--attribute='aria-labelledby="link3"'}}
+            {{#> nav-list nav-list--type="simple"}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Subnav link 1
+                {{/nav-link}}
+              {{/nav-item}}
+              {{#> nav-item newcontent}}
+                {{#> nav-link nav-link--href="#"}}
+                  Subnav link 2
+                {{/nav-link}}
+              {{/nav-item}}
+            {{/nav-list}}
+          {{/nav-subnav}}
+        {{/nav-item}}
+      {{/nav-list}}
+    {{/nav}}
+  {{/page-sidebar}}
+  {{#> page-main}}
+    {{#> page-main-nav}}
+      {{#> nav nav--attribute='aria-label="Tertiary Example"' aria-labelledby="primary-nav"}}
+        {{#> nav-list nav-list--type="tertiary"}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+              Nav Item 1
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Nav Item 2
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Nav Item 3
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Nav Item 4
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Nav Item 5
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav}}
+    {{/page-main-nav}}
+    {{#> page-template-title}}
+    {{/page-template-title}}
+    {{#> page-template-gallery}}
+    {{/page-template-gallery}}
+  {{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-expandable-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-expandable-nav-example.hbs
@@ -1,135 +1,135 @@
 {{#> background-image}}
 {{/background-image}}
 
-{{#> page page--attribute='id="page"'}}
-  {{#> page-header}}
-    {{!-- Brand --}}
-    {{#> page-header-brand}}
-      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-      {{/page-template-header-brand-elements}}
-    {{/page-header-brand}}
-    {{#> page-template-header-tools-elements}}
-    {{/page-template-header-tools-elements}}
-  {{/page-header}}
+{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-expandable-nav"'}}
+{{#> page-header}}
+{{!-- Brand --}}
+{{#> page-header-brand}}
+{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+{{/page-template-header-brand-elements}}
+{{/page-header-brand}}
+{{#> page-template-header-tools-elements}}
+{{/page-template-header-tools-elements}}
+{{/page-header}}
 
-  {{#> page-sidebar}}  
-    {{#> nav nav--interactive="true" nav--expandable="true" nav--attribute='id="primary-nav" aria-label="Primary Nav Expandable Example"'}}
-      {{#> nav-list}}
-        {{#> nav-item nav-item--expandable="true" nav-item--expanded="true" nav-item--current="true"}}
-          {{#> nav-link nav-link--href="#" nav-link--attribute='id="link1"'}}
-            System Panel
-          {{/nav-link}}
-          {{#> nav-subnav nav-subnav--attribute='aria-labelledby="link1"'}}
-            {{#> nav-list nav-list--type="simple"}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Overview
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-                  Resource Usage
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Hypervisors
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Instances
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Volumes
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Networks
-                {{/nav-link}}
-              {{/nav-item}}
-            {{/nav-list}}
-          {{/nav-subnav}}
-        {{/nav-item}}
-        {{#> nav-item nav-item--expandable="true"}}
-          {{#> nav-link nav-link--href="#" nav-link--attribute='id="link2"'}}
-            Policy
-          {{/nav-link}}
-          {{#> nav-subnav nav-subnav--attribute='aria-labelledby="link2"'}}
-            {{#> nav-list nav-list--type="simple"}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Subnav link 1
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Subnav link 2
-                {{/nav-link}}
-              {{/nav-item}}
-            {{/nav-list}}
-          {{/nav-subnav}}
-        {{/nav-item}}
-        {{#> nav-item nav-item--expandable="true"}}
-          {{#> nav-link nav-link--href="#" nav-link--attribute='id="link3"'}}
-            Authentication
-          {{/nav-link}}
-          {{#> nav-subnav nav-subnav--attribute='aria-labelledby="link3"'}}
-            {{#> nav-list nav-list--type="simple"}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Subnav link 1
-                {{/nav-link}}
-              {{/nav-item}}
-              {{#> nav-item newcontent}}
-                {{#> nav-link nav-link--href="#"}}
-                  Subnav link 2
-                {{/nav-link}}
-              {{/nav-item}}
-            {{/nav-list}}
-          {{/nav-subnav}}
-        {{/nav-item}}
-      {{/nav-list}}
-    {{/nav}}
-  {{/page-sidebar}}
-  {{#> page-main}}
-    {{#> page-main-nav}}
-      {{#> nav nav--attribute='aria-label="Tertiary Example"' aria-labelledby="primary-nav"}}
-        {{#> nav-list nav-list--type="tertiary"}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Nav Item 1
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Nav Item 2
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Nav Item 3
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Nav Item 4
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Nav Item 5
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav}}
-    {{/page-main-nav}}
-    {{#> page-template-title}}
-    {{/page-template-title}}
-    {{#> page-template-gallery}}
-    {{/page-template-gallery}}
-  {{/page-main}}
+{{#> page-sidebar}}
+{{#> nav nav--expandable="true" nav--attribute='id="primary-nav" aria-label="Primary Nav Expandable Example"'}}
+{{#> nav-list}}
+{{#> nav-item nav-item--expandable="true" nav-item--expanded="true" nav-item--current="true"}}
+{{#> nav-link nav-link--href="#" nav-link--attribute='id="link1"'}}
+System Panel
+{{/nav-link}}
+{{#> nav-subnav nav-subnav--attribute='aria-labelledby="link1"'}}
+{{#> nav-list nav-list--type="simple"}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Overview
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#" nav-link--current="true"}}
+Resource Usage
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Hypervisors
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Instances
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Volumes
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Networks
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav-subnav}}
+{{/nav-item}}
+{{#> nav-item nav-item--expandable="true"}}
+{{#> nav-link nav-link--href="#" nav-link--attribute='id="link2"'}}
+Policy
+{{/nav-link}}
+{{#> nav-subnav nav-subnav--attribute='aria-labelledby="link2"'}}
+{{#> nav-list nav-list--type="simple"}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Subnav link 1
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Subnav link 2
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav-subnav}}
+{{/nav-item}}
+{{#> nav-item nav-item--expandable="true"}}
+{{#> nav-link nav-link--href="#" nav-link--attribute='id="link3"'}}
+Authentication
+{{/nav-link}}
+{{#> nav-subnav nav-subnav--attribute='aria-labelledby="link3"'}}
+{{#> nav-list nav-list--type="simple"}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Subnav link 1
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Subnav link 2
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav-subnav}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav}}
+{{/page-sidebar}}
+{{#> page-main}}
+{{#> page-main-nav}}
+{{#> nav nav--attribute='aria-label="Tertiary Example"' aria-labelledby="primary-nav"}}
+{{#> nav-list nav-list--type="tertiary"}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#" nav-link--current="true"}}
+Nav Item 1
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Nav Item 2
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Nav Item 3
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Nav Item 4
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Nav Item 5
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav}}
+{{/page-main-nav}}
+{{#> page-template-title}}
+{{/page-template-title}}
+{{#> page-template-gallery}}
+{{/page-template-gallery}}
+{{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-grouped-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-grouped-nav-example.hbs
@@ -1,92 +1,92 @@
 {{#> background-image}}
 {{/background-image}}
 
-{{#> page page--attribute='id="page"'}}
-  {{#> page-header}}
-    {{#> page-header-brand}}
-      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-      {{/page-template-header-brand-elements}}
-    {{/page-header-brand}}
-    {{#> page-header-selector}}
-      pf-c-context-selector
-    {{/page-header-selector}}
-    {{#> page-template-header-tools-elements}}
-    {{/page-template-header-tools-elements}}
-  {{/page-header}}
-  {{#> page-sidebar}}  
-    {{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
-      {{#> nav-section nav-section--attribute='aria-labelledby="grouped-title1"'}}
-        {{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
-          System Panel
-        {{/nav-section-title}}
-        {{#> nav-list nav-list--type="simple"}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Overview
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Resource Usage
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Hypervisors
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Instances
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Volumes
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Networks
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav-section}}
-      {{#> nav-section nav-section--attribute='aria-labelledby="grouped-title2"'}}
-        {{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
-          Policy
-        {{/nav-section-title}}
-        {{#> nav-list nav-list--type="simple"}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Hosts
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Virtual Machines
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item newcontent}}
-            {{#> nav-link nav-link--href="#"}}
-              Storage
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav-section}}
-    {{/nav}}
-  {{/page-sidebar}}
-  {{#> page-main}}
-    {{#> page-template-title}}
-    {{/page-template-title}}
-    {{#> page-main-section page-main-section--modifier="pf-m-light"}}
-      Light content
-    {{/page-main-section}}
-    {{#> page-main-section page-main-section--modifier="pf-m-dark-200"}}
-      Dark content
-    {{/page-main-section}}
-    {{#> page-main-section}}
-      Content
-    {{/page-main-section}}
-  {{/page-main}}
+{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-grouped-nav"'}}
+{{#> page-header}}
+{{#> page-header-brand}}
+{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+{{/page-template-header-brand-elements}}
+{{/page-header-brand}}
+{{#> page-header-selector}}
+pf-c-context-selector
+{{/page-header-selector}}
+{{#> page-template-header-tools-elements}}
+{{/page-template-header-tools-elements}}
+{{/page-header}}
+{{#> page-sidebar}}
+{{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
+{{#> nav-section nav-section--attribute='aria-labelledby="grouped-title1"'}}
+{{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
+System Panel
+{{/nav-section-title}}
+{{#> nav-list nav-list--type="simple"}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Overview
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Resource Usage
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#" nav-link--current="true"}}
+Hypervisors
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Instances
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Volumes
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Networks
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav-section}}
+{{#> nav-section nav-section--attribute='aria-labelledby="grouped-title2"'}}
+{{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
+Policy
+{{/nav-section-title}}
+{{#> nav-list nav-list--type="simple"}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Hosts
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Virtual Machines
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Storage
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav-section}}
+{{/nav}}
+{{/page-sidebar}}
+{{#> page-main}}
+{{#> page-template-title}}
+{{/page-template-title}}
+{{#> page-main-section page-main-section--modifier="pf-m-light"}}
+Light content
+{{/page-main-section}}
+{{#> page-main-section page-main-section--modifier="pf-m-dark-200"}}
+Dark content
+{{/page-main-section}}
+{{#> page-main-section}}
+Content
+{{/page-main-section}}
+{{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-grouped-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-grouped-nav-example.hbs
@@ -1,92 +1,92 @@
 {{#> background-image}}
 {{/background-image}}
 
-{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-grouped-nav"'}}
-{{#> page-header}}
-{{#> page-header-brand}}
-{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-{{/page-template-header-brand-elements}}
-{{/page-header-brand}}
-{{#> page-header-selector}}
-pf-c-context-selector
-{{/page-header-selector}}
-{{#> page-template-header-tools-elements}}
-{{/page-template-header-tools-elements}}
-{{/page-header}}
-{{#> page-sidebar}}
-{{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
-{{#> nav-section nav-section--attribute='aria-labelledby="grouped-title1"'}}
-{{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
-System Panel
-{{/nav-section-title}}
-{{#> nav-list nav-list--type="simple"}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Overview
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Resource Usage
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#" nav-link--current="true"}}
-Hypervisors
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Instances
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Volumes
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Networks
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav-section}}
-{{#> nav-section nav-section--attribute='aria-labelledby="grouped-title2"'}}
-{{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
-Policy
-{{/nav-section-title}}
-{{#> nav-list nav-list--type="simple"}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Hosts
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Virtual Machines
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Storage
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav-section}}
-{{/nav}}
-{{/page-sidebar}}
-{{#> page-main}}
-{{#> page-template-title}}
-{{/page-template-title}}
-{{#> page-main-section page-main-section--modifier="pf-m-light"}}
-Light content
-{{/page-main-section}}
-{{#> page-main-section page-main-section--modifier="pf-m-dark-200"}}
-Dark content
-{{/page-main-section}}
-{{#> page-main-section}}
-Content
-{{/page-main-section}}
-{{/page-main}}
+{{#> page page--attribute='id="page-layout-grouped-nav"'}}
+  {{#> page-header}}
+    {{#> page-header-brand}}
+      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+      {{/page-template-header-brand-elements}}
+    {{/page-header-brand}}
+    {{#> page-header-selector}}
+      pf-c-context-selector
+    {{/page-header-selector}}
+    {{#> page-template-header-tools-elements}}
+    {{/page-template-header-tools-elements}}
+  {{/page-header}}
+  {{#> page-sidebar}}  
+    {{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
+      {{#> nav-section nav-section--attribute='aria-labelledby="grouped-title1"'}}
+        {{#> nav-section-title nav-section-title--attribute='id="grouped-title1"'}}
+          System Panel
+        {{/nav-section-title}}
+        {{#> nav-list nav-list--type="simple"}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Overview
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Resource Usage
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+              Hypervisors
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Instances
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Volumes
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Networks
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav-section}}
+      {{#> nav-section nav-section--attribute='aria-labelledby="grouped-title2"'}}
+        {{#> nav-section-title nav-section-title--attribute='id="grouped-title2"'}}
+          Policy
+        {{/nav-section-title}}
+        {{#> nav-list nav-list--type="simple"}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Hosts
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Virtual Machines
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item newcontent}}
+            {{#> nav-link nav-link--href="#"}}
+              Storage
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav-section}}
+    {{/nav}}
+  {{/page-sidebar}}
+  {{#> page-main}}
+    {{#> page-template-title}}
+    {{/page-template-title}}
+    {{#> page-main-section page-main-section--modifier="pf-m-light"}}
+      Light content
+    {{/page-main-section}}
+    {{#> page-main-section page-main-section--modifier="pf-m-dark-200"}}
+      Dark content
+    {{/page-main-section}}
+    {{#> page-main-section}}
+      Content
+    {{/page-main-section}}
+  {{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-horizontal-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-horizontal-nav-example.hbs
@@ -1,53 +1,52 @@
 {{#> background-image}}
 {{/background-image}}
-{{#> page page--attribute='id="page"' page--modifier="pf-m-exanded"}}
-  {{#> page-header}}
-    {{#> page-header-brand page-header-brand--modifier="pf-u-sr-only pf-u-visible-on-md"}}
-      {{#> page-template-header-brand-elements}}
-      {{/page-template-header-brand-elements}}
-    {{/page-header-brand}}
-    {{#> page-header-selector}}
-      pf-c-context-selector
-    {{/page-header-selector}}
-    {{#> page-header-nav}}
-      {{#> nav nav--horizontal="true" nav--attribute='id="nav-primary" aria-label="Primary Nav Default Example"'}}
-        {{#> nav-list nav-list--type="horizontal"}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-              Nav Item 1
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Nav Item 2
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Link 3
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Link 4
-            {{/nav-link}}
-          {{/nav-item}}
-          {{#> nav-item}}
-            {{#> nav-link nav-link--href="#"}}
-              Link 5
-            {{/nav-link}}
-          {{/nav-item}}
-        {{/nav-list}}
-      {{/nav}}
-    {{/page-header-nav}}
-    {{#> page-template-header-tools-elements}}
-    {{/page-template-header-tools-elements}}
-  {{/page-header}}
-  {{#> page-main}}
-    {{#> page-template-title}}
-    {{/page-template-title}}
-    {{#> page-template-gallery}}
-    {{/page-template-gallery}}
-  {{/page-main}}
+{{#> page page--attribute='id="page-layout-horizontal-nav"' page--modifier="pf-m-scroll-content"}}
+{{#> page-header}}
+{{#> page-header-brand page-header-brand--modifier="pf-u-sr-only pf-u-visible-on-md"}}
+{{#> page-template-header-brand-elements}}
+{{/page-template-header-brand-elements}}
+{{/page-header-brand}}
+{{#> page-header-selector}}
+pf-c-context-selector
+{{/page-header-selector}}
+{{#> page-header-nav}}
+{{#> nav nav--horizontal="true" nav--attribute='id="nav-primary" aria-label="Primary Nav Default Example"'}}
+{{#> nav-list nav-list--type="horizontal"}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#" nav-link--current="true"}}
+Nav Item 1
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Nav Item 2
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Link 3
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Link 4
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item}}
+{{#> nav-link nav-link--href="#"}}
+Link 5
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav}}
+{{/page-header-nav}}
+{{#> page-template-header-tools-elements}}
+{{/page-template-header-tools-elements}}
+{{/page-header}}
+{{#> page-main}}
+{{#> page-template-title}}
+{{/page-template-title}}
+{{#> page-template-gallery}}
+{{/page-template-gallery}}
+{{/page-main}}
 {{/page}}
-

--- a/src/patternfly/demos/PageLayout/examples/page-layout-horizontal-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-horizontal-nav-example.hbs
@@ -1,52 +1,53 @@
 {{#> background-image}}
 {{/background-image}}
-{{#> page page--attribute='id="page-layout-horizontal-nav"' page--modifier="pf-m-scroll-content"}}
-{{#> page-header}}
-{{#> page-header-brand page-header-brand--modifier="pf-u-sr-only pf-u-visible-on-md"}}
-{{#> page-template-header-brand-elements}}
-{{/page-template-header-brand-elements}}
-{{/page-header-brand}}
-{{#> page-header-selector}}
-pf-c-context-selector
-{{/page-header-selector}}
-{{#> page-header-nav}}
-{{#> nav nav--horizontal="true" nav--attribute='id="nav-primary" aria-label="Primary Nav Default Example"'}}
-{{#> nav-list nav-list--type="horizontal"}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#" nav-link--current="true"}}
-Nav Item 1
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Nav Item 2
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Link 3
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Link 4
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item}}
-{{#> nav-link nav-link--href="#"}}
-Link 5
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav}}
-{{/page-header-nav}}
-{{#> page-template-header-tools-elements}}
-{{/page-template-header-tools-elements}}
-{{/page-header}}
-{{#> page-main}}
-{{#> page-template-title}}
-{{/page-template-title}}
-{{#> page-template-gallery}}
-{{/page-template-gallery}}
-{{/page-main}}
+{{#> page page--attribute='id="page-layout-horizontal-nav"'}}
+  {{#> page-header}}
+    {{#> page-header-brand page-header-brand--modifier="pf-u-sr-only pf-u-visible-on-md"}}
+      {{#> page-template-header-brand-elements}}
+      {{/page-template-header-brand-elements}}
+    {{/page-header-brand}}
+    {{#> page-header-selector}}
+      pf-c-context-selector
+    {{/page-header-selector}}
+    {{#> page-header-nav}}
+      {{#> nav nav--horizontal="true" nav--attribute='id="nav-primary" aria-label="Primary Nav Default Example"'}}
+        {{#> nav-list nav-list--type="horizontal"}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+              Nav Item 1
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Nav Item 2
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Link 3
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Link 4
+            {{/nav-link}}
+          {{/nav-item}}
+          {{#> nav-item}}
+            {{#> nav-link nav-link--href="#"}}
+              Link 5
+            {{/nav-link}}
+          {{/nav-item}}
+        {{/nav-list}}
+      {{/nav}}
+    {{/page-header-nav}}
+    {{#> page-template-header-tools-elements}}
+    {{/page-template-header-tools-elements}}
+  {{/page-header}}
+  {{#> page-main}}
+    {{#> page-template-title}}
+    {{/page-template-title}}
+    {{#> page-template-gallery}}
+    {{/page-template-gallery}}
+  {{/page-main}}
 {{/page}}
+

--- a/src/patternfly/demos/PageLayout/examples/page-layout-simple-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-simple-nav-example.hbs
@@ -1,55 +1,55 @@
 {{#> background-image}}
 {{/background-image}}
-{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-simple-nav"'}}
-{{#> page-header}}
-{{!-- Brand --}}
-{{#> page-header-brand}}
-{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-{{/page-template-header-brand-elements}}
-{{/page-header-brand}}
-{{#> page-template-header-tools-elements}}
-{{/page-template-header-tools-elements}}
-{{/page-header}}
-{{#> page-sidebar}}
-{{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
-{{#> nav-list nav-list--type="simple"}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Overview
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Resource Usage
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#" nav-link--current="true"}}
-Hypervisors
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Instances
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Volumes
-{{/nav-link}}
-{{/nav-item}}
-{{#> nav-item newcontent}}
-{{#> nav-link nav-link--href="#"}}
-Networks
-{{/nav-link}}
-{{/nav-item}}
-{{/nav-list}}
-{{/nav}}
-{{/page-sidebar}}
-{{#> page-main}}
-{{#> page-template-title}}
-{{/page-template-title}}
-{{#> page-template-gallery}}
-{{/page-template-gallery}}
-{{/page-main}}
+{{#> page page--attribute='id="page-layout-simple-nav"'}}
+  {{#> page-header}}
+    {{!-- Brand --}}
+    {{#> page-header-brand}}
+      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+      {{/page-template-header-brand-elements}}
+    {{/page-header-brand}}
+    {{#> page-template-header-tools-elements}}
+    {{/page-template-header-tools-elements}}
+  {{/page-header}}
+  {{#> page-sidebar}}  
+    {{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
+      {{#> nav-list nav-list--type="simple"}}
+        {{#> nav-item newcontent}}
+          {{#> nav-link nav-link--href="#"}}
+            Overview
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item newcontent}}
+          {{#> nav-link nav-link--href="#"}}
+            Resource Usage
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item newcontent}}
+          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
+            Hypervisors
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item newcontent}}
+          {{#> nav-link nav-link--href="#"}}
+            Instances
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item newcontent}}
+          {{#> nav-link nav-link--href="#"}}
+            Volumes
+          {{/nav-link}}
+        {{/nav-item}}
+        {{#> nav-item newcontent}}
+          {{#> nav-link nav-link--href="#"}}
+            Networks
+          {{/nav-link}}
+        {{/nav-item}}
+      {{/nav-list}}
+    {{/nav}}
+  {{/page-sidebar}}  
+  {{#> page-main}}
+    {{#> page-template-title}}
+    {{/page-template-title}}
+    {{#> page-template-gallery}}
+    {{/page-template-gallery}}
+  {{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-simple-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-simple-nav-example.hbs
@@ -1,55 +1,55 @@
 {{#> background-image}}
 {{/background-image}}
-{{#> page page--attribute='id="page"'}}
-  {{#> page-header}}
-    {{!-- Brand --}}
-    {{#> page-header-brand}}
-      {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
-      {{/page-template-header-brand-elements}}
-    {{/page-header-brand}}
-    {{#> page-template-header-tools-elements}}
-    {{/page-template-header-tools-elements}}
-  {{/page-header}}
-  {{#> page-sidebar}}  
-    {{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
-      {{#> nav-list nav-list--type="simple"}}
-        {{#> nav-item newcontent}}
-          {{#> nav-link nav-link--href="#"}}
-            Overview
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item newcontent}}
-          {{#> nav-link nav-link--href="#"}}
-            Resource Usage
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item newcontent}}
-          {{#> nav-link nav-link--href="#" nav-link--current="true"}}
-            Hypervisors
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item newcontent}}
-          {{#> nav-link nav-link--href="#"}}
-            Instances
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item newcontent}}
-          {{#> nav-link nav-link--href="#"}}
-            Volumes
-          {{/nav-link}}
-        {{/nav-item}}
-        {{#> nav-item newcontent}}
-          {{#> nav-link nav-link--href="#"}}
-            Networks
-          {{/nav-link}}
-        {{/nav-item}}
-      {{/nav-list}}
-    {{/nav}}
-  {{/page-sidebar}}  
-  {{#> page-main}}
-    {{#> page-template-title}}
-    {{/page-template-title}}
-    {{#> page-template-gallery}}
-    {{/page-template-gallery}}
-  {{/page-main}}
+{{#> page page--modifier="pf-m-scroll-content" page--attribute='id="page-layout-simple-nav"'}}
+{{#> page-header}}
+{{!-- Brand --}}
+{{#> page-header-brand}}
+{{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
+{{/page-template-header-brand-elements}}
+{{/page-header-brand}}
+{{#> page-template-header-tools-elements}}
+{{/page-template-header-tools-elements}}
+{{/page-header}}
+{{#> page-sidebar}}
+{{#> nav nav--attribute='id="primary-nav" aria-label="Primary Nav, Simple List Example"'}}
+{{#> nav-list nav-list--type="simple"}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Overview
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Resource Usage
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#" nav-link--current="true"}}
+Hypervisors
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Instances
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Volumes
+{{/nav-link}}
+{{/nav-item}}
+{{#> nav-item newcontent}}
+{{#> nav-link nav-link--href="#"}}
+Networks
+{{/nav-link}}
+{{/nav-item}}
+{{/nav-list}}
+{{/nav}}
+{{/page-sidebar}}
+{{#> page-main}}
+{{#> page-template-title}}
+{{/page-template-title}}
+{{#> page-template-gallery}}
+{{/page-template-gallery}}
+{{/page-main}}
 {{/page}}

--- a/src/patternfly/demos/PageLayout/page-template-header-brand-elements.hbs
+++ b/src/patternfly/demos/PageLayout/page-template-header-brand-elements.hbs
@@ -2,21 +2,8 @@
   {{#> page-header-brand-toggle}}
     {{#> button button--modifier="pf-m-plain"
       button--attribute='id="nav-toggle"
-                      aria-label="Toggle primary navigation"
-                      onClick="(function(){
-        const mq = window.matchMedia(\'(min-width: 768px)\');
-        let page = document.getElementById(\'primary-nav\');
-              page = page.parentElement;
-
-        if (mq.matches) {
-          page.classList.remove(\'pf-m-expanded\');
-          page.classList.toggle(\'pf-m-collapsed\');
-        } else {
-          page.classList.remove(\'pf-m-collapsed\');
-          page.classList.toggle(\'pf-m-expanded\');
-        }
-          return false;
-      })();return false;"' button--HasBarsIcon="true"}}
+                      aria-label="Toggle primary navigation"' 
+      button--HasBarsIcon="true"}}
     {{/button}}
   {{/page-header-brand-toggle}}
 {{/if}}

--- a/src/patternfly/layouts/Page/docs/code.md
+++ b/src/patternfly/layouts/Page/docs/code.md
@@ -30,5 +30,4 @@ This layout provides the basic chrome for a page, including sidebar, header and 
 | `.pf-m-light` | `.pf-l-page__main-section` | Modifies a main page section to have a light theme. |
 | `.pf-m-dark-200` | `.pf-l-page__main-section` |  Modifies a main page section to have a dark theme and a dark transparent background. |
 | `.pf-m-dark-100` | `.pf-l-page__main-section` |  Modifies a main page section to have a dark theme and a darker transparent background. |
-| `.pf-m-scroll-content` | `.pf-l-page` |   Modifies page layout to have fixed/condensed header on scroll. |
 | `.pf-m-condensed` | `.pf-l-page__header` |   Modifies header to condensed height on scroll (this requires JS to toggle this class on scroll). |

--- a/src/patternfly/layouts/Page/docs/code.md
+++ b/src/patternfly/layouts/Page/docs/code.md
@@ -30,3 +30,5 @@ This layout provides the basic chrome for a page, including sidebar, header and 
 | `.pf-m-light` | `.pf-l-page__main-section` | Modifies a main page section to have a light theme. |
 | `.pf-m-dark-200` | `.pf-l-page__main-section` |  Modifies a main page section to have a dark theme and a dark transparent background. |
 | `.pf-m-dark-100` | `.pf-l-page__main-section` |  Modifies a main page section to have a dark theme and a darker transparent background. |
+| `.pf-m-scroll-content` | `.pf-l-page` |   Modifies page layout to have fixed/condensed header on scroll. |
+| `.pf-m-condensed` | `.pf-l-page__header` |   Modifies header to condensed height on scroll (this requires JS to toggle this class on scroll). |

--- a/src/patternfly/layouts/Page/page.hbs
+++ b/src/patternfly/layouts/Page/page.hbs
@@ -1,4 +1,4 @@
-<div class="pf-l-page{{#if page--expanded}} pf-m-expanded{{/if}}{{#if page--modifier}} {{page--modifier}}{{/if}}"
+<div class="pf-l-page{{#if page--modifier}} {{page--modifier}}{{/if}}"
   {{#if page--attribute}} 
     {{{page--attribute}}}
   {{/if}}>

--- a/src/patternfly/layouts/Page/page.scss
+++ b/src/patternfly/layouts/Page/page.scss
@@ -87,6 +87,10 @@ $nav: "pf-c-nav";
   --pf-l-page__main-section--m-dark-100--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-l-page__main-section--m-dark-200--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
 
+  // page transitions
+  --pf-l-page--m-fixed--transition--in: 250ms;
+  --pf-l-page--m-fixed--transition--out: 150ms;
+
   // Base
   display: grid;
   min-height: 100vh;
@@ -102,6 +106,27 @@ $nav: "pf-c-nav";
       "header header"
       "nav main";
   }
+
+  &.pf-m-scroll-content {
+    height: 100vh;
+  }
+}
+
+.pf-l-page__main,
+.pf-l-page__sidebar {
+  .pf-m-scroll-content & {
+    overflow-y: auto;
+  }
+}
+
+.pf-l-page__header-brand,
+.pf-l-toolbar,
+.pf-l-page__header-avatar {
+  transition: var(--pf-l-page--m-fixed--transition--in);
+
+  .pf-m-fixed & {
+    transition: var(--pf-l-page--m-fixed--transition--out);
+  }
 }
 
 // Header
@@ -115,10 +140,31 @@ $nav: "pf-c-nav";
   max-width: 100%;
   min-height: var(--pf-l-page__header--MinHeight); // Hardcode header height base on design spec
   overflow-x: hidden;
+  transition: var(--pf-l-page--m-fixed--transition--in);
 
   > * {
     display: flex;
     align-items: flex-end;
+  }
+
+  &.pf-m-fixed {
+    min-height: 20px;
+    transition: var(--pf-l-page--m-fixed--transition--in);
+
+    .pf-l-page__header-brand {
+      padding-top: var(--pf-global--spacer--sm);
+      padding-bottom: var(--pf-global--spacer--sm);
+    }
+
+    .pf-l-page__header-avatar {
+      width: 30px;
+      height: 30px;
+    }
+
+    .pf-l-toolbar {
+      margin-top: var(--pf-global--spacer--sm);
+      margin-bottom: var(--pf-global--spacer--sm);
+    }
   }
 }
 

--- a/src/patternfly/layouts/Page/page.scss
+++ b/src/patternfly/layouts/Page/page.scss
@@ -143,7 +143,6 @@ $nav: "pf-c-nav";
   align-items: flex-end;
   max-width: 100%;
   min-height: var(--pf-l-page__header--MinHeight); // Hardcode header height base on design spec
-  overflow-x: hidden;
   transition: var(--pf-l-page--m-condensed--transition--in);
 
   > * {

--- a/src/patternfly/layouts/Page/page.scss
+++ b/src/patternfly/layouts/Page/page.scss
@@ -7,6 +7,7 @@ $nav: "pf-c-nav";
   // Header
   --pf-l-page__header--PaddingBottom: var(--pf-global--spacer--md);
   --pf-l-page__header--MinHeight: #{pf-size-prem(110px)};
+  --pf-l-page__header--m-condensed--MinHeight: #{pf-size-prem(20px)};
 
   // Header brand
   --pf-l-page__header-brand--PaddingTop: var(--pf-global--spacer--md);
@@ -16,6 +17,8 @@ $nav: "pf-c-nav";
   --pf-l-page__header-brand--PaddingBottom--sm: var(--pf-global--spacer--md);
   --pf-l-page__header-brand--BackgroundColor--md: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-l-page__header-brand--FlexBasis--lg: #{pf-size-prem(290px)};
+  --pf-l-page__header-brand--m-condensed--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-l-page__header-brand--m-condensed--PaddingBottom: var(--pf-global--spacer--sm);
 
   // Toggle
   --pf-l-page__header-sidebar-toggle--PaddingTop: var(--pf-global--spacer--sm);
@@ -52,6 +55,10 @@ $nav: "pf-c-nav";
   --pf-l-page__header-tools--avatar--MarginLeft: var(--pf-global--spacer--md);
   --pf-l-page__header-tools--avatar--Width: #{pf-size-prem(48px)};
   --pf-l-page__header-tools--avatar--Height: #{pf-size-prem(48px)};
+  --pf-l-page__header-tools--m-condensed--avatar--Width: #{pf-size-prem(30px)};
+  --pf-l-page__header-tools--m-condensed--avatar--Height: #{pf-size-prem(30px)};
+  --pf-l-page__header--m-condensed--toolbar--MarginTop: var(--pf-global--spacer--sm);
+  --pf-l-page__header--m-condensed--toolbar--MarginBottom: var(--pf-global--spacer--sm);
 
   // Sidebar
   --pf-l-page__sidebar--ZIndex: var(--pf-global--ZIndex--xl);
@@ -87,13 +94,21 @@ $nav: "pf-c-nav";
   --pf-l-page__main-section--m-dark-100--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-l-page__main-section--m-dark-200--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
 
-  // page transitions
-  --pf-l-page--m-fixed--transition--in: 250ms;
-  --pf-l-page--m-fixed--transition--out: 150ms;
+  // context selector
+  --pf-l-page__header-selector--m-condensed--PaddingTop: var(--pf-global--spacer--md);
+  --pf-l-page__header-selector--m-condensed--PaddingBottom: var(--pf-global--spacer--md);
+
+  // Horizontal nav links
+  --pf-c-nav__link--m-condensed--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__link--m-condensed--PaddingBottom: var(--pf-global--spacer--md);
+
+  // transitions
+  --pf-l-page--m-condensed--transition--in: 250ms;
+  --pf-l-page--m-condensed--transition--out: 150ms;
 
   // Base
   display: grid;
-  min-height: 100vh;
+  height: 100vh;
   grid-template-columns: 1fr;
   grid-template-rows: max-content 1fr;
   grid-template-areas:
@@ -106,26 +121,15 @@ $nav: "pf-c-nav";
       "header header"
       "nav main";
   }
-
-  &.pf-m-scroll-content {
-    height: 100vh;
-  }
-}
-
-.pf-l-page__main,
-.pf-l-page__sidebar {
-  .pf-m-scroll-content & {
-    overflow-y: auto;
-  }
 }
 
 .pf-l-page__header-brand,
 .pf-l-toolbar,
-.pf-l-page__header-avatar {
-  transition: var(--pf-l-page--m-fixed--transition--in);
+.pf-c-avatar {
+  transition: var(--pf-l-page--m-condensed--transition--in);
 
-  .pf-m-fixed & {
-    transition: var(--pf-l-page--m-fixed--transition--out);
+  .pf-m-condensed & {
+    transition: var(--pf-l-page--m-condensed--transition--out);
   }
 }
 
@@ -140,30 +144,39 @@ $nav: "pf-c-nav";
   max-width: 100%;
   min-height: var(--pf-l-page__header--MinHeight); // Hardcode header height base on design spec
   overflow-x: hidden;
-  transition: var(--pf-l-page--m-fixed--transition--in);
+  transition: var(--pf-l-page--m-condensed--transition--in);
 
   > * {
     display: flex;
     align-items: flex-end;
   }
 
-  &.pf-m-fixed {
-    min-height: 20px;
-    transition: var(--pf-l-page--m-fixed--transition--in);
+  &.pf-m-condensed {
+    min-height: var(--pf-l-page__header--m-condensed--MinHeight);
 
     .pf-l-page__header-brand {
-      padding-top: var(--pf-global--spacer--sm);
-      padding-bottom: var(--pf-global--spacer--sm);
+      padding-top: var(--pf-l-page__header-brand--m-condensed--PaddingTop);
+      padding-bottom: var(--pf-l-page__header-brand--m-condensed--PaddingBottom);
     }
 
-    .pf-l-page__header-avatar {
-      width: 30px;
-      height: 30px;
+    .pf-c-avatar {
+      width: var(--pf-l-page__header-tools--m-condensed--avatar--Width);
+      height: var(--pf-l-page__header-tools--m-condensed--avatar--Height);
     }
 
     .pf-l-toolbar {
-      margin-top: var(--pf-global--spacer--sm);
-      margin-bottom: var(--pf-global--spacer--sm);
+      margin-top: var(--pf-l-page__header--m-condensed--toolbar--MarginTop);
+      margin-bottom: var(--pf-l-page__header--m-condensed--toolbar--MarginBottom);
+    }
+
+    .pf-c-nav__horizontal-list .pf-c-nav__link {
+      padding-top: var(--pf-c-nav__link--m-condensed--PaddingTop);
+      padding-bottom: var(--pf-c-nav__link--m-condensed--PaddingBottom);
+    }
+
+    .pf-l-page__header-selector {
+      padding-top: var(--pf-l-page__header-selector--m-condensed--PaddingTop);
+      padding-bottom: var(--pf-l-page__header-selector--m-condensed--PaddingBottom);
     }
   }
 }
@@ -258,7 +271,8 @@ $nav: "pf-c-nav";
   width: var(--pf-l-page__sidebar--Width--sm);
   padding-top: var(--pf-l-page__sidebar--PaddingTop);
   padding-bottom: var(--pf-l-page__sidebar--PaddingBottom);
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   background-color: var(--pf-l-page__sidebar--BackgroundColor);
   transition: var(--pf-l-page__sidebar--Transition);
   transform: var(--pf-l-page__sidebar--Transform--out);
@@ -296,7 +310,7 @@ $nav: "pf-c-nav";
   flex-direction: column;
   padding-right: 0;
   overflow-x: hidden;
-  overflow-y: visible;
+  overflow-y: auto;
 }
 
 .pf-l-page__main-nav {


### PR DESCRIPTION
This is doing a couple things but its core purpose is to add the CSS that will allow the header to condense on scroll. So you will see the class `.pf-m-scroll-content` and `.pf-m-condensed` added to the page layout. 
I also removed the JS that is associated with the navigation to keep core clean of any JS. 
I've updated the docs for page and did a few clean up tasks here as well.

This closes #768 and #818 

Questions: 
Do we want`.pf-m-scroll-content` to be a modifier or should be default behaviour?
Naming is hard, does `.pf-m-condensed` make sense for the header modifier? 