### PR TITLE
fix(page-layout):move nav styles to component

### DIFF
--- a/src/patternfly/components/Nav/docs/code.md
+++ b/src/patternfly/components/Nav/docs/code.md
@@ -31,9 +31,10 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__section-title`            | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`                        | Initiates a nav section title |
 | `.pf-c-nav__toggle`                    | `<span>`                                | Initiates a chevron indicating expandability of a `pf-c-nav__list-link` |
 | `.pf-m-expandable`                    | `.pf-c-nav__item`                       | Modifies for the expandable state |
-| `.pf-m-expanded`                      | `.pf-c-nav__item`, `.pf-c-nav__horizontal-list`                       | Modifies for the expanded state |
+| `.pf-m-expanded`                      | `.pf-c-nav__item`                       | Modifies for the expanded state |
 | `.pf-m-hover`                         | `.pf-c-nav__link`                       | Modifies to display the link as hovered |
 | `.pf-m-focus`                         | `.pf-c-nav__link`                       | Modifies to display the link as focussed |
 | `.pf-m-current`                       | `.pf-c-nav__link`                       | Modifies for the current state |
 | `.pf-m-active`                        | `.pf-c-nav__link`,                      | Modifies to display the link as active |
 | `.pf-m-disabled`                      | `.pf-c-nav__link`,                      | Modifies to display the link as disabled |
+| `.pf-m-tall`                      | `.pf-c-nav__horizontal-list`,                      | Modifies to display the tall horizontal nav. This is related to the page layout for desktop view with a tall header.  |

--- a/src/patternfly/components/Nav/docs/code.md
+++ b/src/patternfly/components/Nav/docs/code.md
@@ -37,4 +37,4 @@ The navigation system relies on several different sub-components:
 | `.pf-m-current`                       | `.pf-c-nav__link`                       | Modifies for the current state |
 | `.pf-m-active`                        | `.pf-c-nav__link`,                      | Modifies to display the link as active |
 | `.pf-m-disabled`                      | `.pf-c-nav__link`,                      | Modifies to display the link as disabled |
-| `.pf-m-tall`                      | `.pf-c-nav__horizontal-list`,                      | Modifies to display the tall horizontal nav. This is related to the page layout for desktop view with a tall header.  |
+| `.pf-m-tall`                      | `.pf-c-nav__horizontal-list`                | Modifies to display the tall horizontal nav. This is related to the page layout for desktop view with a tall header.  |

--- a/src/patternfly/components/Nav/docs/code.md
+++ b/src/patternfly/components/Nav/docs/code.md
@@ -31,7 +31,7 @@ The navigation system relies on several different sub-components:
 | `.pf-c-nav__section-title`            | `<h1>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`                        | Initiates a nav section title |
 | `.pf-c-nav__toggle`                    | `<span>`                                | Initiates a chevron indicating expandability of a `pf-c-nav__list-link` |
 | `.pf-m-expandable`                    | `.pf-c-nav__item`                       | Modifies for the expandable state |
-| `.pf-m-expanded`                      | `.pf-c-nav__item`                       | Modifies for the expanded state |
+| `.pf-m-expanded`                      | `.pf-c-nav__item`, `.pf-c-nav__horizontal-list`                       | Modifies for the expanded state |
 | `.pf-m-hover`                         | `.pf-c-nav__link`                       | Modifies to display the link as hovered |
 | `.pf-m-focus`                         | `.pf-c-nav__link`                       | Modifies to display the link as focussed |
 | `.pf-m-current`                       | `.pf-c-nav__link`                       | Modifies for the current state |

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -66,8 +66,10 @@
 
   // List horizontal link
   --pf-c-nav__horizontal-list-item--MarginRight: var(--pf-global--spacer--xl);
