### PR TITLE
fix(workspace): Change bg of preview body to allow component bg to show

### DIFF
--- a/src/site/_site/Preview/styles.scss
+++ b/src/site/_site/Preview/styles.scss
@@ -14,7 +14,7 @@
 .Preview__body {
   width: 100%;
   padding: 1rem;
-  background-color: #fff;
+  background-color: transparent;
   border: 1px solid #eaeaea;
   transition: width .2s ease-in-out;
 }


### PR DESCRIPTION
This changes the white background of the `.Preview__body` in the workspace to instead be transparent, so that the background of a component can show through.