### PR TITLE
feat(PopoverUpgradeExamples): Adding PF3 and PF4 right popover for comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8210,7 +8210,7 @@
       "dependencies": {
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         }
@@ -26637,9 +26637,9 @@
       "dev": true
     },
     "shallowequal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "dev": true
     },
     "sharp": {

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
@@ -7,12 +7,14 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 | PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
 | -- | -- | -- | -- | -- |
 | `.popovers-pf` | `<div>` | `pf-c-popover` | `<div>` | Ceates parent container that holds the popover. |
-| `.container-popovers-pf` | `<div>` | `.pf-c-popover__content` | `<div>` | Creates the container for the popover itself. |
+| `.popover` | `<div>` | `.pf-c-popover__content` | `<div>` | Creates the container for the popover itself. |
+| `.container-popovers-pf` | `<div>` | -- | -- | Creates the container for the popover. |
 | `.top` | `<div>` | `.pf-m-top` | `<div>` | Directs the direction of the popover arrow. Required. |
 | `.right` | `<div>` | `.pf-m-right` | `<div>` | Directs the direction of the popover arrow. Required. |
 | `.bottom` | `<div>` | `.pf-m-bottom` | `<div>` | Directs the direction of the popover arrow. Required. |
 | `.left` | `<div>` | `.pf-m-left` | `<div>` | Directs the direction of the popover arrow. Required. |
 | `.arrow` | `<div>` | `.pf-c-popover__arrow` | `<div>` | Creates an arrow pointing towards the element the popover describes. Required. |
 | `.close` | `<span>` |`.pf-c-popover__close` | `<div>` | Creates the closing button for the popover. |
+| -- | -- | `.pf-c-popover__header` | `<header>` | Creates Popover Header. |
 | `.popover-title` | `<h3>` | `.pf-c-popover__header-title` | `<h1>` | Creates popover title. |    
 | `.popover-content` | `<div>` | `.pf-c-popover__body` | `<div>` | Creates the body of a popover. Required. |

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
@@ -6,8 +6,13 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 
 | PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
 | -- | -- | -- | -- | -- |
-| `.popover` | `<dvi>` | `.pf-c-popover__content` | `<div>` | Creates the container for the popover. |
-| `.pficon-close` | `<span>` |`.pf-c-popover__close` | `<div>` | Creates the closing button for the popover. |
-| `.popover-title` | `h3` | `.pf-c-popover__header` | `<header>` | Creates the header of a popover. |
-| `.popover-title` | `h3` | `.pf-c-popover__header-title` | `<h1>` | Creates the header body. |    
+| `.popovers-pf` | `<div>` | `pf-c-popover` | `<div>` | Ceates parent container that holds the popover. |
+| `.container-popovers-pf` | `<div>` | `.pf-c-popover__content` | `<div>` | Creates the container for the popover itself. |
+| `.top` | `<div>` | `.pf-m-top` | `<div>` | Directs the direction of the popover arrow. Required. |
+| `.right` | `<div>` | `.pf-m-right` | `<div>` | Directs the direction of the popover arrow. Required. |
+| `.bottom` | `<div>` | `.pf-m-bottom` | `<div>` | Directs the direction of the popover arrow. Required. |
+| `.left` | `<div>` | `.pf-m-left` | `<div>` | Directs the direction of the popover arrow. Required. |
+| `.arrow` | `<div>` | `.pf-c-popover__arrow` | `<div>` | Creates an arrow pointing towards the element the popover describes. Required. |
+| `.close` | `<span>` |`.pf-c-popover__close` | `<div>` | Creates the closing button for the popover. |
+| `.popover-title` | `<h3>` | `.pf-c-popover__header-title` | `<h1>` | Creates popover title. |    
 | `.popover-content` | `<div>` | `.pf-c-popover__body` | `<div>` | Creates the body of a popover. Required. |

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
@@ -6,7 +6,7 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 
 | PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
 | -- | -- | -- | -- | -- |
-| `.popovers-pf` | `<div>` | `pf-c-popover` | `<div>` | Ceates parent container that holds the popover. |
+| `.popovers-pf` | `<div>` | `pf-c-popover` | `<div>` | Creates parent container that holds the popover. |
 | `.popover` | `<div>` | `.pf-c-popover__content` | `<div>` | Creates the container for the popover itself. |
 | `.container-popovers-pf` | `<div>` | -- | -- | Creates the container for the popover. |
 | `.top` | `<div>` | `.pf-m-top` | `<div>` | Directs the direction of the popover arrow. Required. |
@@ -15,6 +15,6 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 | `.left` | `<div>` | `.pf-m-left` | `<div>` | Directs the direction of the popover arrow. Required. |
 | `.arrow` | `<div>` | `.pf-c-popover__arrow` | `<div>` | Creates an arrow pointing towards the element the popover describes. Required. |
 | `.close` | `<span>` |`.pf-c-popover__close` | `<div>` | Creates the closing button for the popover. |
-| -- | -- | `.pf-c-popover__header` | `<header>` | Creates Popover Header. |
+| -- | -- | `.pf-c-popover__header` | `<header>` | Creates popover header. |
 | `.popover-title` | `<h3>` | `.pf-c-popover__header-title` | `<h1>` | Creates popover title. |    
 | `.popover-content` | `<div>` | `.pf-c-popover__body` | `<div>` | Creates the body of a popover. Required. |

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
@@ -6,7 +6,8 @@ When converting PatternFly 3 components to PatternFly 4 components, you must als
 
 | PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
 | -- | -- | -- | -- | -- |
-| `.popover-pf` | `<div>` | `.pf-c-popover` | `<div>` | Creates a popover containing content. |
-| `.popover-pf-heading` | `<div>` | `.pf-c-popover__header` | `.pf-c-popover` | Creates the header of a popover. |    
-| `.popover-pf-body` | `<div>` | `.pf-c-popover__body` | `.pf-c-popover` | Creates the body of a popover. Required. | 
-| `.popover-pf-footer` | `<div>` | `.pf-c-popover__footer` | `.pf-c-popover` | Creates the footer of a popover. | 
+| `.popover` | `<dvi>` | `.pf-c-popover__content` | `<div>` | Creates the container for the popover. |
+| `.pficon-close` | `<span>` |`.pf-c-popover__close` | `<div>` | Creates the closing button for the popover. |
+| `.popover-title` | `h3` | `.pf-c-popover__header` | `<header>` | Creates the header of a popover. |
+| `.popover-title` | `h3` | `.pf-c-popover__header-title` | `<h1>` | Creates the header body. |    
+| `.popover-content` | `<div>` | `.pf-c-popover__body` | `<div>` | Creates the body of a popover. Required. |

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/docs/code.md
@@ -1,0 +1,12 @@
+## Overview
+
+When converting PatternFly 3 components to PatternFly 4 components, you must also take into consideration the layouts and sizings that PatternFly 3 utilized from Bootstrap 3.
+
+## Usage
+
+| PF3 Class | Applied To | PF4 Class | Applied To | Outcome |
+| -- | -- | -- | -- | -- |
+| `.popover-pf` | `<div>` | `.pf-c-popover` | `<div>` | Creates a popover containing content. |
+| `.popover-pf-heading` | `<div>` | `.pf-c-popover__header` | `.pf-c-popover` | Creates the header of a popover. |    
+| `.popover-pf-body` | `<div>` | `.pf-c-popover__body` | `.pf-c-popover` | Creates the body of a popover. Required. | 
+| `.popover-pf-footer` | `<div>` | `.pf-c-popover__footer` | `.pf-c-popover` | Creates the footer of a popover. | 

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/index.js
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/index.js
@@ -10,7 +10,7 @@ export const Docs = docs;
 export default () => {
   const PopoverUpgradeExamplesExample1 = PopoverupgradeexamplesExample1();
   const PopoverUpgradeExamplesExample2 = PopoverupgradeexamplesExample2();
-  const headingText = 'Card Migration';
+  const headingText = 'Popover Migration';
 
   return (
     <Documentation docs={Docs} heading={headingText}>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/index.js
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Documentation from '@siteComponents/Documentation';
+import Example from '@siteComponents/Example';
+import docs from '../docs/code.md';
+import PopoverupgradeexamplesExample1 from './popover-upgrade-examples-example1.hbs';
+import PopoverupgradeexamplesExample2 from './popover-upgrade-examples-example2.hbs';
+
+export const Docs = docs;
+
+export default () => {
+  const PopoverUpgradeExamplesExample1 = PopoverupgradeexamplesExample1();
+  const PopoverUpgradeExamplesExample2 = PopoverupgradeexamplesExample2();
+  const headingText = 'Card Migration';
+
+  return (
+    <Documentation docs={Docs} heading={headingText}>
+      <Example heading="PatternFly 3 Popover">{PopoverUpgradeExamplesExample1}</Example>
+      <Example heading="PatternFly 4 Popover">{PopoverUpgradeExamplesExample2}</Example>
+    </Documentation>
+  );
+};

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/index.js
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
 import docs from '../docs/code.md';
@@ -14,6 +15,13 @@ export default () => {
 
   return (
     <Documentation docs={Docs} heading={headingText}>
+      <Helmet>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.54.1/css/patternfly.css" />
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.54.1/css/patternfly-additions.css"
+        />
+      </Helmet>
       <Example heading="PatternFly 3 Popover">{PopoverUpgradeExamplesExample1}</Example>
       <Example heading="PatternFly 4 Popover">{PopoverUpgradeExamplesExample2}</Example>
     </Documentation>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
@@ -6,7 +6,7 @@
         <h3 class="popover-title closable">Popover Header
           <button type="button" class="close" aria-hidden="true"><span class="pficon pficon-close"></span></button>
         </h3>
-      <div class="popover-content"><b>Popover Body</b> <br> <br> This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.</div>
+      <div class="popover-content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
     </div>
   </div>
 </div>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
@@ -1,7 +1,7 @@
 {{#> popover-upgrade-examples}}
 <div class="popovers-pf">
   <div class="container-fluid container-popovers-pf">
-   <div class="popover fade right in" role="tooltip" style="top: 147px; left: 156.25px; display: block;">
+   <div class="popover fade right in" role="tooltip" style="display: block; position:relative;">
       <div class="arrow" style="top: 50%;"></div>
         <h3 class="popover-title closable">1 http smartproxy 1 http http http
           <button type="button" class="close" aria-hidden="true"><span class="pficon pficon-close"></span></button>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
@@ -3,10 +3,10 @@
   <div class="container-fluid container-popovers-pf">
    <div class="popover fade right in" role="tooltip" style="display: block; position:relative;">
       <div class="arrow" style="top: 50%;"></div>
-        <h3 class="popover-title closable">1 http smartproxy 1 http http http
+        <h3 class="popover-title closable">Popover Header
           <button type="button" class="close" aria-hidden="true"><span class="pficon pficon-close"></span></button>
         </h3>
-      <div class="popover-content">This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.</div>
+      <div class="popover-content"><b>Popover Body</b> <br> <br> This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.</div>
     </div>
   </div>
 </div>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
@@ -1,36 +1,16 @@
 {{#> popover-upgrade-examples}}
 <div class="popovers-pf">
   <div class="container-fluid container-popovers-pf">
-    <div class="row row-popovers-pf">
-      <div class="col-sm-3">
-        <div class="popover-pf">
-          <div class="popover-pf-heading">
-            <h2 class="popover-pf-title">
-              popover Title
-            </h2>
-          </div>
-          <div class="popover-pf-body">
-            <p>
-              popover Contents
-            </p>
-          </div>
-        </div>
-      </div>
-      <div class="col-sm-3">
-        <div class="popover-pf">
-          <div class="popover-pf-heading">
-            <h2 class="popover-pf-title">
-              popover Title
-            </h2>
-          </div>
-          <div class="popover-pf-body">
-            <p>
-              popover Contents
-            </p>
-          </div>
-        </div>
-      </div>
+   <div class="popover fade right in" role="tooltip" style="top: 147px; left: 156.25px; display: block;">
+      <div class="arrow" style="top: 50%;"></div>
+        <h3 class="popover-title closable">1 http smartproxy 1 http http http
+          <button type="button" class="close" aria-hidden="true"><span class="pficon pficon-close"></span></button>
+        </h3>
+      <div class="popover-content">This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy. This is more information about a smartproxy.</div>
     </div>
   </div>
 </div>
 {{/popover-upgrade-examples}}
+
+
+

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example1.hbs
@@ -1,0 +1,36 @@
+{{#> popover-upgrade-examples}}
+<div class="popovers-pf">
+  <div class="container-fluid container-popovers-pf">
+    <div class="row row-popovers-pf">
+      <div class="col-sm-3">
+        <div class="popover-pf">
+          <div class="popover-pf-heading">
+            <h2 class="popover-pf-title">
+              popover Title
+            </h2>
+          </div>
+          <div class="popover-pf-body">
+            <p>
+              popover Contents
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-3">
+        <div class="popover-pf">
+          <div class="popover-pf-heading">
+            <h2 class="popover-pf-title">
+              popover Title
+            </h2>
+          </div>
+          <div class="popover-pf-body">
+            <p>
+              popover Contents
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{{/popover-upgrade-examples}}

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
@@ -6,8 +6,5 @@
     {{#> popover-body}}
       Body
     {{/popover-body}}
-    {{#> popover-footer}}
-      Footer
-    {{/popover-footer}}
   {{/popover}}
 {{/popover-upgrade-examples}}

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
@@ -1,10 +1,21 @@
 {{#> popover-upgrade-examples}}
-  {{#> popover}}
-    {{#> popover-header}}
-      Header
-    {{/popover-header}}
-    {{#> popover-body}}
-      Body
-    {{/popover-body}}
-  {{/popover}}
+  <div class="pf-c-popover pf-m-right" role="dialog" aria-modal="true" aria-labelledby="popover-right-header" aria-describedby="popover-right-body">
+  <div class="pf-c-popover__arrow">
+  </div>
+  <div class="pf-c-popover__content">
+    <div class="pf-c-popover__close">
+      <button class="pf-c-button pf-m-plain" aria-label="Close">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+    <header class="pf-c-popover__header">
+      <h1 class="pf-c-popover__header-title" id="popover-right-header">
+        Popover Header
+      </h1>
+    </header>
+    <div class="pf-c-popover__body" id="popover-right-body">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+    </div>
+  </div>
+</div>
 {{/popover-upgrade-examples}}

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
@@ -14,7 +14,7 @@
       </h1>
     </header>
     <div class="pf-c-popover__body" id="popover-right-body">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+      Popover Body <br> <br> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
     </div>
   </div>
 </div>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
@@ -1,5 +1,5 @@
 {{#> popover-upgrade-examples}}
-  <div class="pf-c-popover pf-m-right" role="dialog" aria-modal="true" aria-labelledby="popover-right-header" aria-describedby="popover-right-body">
+<div class="pf-c-popover pf-m-right" role="dialog" aria-modal="true" aria-labelledby="popover-right-header" aria-describedby="popover-right-body">
   <div class="pf-c-popover__arrow">
   </div>
   <div class="pf-c-popover__content">

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
@@ -14,7 +14,7 @@
       </h1>
     </header>
     <div class="pf-c-popover__body" id="popover-right-body">
-      Popover Body <br> <br> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
     </div>
   </div>
 </div>

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/examples/popover-upgrade-examples-example2.hbs
@@ -1,0 +1,13 @@
+{{#> popover-upgrade-examples}}
+  {{#> popover}}
+    {{#> popover-header}}
+      Header
+    {{/popover-header}}
+    {{#> popover-body}}
+      Body
+    {{/popover-body}}
+    {{#> popover-footer}}
+      Footer
+    {{/popover-footer}}
+  {{/popover}}
+{{/popover-upgrade-examples}}

--- a/src/patternfly/upgrade-examples/PopoverUpgradeExamples/popover-upgrade-examples.hbs
+++ b/src/patternfly/upgrade-examples/PopoverUpgradeExamples/popover-upgrade-examples.hbs
@@ -1,0 +1,1 @@
+{{> @partial-block}}


### PR DESCRIPTION
fixes #418.

**MIGRATION DOC**
Popover Upgrade Examples

**Features:**
- added PF3 popover based classes and code examples
- added PF4 popover based classes and code examples
- added content to the class comparison documentation at the bottom of the page.