-  --pf-c-nav__horizontal-list-link--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-nav__horizontal-list-link--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-nav__horizontal-list-link--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-nav__horizontal-list-link--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-nav__horizontal-list-link--m-expanded--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-nav__horizontal-list-link--m-expanded--PaddingBottom: var(--pf-global--spacer--lg);
 
   // font
   --pf-c-nav__horizontal-list-link--FontWeight: var(--pf-global--FontWeight--normal);
@@ -444,6 +446,13 @@
       height: var(--pf-c-nav__horizontal-list-link--after--Height);
       content: "";
       background-color: var(--pf-c-nav__horizontal-list-link--after--BackgroundColor);
+    }
+  }
+
+  &.pf-m-expanded {
+    .pf-c-nav__link {
+      padding-top: var(--pf-c-nav__horizontal-list-link--m-expanded--PaddingTop);
+      padding-bottom: var(--pf-c-nav__horizontal-list-link--m-expanded--PaddingBottom);
     }
   }
 }

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -68,8 +68,10 @@
   --pf-c-nav__horizontal-list-item--MarginRight: var(--pf-global--spacer--xl);
   --pf-c-nav__horizontal-list-link--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-nav__horizontal-list-link--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-nav__horizontal-list-link--m-expanded--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-nav__horizontal-list-link--m-expanded--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-nav__horizontal-list-link--m-tall--PaddingTop: var(--pf-global--spacer--lg);
+  --pf-c-nav__horizontal-list-link--m-tall--PaddingBottom: var(--pf-global--spacer--lg);
+  --pf-c-nav__horizontal-list-link--m-tall--transition--in: 250ms;
+  --pf-c-nav__horizontal-list-link--m-tall--transition--out: 150ms;
 
   // font
   --pf-c-nav__horizontal-list-link--FontWeight: var(--pf-global--FontWeight--normal);
@@ -392,6 +394,7 @@
     color: var(--pf-c-nav__horizontal-list-link--Color);
     white-space: nowrap;
     background-color: var(--pf-c-nav__horizontal-list-link--BackgroundColor);
+    transition: var(--pf-c-nav__horizontal-list-link--m-tall--transition--in);
 
     // States
     &.pf-m-hover,
@@ -449,10 +452,11 @@
     }
   }
 
-  &.pf-m-expanded {
+  &.pf-m-tall {
     .pf-c-nav__link {
-      padding-top: var(--pf-c-nav__horizontal-list-link--m-expanded--PaddingTop);
-      padding-bottom: var(--pf-c-nav__horizontal-list-link--m-expanded--PaddingBottom);
+      padding-top: var(--pf-c-nav__horizontal-list-link--m-tall--PaddingTop);
+      padding-bottom: var(--pf-c-nav__horizontal-list-link--m-tall--PaddingBottom);
+      transition: var(--pf-c-nav__horizontal-list-link--m-tall--transition--out);
     }
   }
 }

--- a/src/patternfly/demos/PageLayout/examples/index.js
+++ b/src/patternfly/demos/PageLayout/examples/index.js
@@ -2,13 +2,13 @@ import React from 'react';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
 
-import PageLayoutDefaultNavExpandedHeaderExampleRaw from '!raw!./page-layout-default-nav-expanded-header-example.hbs';
+import PageLayoutDefaultNavTallHeaderExampleRaw from '!raw!./page-layout-default-nav-tall-header-example.hbs';
 import PageLayoutExpandableNavExampleRaw from '!raw!./page-layout-expandable-nav-example.hbs';
 import PageLayoutHorizontalNavExampleRaw from '!raw!./page-layout-horizontal-nav-example.hbs';
 import PageLayoutSimpleNavExampleRaw from '!raw!./page-layout-simple-nav-example.hbs';
 import PageLayoutGroupedNavExampleRaw from '!raw!./page-layout-grouped-nav-example.hbs';
 
