### PR TITLE
fix(naming): rename template styles.scss into componentName.scss

### DIFF
--- a/build/blueprints/template/files/src/patternfly/__typeDirectory__/__namePascalized__/examples/index.js
+++ b/build/blueprints/template/files/src/patternfly/__typeDirectory__/__namePascalized__/examples/index.js
@@ -7,7 +7,7 @@ import {{moduleName}}SimpleExample from './{{nameDasherized}}-simple-example.hbs
 import {{moduleName}}ComplexExample from './{{nameDasherized}}-complex-example.hbs';
 import {{nameCamelized}}ComplexExampleDoc from '../docs/{{nameDasherized}}-complex.md';
 import docs from '../docs/code.md';
-import '../styles.scss';
+import '../{{nameCamelized}}.scss';
 
 export const Docs = docs;
 


### PR DESCRIPTION
styles.scss doesn't exist anymore in the generated component.
use the componentName.scss file.