### PR TITLE
update expandable nav toggle's a11y attributes (#746)

### DIFF
--- a/src/patternfly/components/Nav/nav-link.hbs
+++ b/src/patternfly/components/Nav/nav-link.hbs
@@ -14,8 +14,8 @@
   {{/if}}>
   {{> @partial-block}}
   {{#if nav-item--expandable}}
-    <span class="pf-c-nav__toggle" tabindex="-1" aria-disabled="true">
-      <i class="fas fa-angle-right"></i>
+    <span class="pf-c-nav__toggle">
+      <i class="fas fa-angle-right" aria-hidden="true"></i>
     </span>
   {{/if}}
 </a>


### PR DESCRIPTION
Saw that `label:help wanted`!

Addresses #746 

- Removes tabindex and aria-disabled from toggle's wrapper,
- adds aria-hidden to toggle's icon