### PR TITLE
feat(dropdown): Implements search interface for dropdown with many items

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown-menu-search.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu-search.hbs
@@ -1,0 +1,21 @@
+<ul class="pf-c-dropdown__menu{{#if dropdown-menu--modifier}} {{dropdown-menu--modifier}}{{/if}}"
+  aria-labelledby="{{id}}-button"
+  {{#unless dropdown--IsExpanded}}hidden{{/unless}}
+  {{#if dropdown-menu--attribute}}
+	  {{{dropdown-menu--attribute}}}
+  {{/if}}>
+  <li>
+    {{#> input-group}}
+      {{#> form-control controlType="input" input="true" form-control--attribute='type="search" id="textInput11" name="textInput11" aria-label="search input example"'}}
+      {{/form-control}}
+      {{#> button button--modifier="pf-m-tertiary" button--HasSearchIcon="true" button--attribute='aria-label="search button for search input"'}}
+      {{/button}}
+    {{/input-group}}
+  </li>
+  <li><a class="pf-c-dropdown__menu-item" href="#">Link</a></li>
+  <li><button class="pf-c-dropdown__menu-item">Action</button></li>
+  <li><a class="pf-c-dropdown__menu-item pf-m-disabled" aria-disabled="true" tabindex="-1" href="#">Disabled Link</a></li>
+  <li><button class="pf-c-dropdown__menu-item" disabled>Disabled Action</button></li>
+  <li class="pf-c-dropdown__separator" role="separator"></li>
+  <li><a class="pf-c-dropdown__menu-item" href="#">Separated Link</a></li>
+</ul>

--- a/src/patternfly/components/Dropdown/dropdown.hbs
+++ b/src/patternfly/components/Dropdown/dropdown.hbs
@@ -14,6 +14,8 @@
     {{> dropdown-multi-select}}
   {{else if dropdown--IsActionMenu}}
     {{> dropdown-menu}}
+  {{else if dropdown--IsSearch}}
+    {{> dropdown-menu-search}}    
   {{else}}
     {{> dropdown-basic}}
   {{/if}}

--- a/src/patternfly/components/Dropdown/examples/dropdown-search-expanded-example.hbs
+++ b/src/patternfly/components/Dropdown/examples/dropdown-search-expanded-example.hbs
@@ -1,0 +1,3 @@
+{{#> dropdown id="dropdown-example-expanded" dropdown--IsSearch="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+  Expanded Dropdown
+{{/dropdown}}

--- a/src/patternfly/components/Dropdown/examples/index.js
+++ b/src/patternfly/components/Dropdown/examples/index.js
@@ -14,6 +14,8 @@ import DropdownKebabAlignRightRaw from '!raw!./dropdown-kebab-align-right-exampl
 import DropdownAlignRightRaw from '!raw!./dropdown-align-right-example.hbs';
 import DropdownTopRaw from '!raw!./dropdown-top-example.hbs';
 import DropdownExpanded from './dropdown-expanded-example.hbs';
+import DropdownSearchExpandedRaw from '!raw!./dropdown-search-expanded-example.hbs';
+import DropdownSearchExpanded from './dropdown-search-expanded-example.hbs';
 import DropdownBasicExpanded from './dropdown-basic-expanded-example.hbs';
 import DropdownSelectExpanded from './dropdown-select-expanded-example.hbs';
 import DropdownSelectExpandedSelected from './dropdown-select-expanded-selected-example.hbs';
@@ -35,6 +37,7 @@ export const Docs = docs;
 
 export default () => {
   const dropdownExpanded = DropdownExpanded();
+  const dropdownSearchExpanded = DropdownSearchExpanded();
   const dropdownBasicExpanded = DropdownBasicExpanded();
   const dropdownSelectExpanded = DropdownSelectExpanded();
   const dropdownSelectExpandedSelected = DropdownSelectExpandedSelected();
@@ -63,21 +66,24 @@ export default () => {
       <Example heading="Dropdown (collapsed)" handlebars={DropdownCollapsedRaw}>
         {dropdownCollapsed}
       </Example>
-      <Example className="is-expanded-dropdown" 
-        heading="Dropdown Select (expanded)" 
+      <Example className="is-expanded-dropdown" heading="Dropdown with links and actions and search (expanded)" handlebars={DropdownSearchExpandedRaw}>
+        {dropdownSearchExpanded}
+      </Example>
+      <Example className="is-expanded-dropdown"
+        heading="Dropdown Select (expanded)"
         handlebars={DropdownSelectExpandedRaw}
         docs={DropdownSelectDoc}>
         {dropdownSelectExpanded}
       </Example>
-      <Example className="is-expanded-dropdown" 
-        heading="Dropdown Select (expanded, first item selected)" 
+      <Example className="is-expanded-dropdown"
+        heading="Dropdown Select (expanded, first item selected)"
         handlebars={DropdownSelectExpandedSelectedRaw}
         docs={DropdownSelectDoc}>
         {dropdownSelectExpandedSelected}
       </Example>
-      <Example 
-        heading="Dropdown Select (collapsed)" 
-        handlebars={DropdownSelectRaw} 
+      <Example
+        heading="Dropdown Select (collapsed)"
+        handlebars={DropdownSelectRaw}
         docs={DropdownSelectDoc}>
         {dropdownSelect}
       </Example>


### PR DESCRIPTION
End objective is to create a Context Selector as described in https://github.com/patternfly/patternfly-next/issues/133. When discussing with @mcoker decided to see if the existing dropdown component can be used.

Started with a basic example of a dropdown with search only using existing PF4 code. Visually this is not optimal but serves a a starting point for further conversation/improvement.

<img width="640" alt="screenshot 2018-12-14 17 03 09" src="https://user-images.githubusercontent.com/54224/50013688-2be58300-ffc2-11e8-86fa-401b995a2536.png">
