### PR TITLE
fix(box shadow utility): Add left variants

### DIFF
--- a/src/patternfly/utilities/BoxShadow/box-shadow.scss
+++ b/src/patternfly/utilities/BoxShadow/box-shadow.scss
@@ -8,18 +8,21 @@ $pf-u-box-shadow-options: (
   box-shadow-sm-top:    (box-shadow var(--pf-global--BoxShadow--sm-top)),
   box-shadow-sm-right:  (box-shadow var(--pf-global--BoxShadow--sm-right)),
   box-shadow-sm-bottom: (box-shadow var(--pf-global--BoxShadow--sm-bottom)),
+  box-shadow-sm-left:   (box-shadow var(--pf-global--BoxShadow--sm-left)),
 
   // medium
   box-shadow-md:        (box-shadow var(--pf-global--BoxShadow--md)),
   box-shadow-md-top:    (box-shadow var(--pf-global--BoxShadow--md-top)),
   box-shadow-md-right:  (box-shadow var(--pf-global--BoxShadow--md-right)),
   box-shadow-md-bottom: (box-shadow var(--pf-global--BoxShadow--md-bottom)),
+  box-shadow-md-left:   (box-shadow var(--pf-global--BoxShadow--md-left)),
 
   // large
   box-shadow-lg:        (box-shadow var(--pf-global--BoxShadow--lg)),
   box-shadow-lg-top:    (box-shadow var(--pf-global--BoxShadow--lg-top)),
   box-shadow-lg-right:  (box-shadow var(--pf-global--BoxShadow--lg-right)),
   box-shadow-lg-bottom: (box-shadow var(--pf-global--BoxShadow--lg-bottom)),
+  box-shadow-lg-left:   (box-shadow var(--pf-global--BoxShadow--lg-left)),
 
   box-shadow-inset:     (box-shadow var(--pf-global--BoxShadow--inset))
 );


### PR DESCRIPTION
Adds the missing leftward variants of the Box Shadow utility. Resolves #856.