### PR TITLE
fix(tableRowStyling): mirror datalist item box shadow styling for expandable table tr item.

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -155,6 +155,7 @@ $pf-c-table-xs-breakpoint: 380px;
 
   // Modifier - Expandable row expanded
   --pf-c-table__expandable-row--m-expanded--BoxShadow:        var(--pf-global--BoxShadow--md);
+  --pf-c-table__expandable-row--m-expanded--BoxShadow--bottom:var(--pf-global--BoxShadow--md-bottom);
 
   // Modifier - Sort descending
   --pf-c-table__sort--sorted--Color:                          var(--pf-global--active-color--100);
@@ -277,7 +278,7 @@ $pf-c-table-xs-breakpoint: 380px;
     // reset borders to default values
     border-bottom-color: var(--pf-c-table--BorderColor);
     border-bottom-width: var(--pf-c-table--BorderWidth);
-    box-shadow: var(--pf-c-table__expandable-row--m-expanded--BoxShadow);
+    box-shadow: var(--pf-c-table__expandable-row--m-expanded--BoxShadow--bottom);
 
     td:first-child::before {
       background-color: var(--pf-c-table__expandable-row--before--BackgroundColor);


### PR DESCRIPTION
fixes #956.

Applied DataList list item box-shadow property to expandable table tr list items. 

**BEFORE:**
<img width="1059" alt="48739664-3c504b00-ec1a-11e8-9cfd-39646331bf8d" src="https://user-images.githubusercontent.com/1402829/49894393-dd967f80-fe1b-11e8-8623-e203bb3c718f.png">

**AFTER:**
![screen shot 2018-12-12 at 2 40 57 pm](https://user-images.githubusercontent.com/1402829/49894465-f9018a80-fe1b-11e8-839a-7932937c184f.png)
