### PR TITLE
fix(about-modal): makes changes for Openshift POC

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box-logo-image.hbs
+++ b/src/patternfly/components/AboutModalBox/about-modal-box-logo-image.hbs
@@ -1,4 +1,0 @@
-<img class="pf-c-about-modal-box__logo-image{{#if about-modal-box-logo-image--modifier}} {{about-modal-box-logo-image--modifier}}{{/if}}"
-  {{#if about-modal-box-logo-image--attribute}}
-    {{{about-modal-box-logo-image--attribute}}}
-  {{/if}}>

--- a/src/patternfly/components/AboutModalBox/about-modal-box-logo.hbs
+++ b/src/patternfly/components/AboutModalBox/about-modal-box-logo.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-about-modal-box__logo{{#if about-modal-box-logo--modifier}} {{about-modal-box-logo--modifier}}{{/if}}"
-  {{#if about-modal-box-logo--attribute}}
-    {{{about-modal-box-logo--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -81,23 +81,6 @@
   // This is the min allowable height of the content
   --pf-c-about-modal-box__content--MinHeight: calc(1rem * 4 * var(--pf-global--LineHeight--md));
 
-  // Logo
-  // Set default padding right, bottom, left to shared values
-  --pf-c-about-modal-box__logo--PaddingRight: var(--pf-c-about-modal-box--PaddingRight);
-  --pf-c-about-modal-box__logo--PaddingBottom: var(--pf-c-about-modal-box--PaddingBottom);
-  --pf-c-about-modal-box__logo--PaddingLeft: var(--pf-c-about-modal-box--PaddingLeft);
-
-  // Logo image
-  --pf-c-about-modal-box__logo-image--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-about-modal-box__logo-image--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-about-modal-box__logo-image--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-about-modal-box__logo-image--PaddingLeft: var(--pf-global--spacer--md);
-
-  // height and width determined manually by visual design
-  --pf-c-about-modal-box__logo-image--Width: #{pf-size-prem(236px)};
-  --pf-c-about-modal-box__logo-image--Height: #{pf-size-prem(110px)};
-  --pf-c-about-modal-box__logo-image--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
-
   // Button close
   --pf-c-about-modal-box__button-close--Color: var(--pf-global--Color--100);
   --pf-c-about-modal-box__button-close--hover--Color: var(--pf-global--Color--100);

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -9,7 +9,7 @@
   --pf-c-about-modal-box--BackgroundColor: #{$pf-color-black-1000};
 
   // This is a special one-off glow for the about modal
-  --pf-c-about-modal-box--BoxShadow: 0 0 100px 0 rgba(256, 256, 256, .05);
+  --pf-c-about-modal-box--BoxShadow: 0 0 100px 0 rgba(255, 255, 255, .05);
   --pf-c-about-modal-box--ZIndex: var(--pf-global--ZIndex--2xl);
 
   // Width and height values are determined by design
@@ -128,15 +128,11 @@
   height: 100vh;
   overflow-x: hidden;
   overflow-y: auto;
-  /* stylelint-disable */
-  scrollbar-color: #c10;
   background-color: var(--pf-c-about-modal-box--BackgroundColor); // Because this component is always dark, set the background color
   box-shadow: var(--pf-c-about-modal-box--BoxShadow);
-  grid-template-columns: var(--pf-c-about-modal-box--grid-template-columns);
 
   @media only screen and (min-width: $pf-global--breakpoint--sm) {
-    --pf-c-about-modal-box--grid-template-columns: var(--pf-c-about-modal-box--lg--grid-template-columns);
-
+    grid-template-columns: var(--pf-c-about-modal-box--sm--grid-template-columns);
     grid-template-areas:
       "brand          hero"
       "header         hero"

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -2,18 +2,21 @@
 
 .pf-c-about-modal-box {
   // Component variables
+  --pf-c-about-modal-box--sm--grid-template-columns: 5fr 1fr;
+  --pf-c-about-modal-box--lg--grid-template-columns: 70fr 30fr;
+
   // Modal uses a non-standard background color
   --pf-c-about-modal-box--BackgroundColor: #{$pf-color-black-1000};
 
   // This is a special one-off glow for the about modal
-  --pf-c-about-modal-box--BoxShadow: 0 0 100px 0 rgba(256, 256, 256, .4);
+  --pf-c-about-modal-box--BoxShadow: 0 0 100px 0 rgba(256, 256, 256, .05);
   --pf-c-about-modal-box--ZIndex: var(--pf-global--ZIndex--2xl);
 
   // Width and height values are determined by design
-  --pf-c-about-modal-box--MaxWidth: #{pf-size-prem(1232px)};
+  --pf-c-about-modal-box--MaxWidth: #{pf-size-prem(1109px)};
 
   // Height is optimized for the exact height desired
-  --pf-c-about-modal-box--Height: #{pf-size-prem(762px)};
+  --pf-c-about-modal-box--Height: #{pf-size-prem(686px)};
 
   // MinHeight is based on all the spacers we know we have, plus some LineHeight to make some space for at least one line of content in each section
   --pf-c-about-modal-box--MinHeight: calc(var(--pf-c-about-modal-box__brand--PaddingTop) + var(--pf-c-about-modal-box__brand--PaddingBottom) + var(--pf-c-about-modal-box__header--PaddingBottom) + var(--pf-c-about-modal-box__content--MarginTop) + var(--pf-c-about-modal-box__content--MarginBottom) + var(--pf-c-about-modal-box__brand-image--Height) + (1rem * 6 * var(--pf-global--LineHeight--md)));
@@ -118,33 +121,31 @@
   grid-template-areas:
     "brand close"
     "header header"
-    "content content"
-    "logo logo";
+    "content content";
 
   // Modal is full screen until larger breakpoint
   width: 100vw;
   height: 100vh;
   overflow-x: hidden;
   overflow-y: auto;
+  /* stylelint-disable */
+  scrollbar-color: #c10;
   background-color: var(--pf-c-about-modal-box--BackgroundColor); // Because this component is always dark, set the background color
   box-shadow: var(--pf-c-about-modal-box--BoxShadow);
+  grid-template-columns: var(--pf-c-about-modal-box--grid-template-columns);
 
   @media only screen and (min-width: $pf-global--breakpoint--sm) {
-    grid-template-columns: 5fr 1fr;
-    grid-template-areas:
-      "brand          hero"
-      "header         hero"
-      "content        hero"
-      "logo           hero";
-  }
+    --pf-c-about-modal-box--grid-template-columns: var(--pf-c-about-modal-box--lg--grid-template-columns);
 
-  @media only screen and (min-width: $pf-global--breakpoint--lg) {
-    grid-template-columns: 62fr 38fr;
-    grid-template-rows: max-content max-content auto;
     grid-template-areas:
       "brand          hero"
       "header         hero"
       "content        hero";
+  }
+
+  @media only screen and (min-width: $pf-global--breakpoint--lg) {
+    grid-template-columns: var(--pf-c-about-modal-box--lg--grid-template-columns);
+    grid-template-rows: max-content max-content auto;
     max-width: var(--pf-c-about-modal-box--MaxWidth);
     height: var(--pf-c-about-modal-box--Height);
     min-height: var(--pf-c-about-modal-box--MinHeight);
@@ -191,36 +192,13 @@
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 
   @media screen and (min-width: $pf-global--breakpoint--sm) {
     min-height: auto;
     overflow: visible;
     overscroll-behavior: auto;
   }
-}
-
-// Logo
-.pf-c-about-modal-box__logo {
-  grid-area: logo;
-  padding-right: var(--pf-c-about-modal-box__logo--PaddingRight);
-  padding-bottom: var(--pf-c-about-modal-box__logo--PaddingBottom);
-  padding-left: var(--pf-c-about-modal-box__logo--PaddingLeft);
-
-  @media only screen and (min-width: $pf-global--breakpoint--lg) {
-    grid-area: 2 / 2;
-    align-self: end;
-    padding: 0;
-  }
-}
-
-.pf-c-about-modal-box__logo-image {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--pf-c-about-modal-box__logo-image--Width);
-  height: var(--pf-c-about-modal-box__logo-image--Height);
-  padding: var(--pf-c-about-modal-box__logo-image--PaddingTop) var(--pf-c-about-modal-box__logo-image--PaddingRight) var(--pf-c-about-modal-box__logo-image--PaddingBottom) var(--pf-c-about-modal-box__logo-image--PaddingLeft);
-  background-color: var(--pf-c-about-modal-box__logo-image--BackgroundColor);
 }
 
 // Close

--- a/src/patternfly/components/AboutModalBox/docs/code.md
+++ b/src/patternfly/components/AboutModalBox/docs/code.md
@@ -25,7 +25,5 @@ About modal layout.
 | `.pf-c-about-modal-box__header`       |  `<div>`, `<header>`   |  Initiates a modal box header cell. |
 | `.pf-c-about-modal-box__hero`         |  `<div>`               |  Initiates a modal box hero cell. |
 | `.pf-c-about-modal-box__hero-image`   |  `<img>`               |  Initiates a modal box hero image. |
-| `.pf-c-about-modal-box__logo`         |  `<div>`               |  Initiates a modal box logo cell. |
-| `.pf-c-about-modal-box__logo-image`   |  `<img>`               |  Initiates a modal box logo image. |
 | `.pf-c-about-modal-box__content`      |  `<div>`               |  Initiates a modal box content cell. |
 | `.pf-m-hover` | `.pf-c-about-modal-box__close .pf-c-button.pf-m-action` | Forces display of the hover state of the button. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:hover` pseudo-class.

--- a/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
+++ b/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
@@ -21,10 +21,6 @@
     {{#> about-modal-box-hero-image about-modal-box-hero-image--attribute='src="/assets/images/pfbg_992.jpg" alt="Patternfly Background Image"'}}
     {{/about-modal-box-hero-image}}
   {{/about-modal-box-hero}}
-  {{#> about-modal-box-logo}}
-    {{#> about-modal-box-logo-image about-modal-box-logo-image--attribute='src="/assets/images/pf_logo.svg" alt="Product Logo"'}}
-    {{/about-modal-box-logo-image}}
-  {{/about-modal-box-logo}}
   {{#> about-modal-box-content}}
     content
   {{/about-modal-box-content}}

--- a/src/patternfly/components/Backdrop/backdrop.scss
+++ b/src/patternfly/components/Backdrop/backdrop.scss
@@ -2,7 +2,7 @@
 
 .pf-c-backdrop {
   --pf-c-backdrop--ZIndex: var(--pf-global--ZIndex--2xl);
-  --pf-c-backdrop--Color: var(--pf-global--BackgroundColor--dark-transparent-200);
+  --pf-c-backdrop--Color: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-c-backdrop--BackdropFilter: blur(10px);
 
   position: fixed;

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -7,6 +7,9 @@
   --pf-c-content--FontSize: var(--pf-global--FontSize--md);
   --pf-c-content--FontWeight: var(--pf-global--FontWeight--normal);
 
+  // this ensures color is not overridden
+  --pf-c-content--Color: var(--pf-global--Color--100);
+
   // h1 - Main title
   --pf-c-content--h1--MarginTop: var(--pf-global--spacer--lg);
   --pf-c-content--h1--MarginBottom: var(--pf-global--spacer--md);
@@ -86,6 +89,10 @@
 
   font-size: var(--pf-c-content--FontSize);
   line-height: var(--pf-c-content--LineHeight);
+
+  & * {
+    color: var(--pf-c-content--Color);
+  }
 
   a {
     color: var(--pf-c-content--a--Color);

--- a/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
+++ b/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
@@ -24,10 +24,6 @@
           {{#> about-modal-box-hero-image about-modal-box-hero-image--attribute='src="/assets/images/pfbg_992.jpg" alt="Patternfly Background Image"'}}
           {{/about-modal-box-hero-image}}
         {{/about-modal-box-hero}}
-        {{#> about-modal-box-logo}}
-          {{#> about-modal-box-logo-image about-modal-box-logo-image--attribute='src="/assets/images/pf_logo.svg" alt="Product Logo"'}}
-          {{/about-modal-box-logo-image}}
-        {{/about-modal-box-logo}}
         {{#> about-modal-box-content}}
           {{#> content}}
           <dl>


### PR DESCRIPTION
This is work requested by @kybaker for the Openshift POC.

The about modal has been simplified a bit by removing the secondary logo.

Also a bunch of minor design changes :)