### PR TITLE
fix(aboutmodalbox): center close icon button

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -249,7 +249,7 @@
   // Since this btn is unique to the about modal, use contextual selectors in this specific instance
   .pf-c-button.pf-m-plain {
     display: flex;
-    align-content: center;
+    align-items: center;
     justify-content: center;
     width: var(--pf-c-about-modal-box__button-close--Width);
     height: var(--pf-c-about-modal-box__button-close--Height);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1016

this was broken in Edge.