-import PageLayoutDefaultNavExpandedHeaderExample from './page-layout-default-nav-expanded-header-example.hbs';
+import PageLayoutDefaultNavTallHeaderExample from './page-layout-default-nav-tall-header-example.hbs';
 import PageLayoutExpandableNavExample from './page-layout-expandable-nav-example.hbs';
 import PageLayoutHorizontalNavExample from './page-layout-horizontal-nav-example.hbs';
 import PageLayoutSimpleNavExample from './page-layout-simple-nav-example.hbs';
@@ -19,7 +19,7 @@ import docs from '../docs/code.md';
 export const Docs = docs;
 
 export default () => {
-  const pageLayoutDefaultNavExpandedHeaderExample = PageLayoutDefaultNavExpandedHeaderExample();
+  const pageLayoutDefaultNavTallHeaderExample = PageLayoutDefaultNavTallHeaderExample();
   const pageLayoutExpandableNavExample = PageLayoutExpandableNavExample();
   const pageLayoutHorizontalNavExample = PageLayoutHorizontalNavExample();
   const pageLayoutSimpleNavExample = PageLayoutSimpleNavExample();
@@ -29,11 +29,11 @@ export default () => {
   return (
     <Documentation docs={Docs} heading={headingText}>
       <Example
-        heading="Page Layout Default Nav Expanded Header Example"
+        heading="Page Layout Default Nav Tall Header Example"
         fullPageOnly="true"
-        handlebars={PageLayoutDefaultNavExpandedHeaderExampleRaw}
+        handlebars={PageLayoutDefaultNavTallHeaderExampleRaw}
       >
-        {pageLayoutDefaultNavExpandedHeaderExample}
+        {pageLayoutDefaultNavTallHeaderExample}
       </Example>
       <Example
         heading="Page Layout Expandable Nav Example"

--- a/src/patternfly/demos/PageLayout/examples/page-layout-default-nav-tall-header-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-default-nav-tall-header-example.hbs
@@ -1,7 +1,7 @@
 {{#> background-image}}
 {{/background-image}}
 {{#> page page--attribute='id="page-layout-default-nav"'}}
-  {{#> page-header page-header--modifier="pf-m-expanded"}}
+  {{#> page-header page-header--modifier="pf-m-tall"}}
     {{!-- Brand --}}
     {{#> page-header-brand}}
       {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-grouped-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-grouped-nav-example.hbs
@@ -7,9 +7,6 @@
       {{#> page-template-header-brand-elements page-template-header-brand--toggle="true"}}
       {{/page-template-header-brand-elements}}
     {{/page-header-brand}}
-    {{#> page-header-selector}}
-      pf-c-context-selector
-    {{/page-header-selector}}
     {{#> page-template-header-tools-elements}}
     {{/page-template-header-tools-elements}}
   {{/page-header}}

--- a/src/patternfly/demos/PageLayout/examples/page-layout-horizontal-nav-example.hbs
+++ b/src/patternfly/demos/PageLayout/examples/page-layout-horizontal-nav-example.hbs
@@ -6,9 +6,6 @@
       {{#> page-template-header-brand-elements}}
       {{/page-template-header-brand-elements}}
     {{/page-header-brand}}
-    {{#> page-header-selector}}
-      pf-c-context-selector
-    {{/page-header-selector}}
     {{#> page-header-nav}}
       {{#> nav nav--horizontal="true" nav--attribute='id="nav-primary" aria-label="Primary Nav Default Example"'}}
         {{#> nav-list nav-list--type="horizontal"}}

--- a/src/patternfly/layouts/Page/docs/code.md
+++ b/src/patternfly/layouts/Page/docs/code.md
@@ -30,4 +30,4 @@ This layout provides the basic chrome for a page, including sidebar, header and 
 | `.pf-m-light` | `.pf-l-page__main-section` | Modifies a main page section to have a light theme. |
 | `.pf-m-dark-200` | `.pf-l-page__main-section` |  Modifies a main page section to have a dark theme and a dark transparent background. |
 | `.pf-m-dark-100` | `.pf-l-page__main-section` |  Modifies a main page section to have a dark theme and a darker transparent background. |
-| `.pf-m-expanded` | `.pf-l-page__header` |   Modifies header to expanded height on desktop. This class should be added on desktop/toggled on scroll via Javascript. |
+| `.pf-m-tall` | `.pf-l-page__header` |   Modifies header to tallest height on desktop. This class should be added on desktop/toggled on scroll via Javascript. |

--- a/src/patternfly/layouts/Page/examples/page-layout-nav-horizontal-example.hbs
+++ b/src/patternfly/layouts/Page/examples/page-layout-nav-horizontal-example.hbs
@@ -4,10 +4,6 @@
     {{#> page-header-brand}}
       Logo
     {{/page-header-brand}}
-    {{!-- Context Selector --}}
-    {{#> page-header-selector}}
-      pf-c-context-selector
-    {{/page-header-selector}}
     {{!-- Horizontal Nav --}}
     {{#> page-header-nav}}
       pf-c-nav

--- a/src/patternfly/layouts/Page/examples/page-layout-nav-vertical-example.hbs
+++ b/src/patternfly/layouts/Page/examples/page-layout-nav-vertical-example.hbs
@@ -9,9 +9,6 @@
         Logo
       {{/page-header-brand-link}}
     {{/page-header-brand}}
-    {{#> page-header-selector}}
-      pf-c-context-selector
-    {{/page-header-selector}}
     {{#> page-header-tools}}
       pf-l-toolbar
     {{/page-header-tools}}

--- a/src/patternfly/layouts/Page/page-header-selector.hbs
+++ b/src/patternfly/layouts/Page/page-header-selector.hbs
@@ -1,6 +1,0 @@
-<div class="pf-l-page__header-selector{{#if page-header-selector--modifier}} {{page-header-selector--modifier}}{{/if}}"
-  {{#if page-header-selector--attribute}}
-    {{{page-header-selector--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/layouts/Page/page.scss
+++ b/src/patternfly/layouts/Page/page.scss
@@ -34,12 +34,6 @@ $nav: "pf-c-nav";
   // Header brand logo
   --pf-l-page__header-brand-logo--Height: #{pf-size-prem(11px)};
 
-  // Header context selector
-  --pf-l-page__header-selector--PaddingLeft: var(--pf-global--spacer--md);
-  --pf-l-page__header-selector--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-l-page__header-selector--PaddingBottom: var(--pf-global--spacer--lg);
-  --pf-l-page__header-selector--PaddingLeft: var(--pf-global--spacer--xl);
-
   // Header nav
   --pf-l-page__header-nav--PaddingRight: var(--pf-global--spacer--xl);
   --pf-l-page__header-nav--PaddingLeft: var(--pf-global--spacer--xl);
@@ -49,12 +43,12 @@ $nav: "pf-c-nav";
   --pf-l-page__header-nav--BackgroundColor--sm: var(--pf-global--BackgroundColor--dark-transparent-100);
 
   // Header tools
-  --pf-l-page__header-tools--toolbar--MarginTop: var(--pf-global--spacer--sm);
-  --pf-l-page__header-tools--toolbar--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-l-page__header-tools--MarginTop: var(--pf-global--spacer--sm);
+  --pf-l-page__header-tools--MarginBottom: var(--pf-global--spacer--sm);
   --pf-l-page__header-tools--MarginRight: var(--pf-global--spacer--xl);
   --pf-l-page__header-tools--avatar--MarginLeft: var(--pf-global--spacer--md);
-  --pf-l-page__header-tools--toolbar--m-expanded--MarginTop: var(--pf-global--spacer--md);
-  --pf-l-page__header-tools--toolbar--m-expanded--MarginBottom: var(--pf-global--spacer--md);
+  --pf-l-page__header-tools--m-expanded--MarginTop: var(--pf-global--spacer--md);
+  --pf-l-page__header-tools--m-expanded--MarginBottom: var(--pf-global--spacer--md);
 
   // Sidebar
   --pf-l-page__sidebar--ZIndex: var(--pf-global--ZIndex--xl);
@@ -90,16 +84,6 @@ $nav: "pf-c-nav";
   --pf-l-page__main-section--m-dark-100--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-l-page__main-section--m-dark-200--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
 
-  // context selector
-  --pf-l-page__header-selector--PaddingTop: var(--pf-global--spacer--md);
-  --pf-l-page__header-selector--PaddingBottom: var(--pf-global--spacer--md);
-
-  // Horizontal nav links
-  --pf-c-nav__horizontal-list-link--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-nav__horizontal-list-link--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-nav__horizontal-list-link--m-expanded--PaddingTop: var(--pf-global--spacer--lg);
-  --pf-c-nav__horizontal-list-link--m-expanded--PaddingBottom: var(--pf-global--spacer--lg);
-
   // transitions
   --pf-l-page--m-expanded--transition--in: 250ms;
   --pf-l-page--m-expanded--transition--out: 150ms;
@@ -122,8 +106,7 @@ $nav: "pf-c-nav";
 }
 
 .pf-l-page__header-brand,
-.pf-l-toolbar,
-.pf-c-avatar {
+.pf-l-page__header-tools {
   transition: var(--pf-l-page--m-expanded--transition--in);
 
   .pf-m-expanded & {
@@ -143,7 +126,6 @@ $nav: "pf-c-nav";
   min-height: var(--pf-l-page__header--MinHeight);
   transition: var(--pf-l-page--m-expanded--transition--in);
 
-
   > * {
     display: flex;
     align-items: flex-end;
@@ -155,20 +137,8 @@ $nav: "pf-c-nav";
   }
 
   .pf-l-page__header-tools {
-    .pf-l-toolbar {
-      margin-top: var(--pf-l-page__header-tools--toolbar--MarginTop);
-      margin-bottom: var(--pf-l-page__header-tools--toolbar--MarginBottom);
-    }
-  }
-
-  .pf-c-nav__horizontal-list .pf-c-nav__link {
-    padding-top: var(--pf-c-nav__horizontal-list-link--PaddingTop);
-    padding-bottom: var(--pf-c-nav__horizontal-list-link--PaddingBottom);
-  }
-
-  .pf-l-page__header-selector {
-    padding-top: var(--pf-l-page__header-selector--PaddingTop);
-    padding-bottom: var(--pf-l-page__header-selector--PaddingBottom);
+    margin-top: var(--pf-l-page__header-tools--MarginTop);
+    margin-bottom: var(--pf-l-page__header-tools--MarginBottom);
   }
 
   &.pf-m-expanded {
@@ -179,14 +149,9 @@ $nav: "pf-c-nav";
       padding-bottom: var(--pf-l-page__header-brand--m-expanded--PaddingBottom);
     }
 
-    .pf-l-toolbar {
-      margin-top: var(--pf-l-page__header-tools--toolbar--m-expanded--MarginTop); // include margin-top for avatar to position itself vertically
-      margin-bottom: var(--pf-l-page__header-tools--toolbar--m-expanded--MarginBottom);
-    }
-
-    .pf-c-nav__horizontal-list .pf-c-nav__link {
-      padding-top: var(--pf-c-nav__horizontal-list-link--m-expanded--PaddingTop);
-      padding-bottom: var(--pf-c-nav__horizontal-list-link--m-expanded--PaddingBottom);
+    .pf-l-page__header-tools {
+      margin-top: var(--pf-l-page__header-tools--m-expanded--MarginTop); // include margin-top for avatar to position itself vertically
+      margin-bottom: var(--pf-l-page__header-tools--m-expanded--MarginBottom);
     }
   }
 }
@@ -243,15 +208,6 @@ $nav: "pf-c-nav";
     margin-left: var(--pf-l-page__header-nav--MarginLeft--md);
     background-color: transparent;
   }
-}
-
-// Context selector
-.pf-l-page__header-selector {
-  flex-shrink: 1;
-  align-items: center;
-  padding-top: var(--pf-l-page__header-selector--PaddingTop);
-  padding-bottom: var(--pf-l-page__header-selector--PaddingBottom);
-  padding-left: var(--pf-l-page__header-selector--PaddingLeft);
 }
 
 // Header tools

--- a/src/patternfly/layouts/Page/page.scss
+++ b/src/patternfly/layouts/Page/page.scss
@@ -105,14 +105,6 @@ $nav: "pf-c-nav";
   }
 }
 
-.pf-l-page__header-brand,
-.pf-l-page__header-tools {
-  transition: var(--pf-l-page--m-tall--transition--in);
-
-  .pf-m-expanded & {
-    transition: var(--pf-l-page--m-tall--transition--out);
-  }
-}
 
 // Header
 .pf-l-page__header {
@@ -131,18 +123,24 @@ $nav: "pf-c-nav";
     align-items: flex-end;
   }
 
+  .pf-l-page__header-brand,
+  .pf-l-page__header-tools {
+    transition: var(--pf-l-page--m-tall--transition--in);
+  }
+
   .pf-l-page__header-brand {
     padding-top: var(--pf-l-page__header-brand--PaddingTop);
     padding-bottom: var(--pf-l-page__header-brand--PaddingBottom);
   }
 
   .pf-l-page__header-tools {
-    margin-top: var(--pf-l-page__header-tools--MarginTop);
-    margin-bottom: var(--pf-l-page__header-tools--MarginBottom);
+    padding-top: var(--pf-l-page__header-tools--MarginTop);
+    padding-bottom: var(--pf-l-page__header-tools--MarginBottom);
   }
 
   &.pf-m-tall {
     min-height: var(--pf-l-page__header--m-tall--MinHeight);
+    transition: var(--pf-l-page--m-tall--transition--out);
 
     .pf-l-page__header-brand {
       padding-top: var(--pf-l-page__header-brand--m-tall--PaddingTop);
@@ -150,8 +148,8 @@ $nav: "pf-c-nav";
     }
 
     .pf-l-page__header-tools {
-      margin-top: var(--pf-l-page__header-tools--m-tall--MarginTop); // include margin-top for avatar to position itself vertically
-      margin-bottom: var(--pf-l-page__header-tools--m-tall--MarginBottom);
+      padding-top: var(--pf-l-page__header-tools--m-tall--MarginTop); // include margin-top for avatar to position itself vertically
+      padding-bottom: var(--pf-l-page__header-tools--m-tall--MarginBottom);
     }
   }
 }

--- a/src/patternfly/layouts/Page/page.scss
+++ b/src/patternfly/layouts/Page/page.scss
@@ -6,7 +6,7 @@ $nav: "pf-c-nav";
 .pf-l-page {
   // Header
   --pf-l-page__header--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-l-page__header--m-expanded--MinHeight: #{pf-size-prem(110px)};
+  --pf-l-page__header--m-tall--MinHeight: #{pf-size-prem(110px)};
   --pf-l-page__header--MinHeight: 0;
 
   // Header brand
@@ -17,8 +17,8 @@ $nav: "pf-c-nav";
   --pf-l-page__header-brand--PaddingBottom--sm: var(--pf-global--spacer--md);
   --pf-l-page__header-brand--BackgroundColor--md: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-l-page__header-brand--FlexBasis--lg: #{pf-size-prem(290px)};
-  --pf-l-page__header-brand--m-expanded--PaddingTop: var(--pf-global--spacer--md);
-  --pf-l-page__header-brand--m-expanded--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-l-page__header-brand--m-tall--PaddingTop: var(--pf-global--spacer--md);
+  --pf-l-page__header-brand--m-tall--PaddingBottom: var(--pf-global--spacer--md);
 
   // Toggle
   --pf-l-page__header-sidebar-toggle--PaddingTop: var(--pf-global--spacer--sm);
@@ -47,8 +47,8 @@ $nav: "pf-c-nav";
   --pf-l-page__header-tools--MarginBottom: var(--pf-global--spacer--sm);
   --pf-l-page__header-tools--MarginRight: var(--pf-global--spacer--xl);
   --pf-l-page__header-tools--avatar--MarginLeft: var(--pf-global--spacer--md);
-  --pf-l-page__header-tools--m-expanded--MarginTop: var(--pf-global--spacer--md);
-  --pf-l-page__header-tools--m-expanded--MarginBottom: var(--pf-global--spacer--md);
+  --pf-l-page__header-tools--m-tall--MarginTop: var(--pf-global--spacer--md);
+  --pf-l-page__header-tools--m-tall--MarginBottom: var(--pf-global--spacer--md);
 
   // Sidebar
   --pf-l-page__sidebar--ZIndex: var(--pf-global--ZIndex--xl);
@@ -85,8 +85,8 @@ $nav: "pf-c-nav";
   --pf-l-page__main-section--m-dark-200--BackgroundColor: var(--pf-global--BackgroundColor--dark-transparent-200);
 
   // transitions
-  --pf-l-page--m-expanded--transition--in: 250ms;
-  --pf-l-page--m-expanded--transition--out: 150ms;
+  --pf-l-page--m-tall--transition--in: 250ms;
+  --pf-l-page--m-tall--transition--out: 150ms;
 
   // Base
   display: grid;
@@ -107,10 +107,10 @@ $nav: "pf-c-nav";
 
 .pf-l-page__header-brand,
 .pf-l-page__header-tools {
-  transition: var(--pf-l-page--m-expanded--transition--in);
+  transition: var(--pf-l-page--m-tall--transition--in);
 
   .pf-m-expanded & {
-    transition: var(--pf-l-page--m-expanded--transition--out);
+    transition: var(--pf-l-page--m-tall--transition--out);
   }
 }
 
@@ -124,7 +124,7 @@ $nav: "pf-c-nav";
   align-items: flex-end;
   max-width: 100%;
   min-height: var(--pf-l-page__header--MinHeight);
-  transition: var(--pf-l-page--m-expanded--transition--in);
+  transition: var(--pf-l-page--m-tall--transition--in);
 
   > * {
     display: flex;
@@ -141,17 +141,17 @@ $nav: "pf-c-nav";
     margin-bottom: var(--pf-l-page__header-tools--MarginBottom);
   }
 
-  &.pf-m-expanded {
-    min-height: var(--pf-l-page__header--m-expanded--MinHeight);
+  &.pf-m-tall {
+    min-height: var(--pf-l-page__header--m-tall--MinHeight);
 
     .pf-l-page__header-brand {
-      padding-top: var(--pf-l-page__header-brand--m-expanded--PaddingTop);
-      padding-bottom: var(--pf-l-page__header-brand--m-expanded--PaddingBottom);
+      padding-top: var(--pf-l-page__header-brand--m-tall--PaddingTop);
+      padding-bottom: var(--pf-l-page__header-brand--m-tall--PaddingBottom);
     }
 
     .pf-l-page__header-tools {
-      margin-top: var(--pf-l-page__header-tools--m-expanded--MarginTop); // include margin-top for avatar to position itself vertically
-      margin-bottom: var(--pf-l-page__header-tools--m-expanded--MarginBottom);
+      margin-top: var(--pf-l-page__header-tools--m-tall--MarginTop); // include margin-top for avatar to position itself vertically
+      margin-bottom: var(--pf-l-page__header-tools--m-tall--MarginBottom);
     }
   }
 }


### PR DESCRIPTION
This moves the styles that were in the page layout for horizontal nav back to the nav component. Also moves the spacing for the toolbar to the header tools layout and not the toolbar layout.