### PR TITLE
refactor(dropdown): pf-m-align-right class shuffle, other workspace bug fixes

### DIFF
--- a/src/patternfly/components/Dropdown/docs/code.md
+++ b/src/patternfly/components/Dropdown/docs/code.md
@@ -32,7 +32,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-m-expanded` | `.pf-c-dropdown` | Modifies for the expanded state |
 | `.pf-m-plain` | `.pf-c-dropdown` | Modifies to display the toggle with no border or background |
 | `.pf-m-top` | `.pf-c-dropdown` | Modifies to display the menu above the toggle |
-| `.pf-m-align-right` | `.pf-c-dropdown` | Modifies to display the menu aligned to the right edge of the toggle |
+| `.pf-m-align-right` | `.pf-c-dropdown__menu` | Modifies to display the menu aligned to the right edge of the toggle |
 | `.pf-m-hover` | `.pf-c-dropdown__menu-item`, `.pf-c-dropdown__toggle` | Forces display of the hover state of the element. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:hover` pseudo-class. |
 | `.pf-m-focus` | `.pf-c-dropdown__menu-item` | Forces display of the focus state of the element. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:focus` pseudo-class. |
 | `.pf-m-active` | `.pf-c-dropdown__toggle` | Forces display of the active state of the element. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:active` pseudo-class. |

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -134,11 +134,11 @@
   border: var(--pf-c-dropdown__menu--BorderWidth) solid transparent;
   box-shadow: var(--pf-c-dropdown__menu--BoxShadow);
 
-  .pf-m-align-right > & {
+  &.pf-m-align-right {
     right: 0;
   }
 
-  .pf-m-top > & {
+  .pf-c-dropdown.pf-m-top & {
     top: 0;
     transform: var(--pf-c-dropdown__menu--top--Transform);
   }

--- a/src/patternfly/components/Dropdown/examples/dropdown-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-align-right-example.hbs
@@ -1,3 +1,3 @@
-{{#> dropdown id="dropdown-example-rightAligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-align-right" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-rightAligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown-menu--modifier="pf-m-align-right"}}
   Right
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-align-right-example.hbs
@@ -1,2 +1,2 @@
-{{#> dropdown id="dropdown-example-kebab-right-aligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+{{#> dropdown id="dropdown-example-kebab-right-aligned" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions" dropdown-menu--modifier="pf-m-align-right"}}
 {{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-kebab-right-aligned-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-kebab-right-aligned-example.hbs
@@ -1,1 +1,0 @@
-{{#> dropdown id="dropdown-example-kebab" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-plain pf-m-align-right" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-top-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-top-example.hbs
@@ -1,4 +1,4 @@
-{{#> dropdown id="dropdown-example-top-collapsed" dropdown--IsActionMenu="true" dropdown--modifier="pf-m-top" pf-c-dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-example-top-collapsed" dropdown--IsActionMenu="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
   Top
 {{/dropdown}}
 {{#> dropdown id="dropdown-example-top-expanded" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}

--- a/src/patternfly/components/Dropdown/examples/index.js
+++ b/src/patternfly/components/Dropdown/examples/index.js
@@ -93,8 +93,7 @@ export default () => {
       <Example
         className="is-expanded-dropdown is-align-right"
         heading="Kebab Align Right"
-        handlebars={DropdownKebabAlignRightRaw}
-      >
+        handlebars={DropdownKebabAlignRightRaw}>
         {dropdownKebabAlignRight}
       </Example>
       <Example className="is-expanded-dropdown is-align-right" heading="Align Right" handlebars={DropdownAlignRightRaw}>


### PR DESCRIPTION
I had to leave `.pf-m-top` on the `.pf-c-dropdown` element because that class also flips the toggle icon when the dropdown is expanded, so I scoped the menu styles to `.pf-c-dropdown.pf-m-top` https://github.com/patternfly/patternfly-next/issues/836