### PR TITLE
fix(grid): add min-width/height 0 to override min-content

### DIFF
--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -49,9 +49,11 @@
   grid-template-columns: repeat(12, [col-start] 1fr);
 
   > *,
-  &__item {
+  .pf-l-grid__item {
     grid-column-start: auto;
     grid-column-end: span 12;
+    min-width: 0;
+    min-height: 0;
   }
 
   // Loop through $breakpoints map to generate responsive classes


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/920