### PR TITLE
enhancement(update card for generic container use):Expand card implementation

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -29,12 +29,14 @@
   box-shadow: var(--pf-c-card--BoxShadow);
 
   // If the first child isn't the header, then we need to put the header's top padding there
-  > :first-child:not(.pf-c-card__header) {
+  > :first-child.pf-c-card__body,
+  > :first-child.pf-c-card__footer {
     padding-top: var(--pf-c-card__header--PaddingTop);
   }
 
   // If the last child isn't the footer, then we need to put the footer's bottom padding there
-  > :last-child:not(.pf-c-card__footer) {
+  > :last-child.pf-c-card__header,
+  > :last-child.pf-c-card__body {
     padding-bottom: var(--pf-c-card__footer--PaddingBottom);
   }
 }

--- a/src/patternfly/components/Card/docs/code.md
+++ b/src/patternfly/components/Card/docs/code.md
@@ -1,12 +1,12 @@
 ## Overview
 
-A card is a generic rectangular container that can be used to build other components.  A card can have three optional sections: header, body, and footer. 
+A card is a generic rectangular container that can be used to build other components. A card can have three optional sections: header, body and footer.
 
 ## Usage
 
 | Class                | Applied     | Outcome                                                                                                                                                                              |
 | -------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.pf-c-card`          | `<div>`     | Creates a card containing content                                                                                                                                                     |
-| `.pf-c-card__header`          | `.pf-c-card`     | Creates the header of a card                                                                                                                                                     |
-| `.pf-c-card__body`          | `.pf-c-card`     | Creates the body of a card.  ** Required.**                                                                                                                                                   |
-| `.pf-c-card__footer`          | `.pf-c-card`     | Creates the footer of a card                                                                                                                                                     |
+| `.pf-c-card`          | `<div>`     | Creates a card containing content.                                                                                                                                                     |
+| `.pf-c-card__header`          | `.pf-c-card`     | Creates the header of a card.                                                                                                                                                     |
+| `.pf-c-card__body`          | `.pf-c-card`     | Creates the body of a card.                                                                                                                                                 |
+| `.pf-c-card__footer`          | `.pf-c-card`     | Creates the footer of a card.                                                                                                                                                     |


### PR DESCRIPTION
Updated card css to target `header`, `body`, `footer` for automatic layout rather than generic first/last descendant elements.

Opened to address use with table example #841 

Closes #835 

