### PR TITLE
fix(buttons): vertically center text in 'links as buttons'

### DIFF
--- a/src/patternfly/_variables.scss
+++ b/src/patternfly/_variables.scss
@@ -140,6 +140,7 @@
   // Line height
   --pf-global--LineHeight--sm: #{$pf-global--LineHeight--sm};
   --pf-global--LineHeight--md: #{$pf-global--LineHeight--md};
+  --pf-global--LineHeight--lg: #{$pf-global--LineHeight--lg};
 
   // List
   --pf-global-ListStyle: #{$pf-global--ListStyle};

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -6,7 +6,7 @@
   --pf-c-button--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-button--PaddingBottom: var(--pf-global--spacer--xs);
   --pf-c-button--PaddingLeft: var(--pf-global--spacer--lg);
-  --pf-c-button--LineHeight: var(--pf-global--LineHeight--md);
+  --pf-c-button--LineHeight: var(--pf-global--LineHeight--lg);
   --pf-c-button--FontWeight: var(--pf-global--FontWeight--semi-bold);
   --pf-c-button--FontSize: var(--pf-global--FontSize--md);
   --pf-c-button--BorderRadius: var(--pf-global--BorderRadius--lg);

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -178,6 +178,7 @@ $pf-global--FontWeight--bold: 600 !default;
 // Line height
 $pf-global--LineHeight--sm: 1.3 !default;
 $pf-global--LineHeight--md: 1.5 !default;
+$pf-global--LineHeight--lg: 2.25 !default;
 
 // Links
 $pf-global--link--FontWeight:             $pf-global--FontWeight--semi-bold !default;


### PR DESCRIPTION
Caught the Jenn Giardino and Sara Chizari's talk at All Things Open this week. Really great work on the accessibility! Starting to check the components out, and found the text in "links as buttons" is misaligned.

This PR adds a new global line height, sized to match the existing button content height, and applies that to buttons. (The change doesn't affect the `button` buttons, since by default `button`s ignore line height and instead center text vertically.)

Screenshots:

Before | After
---|---
<img alt="before screenshot: text is at top of buttons" src="https://user-images.githubusercontent.com/3282350/47529000-a0c6f700-d874-11e8-9ae6-e64dd37253a2.png">|<img alt="after screenshot: text is vertically centered in buttons" src="https://user-images.githubusercontent.com/3282350/47529622-5181c600-d876-11e8-9c6f-26ab30b6302b.png">