### PR TITLE
feat(AlertGroup): Introduce Alert Group component

### DIFF
--- a/src/patternfly/components/AlertGroup/alert-group.hbs
+++ b/src/patternfly/components/AlertGroup/alert-group.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-alert-group{{#if alert-group--modifier}} {{alert-group--modifier}}{{/if}}"
+<ul class="pf-c-alert-group{{#if alert-group--modifier}} {{alert-group--modifier}}{{/if}}"
   {{#if alert-group--attribute}}
     {{{alert-group--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</ul>

--- a/src/patternfly/components/AlertGroup/alert-group.hbs
+++ b/src/patternfly/components/AlertGroup/alert-group.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-alert-group{{#if alert-group--modifier}} {{alert-group--modifier}}{{/if}}"
+  {{#if alert-group--attribute}}
+    {{{alert-group--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/AlertGroup/alert-group.scss
+++ b/src/patternfly/components/AlertGroup/alert-group.scss
@@ -10,8 +10,6 @@
   --pf-c-alert-group--m-toast--Right: var(--pf-global--spacer--xl);
   --pf-c-alert-group--m-toast--MaxWidth: #{pf-size-prem(600px)};
 
-  width: 100%;
-
   // Spacing between alerts
   > .pf-c-alert:not(:last-child) {
     margin-bottom: var(--pf-c-alert-group__item--MarginBottom);

--- a/src/patternfly/components/AlertGroup/alert-group.scss
+++ b/src/patternfly/components/AlertGroup/alert-group.scss
@@ -3,7 +3,7 @@
 // Tabs
 .pf-c-alert-group {
   // Alert Group variables
-  --pf-c-alert-group__item--MarginBottom: var(--pf-global--spacer--sm);
+  --pf-c-alert-group__item--MarginTop: var(--pf-global--spacer--sm);
 
   // Toast variables
   --pf-c-alert-group--m-toast--Top: var(--pf-global--spacer--2xl);
@@ -11,8 +11,8 @@
   --pf-c-alert-group--m-toast--MaxWidth: #{pf-size-prem(600px)};
 
   // Spacing between alerts
-  > .pf-c-alert:not(:last-child) {
-    margin-bottom: var(--pf-c-alert-group__item--MarginBottom);
+  > * + * {
+    margin-top: var(--pf-c-alert-group__item--MarginTop);
   }
 
   // Toast positioning modifier

--- a/src/patternfly/components/AlertGroup/alert-group.scss
+++ b/src/patternfly/components/AlertGroup/alert-group.scss
@@ -1,4 +1,4 @@
-@import "../../patternfly-utilities";
+@import "../../patternfly-imports";
 
 // Tabs
 .pf-c-alert-group {

--- a/src/patternfly/components/AlertGroup/alert-group.scss
+++ b/src/patternfly/components/AlertGroup/alert-group.scss
@@ -1,0 +1,37 @@
+@import "../../patternfly-utilities";
+
+// Tabs
+.pf-c-alert-group {
+  // Alert Group variables
+  --pf-c-alert-group__item--MarginBottom: var(--pf-global--spacer--sm);
+
+  // Toast variables
+  --pf-c-alert-group--m-toast--Top: 0;
+  --pf-c-alert-group--m-toast--Right: 0;
+  --pf-c-alert-group--m-toast--MaxWidth: #{pf-size-prem(600px)};
+  --pf-c-alert-group--m-toast--PaddingTop: var(--pf-global--spacer--2xl);
+  --pf-c-alert-group--m-toast--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-alert-group--m-toast--PaddingBottom: 0;
+  --pf-c-alert-group--m-toast--PaddingLeft: var(--pf-global--spacer--xl);
+
+  width: 100%;
+
+  // Spacing between alerts
+  > .pf-c-alert:not(:last-child) {
+    margin-bottom: var(--pf-c-alert-group__item--MarginBottom);
+  }
+
+  // Toast positioning modifier
+  &.pf-m-toast {
+    position: fixed;
+    top: var(--pf-c-alert-group--m-toast--Top);
+    right: var(--pf-c-alert-group--m-toast--Right);
+    max-width: var(--pf-c-alert-group--m-toast--MaxWidth);
+    padding: var(--pf-c-alert-group--m-toast--PaddingTop) var(--pf-c-alert-group--m-toast--PaddingRight) var(--pf-c-alert-group--m-toast--PaddingBottom) var(--pf-c-alert-group--m-toast--PaddingLeft);
+    pointer-events: none;
+
+    & > * {
+      pointer-events: initial;
+    }
+  }
+}

--- a/src/patternfly/components/AlertGroup/alert-group.scss
+++ b/src/patternfly/components/AlertGroup/alert-group.scss
@@ -6,13 +6,9 @@
   --pf-c-alert-group__item--MarginBottom: var(--pf-global--spacer--sm);
 
   // Toast variables
-  --pf-c-alert-group--m-toast--Top: 0;
-  --pf-c-alert-group--m-toast--Right: 0;
+  --pf-c-alert-group--m-toast--Top: var(--pf-global--spacer--2xl);
+  --pf-c-alert-group--m-toast--Right: var(--pf-global--spacer--xl);
   --pf-c-alert-group--m-toast--MaxWidth: #{pf-size-prem(600px)};
-  --pf-c-alert-group--m-toast--PaddingTop: var(--pf-global--spacer--2xl);
-  --pf-c-alert-group--m-toast--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-alert-group--m-toast--PaddingBottom: 0;
-  --pf-c-alert-group--m-toast--PaddingLeft: var(--pf-global--spacer--xl);
 
   width: 100%;
 
@@ -26,12 +22,7 @@
     position: fixed;
     top: var(--pf-c-alert-group--m-toast--Top);
     right: var(--pf-c-alert-group--m-toast--Right);
+    width: calc(100% - calc(var(--pf-c-alert-group--m-toast--Right) * 2));
     max-width: var(--pf-c-alert-group--m-toast--MaxWidth);
-    padding: var(--pf-c-alert-group--m-toast--PaddingTop) var(--pf-c-alert-group--m-toast--PaddingRight) var(--pf-c-alert-group--m-toast--PaddingBottom) var(--pf-c-alert-group--m-toast--PaddingLeft);
-    pointer-events: none;
-
-    & > * {
-      pointer-events: initial;
-    }
   }
 }

--- a/src/patternfly/components/AlertGroup/alert-item.hbs
+++ b/src/patternfly/components/AlertGroup/alert-item.hbs
@@ -1,0 +1,6 @@
+<li class="pf-c-alert-group__item{{#if alert-item--modifier}} {{alert-item--modifier}}{{/if}}" 
+  {{#if alert-item--attribute}}
+    {{{alert-item--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</li>

--- a/src/patternfly/components/AlertGroup/docs/alert-group.md
+++ b/src/patternfly/components/AlertGroup/docs/alert-group.md
@@ -2,4 +2,5 @@
 
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-c-alert-group` | `<div>` | Creates an alert group component. **Required** |
+| `.pf-c-alert-group` | `<ul>` | Creates an alert group component. **Required** |
+| `.pf-c-alert-group__item` | `<li>` | Creates an alert group item. **Required** |

--- a/src/patternfly/components/AlertGroup/docs/alert-group.md
+++ b/src/patternfly/components/AlertGroup/docs/alert-group.md
@@ -1,0 +1,5 @@
+### Usage
+
+| Attribute | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-c-alert-group` | `<div>` | Creates an alert group component. **Required** |

--- a/src/patternfly/components/AlertGroup/docs/alert-group.md
+++ b/src/patternfly/components/AlertGroup/docs/alert-group.md
@@ -1,4 +1,4 @@
-## Overview 
+## Overview
 
 `.pf-c-alert-group` is optional when only one alert is needed. It becomes required when more than one alert is used in a list.
 

--- a/src/patternfly/components/AlertGroup/docs/alert-group.md
+++ b/src/patternfly/components/AlertGroup/docs/alert-group.md
@@ -1,3 +1,7 @@
+## Overview 
+
+`.pf-c-alert-group` is optional when only one alert is needed. It becomes required when more than one alert is used in a list.
+
 ### Usage
 
 | Attribute | Applied To | Outcome |

--- a/src/patternfly/components/AlertGroup/docs/code.md
+++ b/src/patternfly/components/AlertGroup/docs/code.md
@@ -1,3 +1,3 @@
 ## Overview
 
-Alert Groups are used to contain and align consecutive alerts. Groups can either be placed inline alongside a page's content or in the corner as a Toast Group using the `.pf-m-toast` modifier.
+Alert Groups are used to contain and align consecutive alerts. Groups can either be placed inline alongside a page's content or in the top-right corner as a Toast Group using the `.pf-m-toast` modifier.

--- a/src/patternfly/components/AlertGroup/docs/code.md
+++ b/src/patternfly/components/AlertGroup/docs/code.md
@@ -1,0 +1,3 @@
+## Overview
+
+Alert Groups are used to contain and align consecutive alerts. Groups can either be placed inline alongside a page's content or in the corner as a Toast Group using the `.pf-m-toast` modifier.

--- a/src/patternfly/components/AlertGroup/docs/design.md
+++ b/src/patternfly/components/AlertGroup/docs/design.md
@@ -1,0 +1,7 @@
+# Component Name
+
+Alert Groups contain and align consecutive alerts.
+
+## Usage
+
+Alert Groups should be used wherever and whenever multiple alerts are displayed, either inline with a page's content or in the corner as a group of toast notifications.

--- a/src/patternfly/components/AlertGroup/docs/design.md
+++ b/src/patternfly/components/AlertGroup/docs/design.md
@@ -4,4 +4,4 @@ Alert Groups contain and align consecutive alerts.
 
 ## Usage
 
-Alert Groups should be used wherever and whenever multiple alerts are displayed, either inline with a page's content or in the corner as a group of toast notifications.
+Alert Groups should be used wherever and whenever multiple alerts are displayed, either inline with a page's content or in the top-right corner as a group of toast notifications.

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -2,7 +2,13 @@
 
 An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Group with unique positioning in the top-right corner of the window. `.pf-c-alert-group` is required to create a Toast Alert Group.
 
-Every alert within a Toast Alert group must include a close button to dismiss the alert.
+Every Toast alert must include a close button to dismiss the alert.
+
+## Accessibility
+
+| Attribute | Applied To | Outcome |
+| -- | -- | -- |
+| `role="alert"` | `.pf-c-alert` | Used to communicate the toast alert's time-sensitive information to screen reader users. |
 
 ### Modifiers
 

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -14,4 +14,4 @@ Every Toast alert must include a close button to dismiss the alert.
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-m-toast`| `.pf-c-alert-group` | Applies toast notification styling to an alert group. |
+| `.pf-m-toast`| `.pf-c-alert-group` | Applies toast alert styling to an alert group. |

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -8,7 +8,7 @@ Every Toast alert must include a close button to dismiss the alert.
 
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |
-| `role="alert"` | `.pf-c-alert` | Used to communicate the toast alert's time-sensitive information to screen reader users. |
+| `role="alert"` | `.pf-c-alert__body` |  Communicates contents of the alert message to the user. **Required** |
 
 ### Modifiers
 

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -1,3 +1,7 @@
+## Overview 
+
+`.pf-c-alert-group` is required when used for toast notifications.
+
 ### Modifiers
 
 | Class | Applied To | Outcome |

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -1,8 +1,6 @@
 ## Overview
 
-An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Group with unique positioning and notification-like alert behavior. `.pf-c-alert-group` is required to create a Toast Alert Group.
-
-Alerts within the group should not include any actions, links, or buttons except for a close button that dismisses the alert. If more than three toast alerts need to be shown at the same time, a unique third toast should include a single secondary action button to view all notifications within a notification drawer.
+An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Group with unique positioning in the top-right corner of the window. `.pf-c-alert-group` is required to create a Toast Alert Group.
 
 ### Modifiers
 

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -1,0 +1,5 @@
+### Modifiers
+
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-m-toast`| `.pf-c-alert-group` | Applies toast notification styling to an alert group. |

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -1,6 +1,8 @@
-## Overview 
+## Overview
 
-`.pf-c-alert-group` is required when used for toast notifications.
+An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Group with unique positioning and notification-like alert behavior. `.pf-c-alert-group` is required to create a Toast Alert Group.
+
+Alerts within the group should not include any actions, links, or buttons except for a close button that dismisses the alert. If more than three toast alerts need to be shown at the same time, a unique third toast should include a single secondary action button to view all notifications within a notification drawer.
 
 ### Modifiers
 

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -4,12 +4,6 @@ An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Gr
 
 Every alert within a Toast Alert group must include a close button to dismiss the alert.
 
-### Accessibility
-
-| Class | Applied To | Outcome |
-| -- | -- | -- |
-| `.pf-u-sr-only` | `.pf-c-alert__title <span>` | Content that is visually hidden but accessible to assistive technologies. This should state the type of notification and refer to itself as a notification rather than an alert.  ** Required**|
-
 ### Modifiers
 
 | Class | Applied To | Outcome |

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -4,6 +4,12 @@ An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Gr
 
 Every alert within a Toast Alert group must include a close button to dismiss the alert.
 
+### Accessibility
+
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-u-sr-only` | `.pf-c-alert__title <span>` | Content that is visually hidden but accessible to assistive technologies. This should state the type of notification and refer to itself as a notification rather than an alert.  ** Required**|
+
 ### Modifiers
 
 | Class | Applied To | Outcome |

--- a/src/patternfly/components/AlertGroup/docs/toast-group.md
+++ b/src/patternfly/components/AlertGroup/docs/toast-group.md
@@ -2,6 +2,8 @@
 
 An alert group that includes the `.pf-m-toast` modifier becomes a Toast Alert Group with unique positioning in the top-right corner of the window. `.pf-c-alert-group` is required to create a Toast Alert Group.
 
+Every alert within a Toast Alert group must include a close button to dismiss the alert.
+
 ### Modifiers
 
 | Class | Applied To | Outcome |

--- a/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
@@ -1,14 +1,12 @@
 {{#> alert-group}}
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Alert"'}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
-        {{#> alert-body alert-body--attribute='role="alert"'}}
-          {{#> alert-title}}
-            {{#> accessibility accessibility--type="sr-only"}}
-              Success alert: 
-            {{/accessibility}}
-            Success alert title
+      {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> alert-title}}
+          {{#> screen-reader}}Success alert:{{/screen-reader}}
+          Success alert title
         {{/alert-title}}
       {{/alert-body}}
     {{/alert}}
@@ -16,19 +14,17 @@
 
   {{#> alert-item}}
     {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Alert"'}}
-      {{#> alert-icon alert-icon--danger="true"}}
+      {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
         {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}
-            Danger alert:
-          {{/accessibility}}
+          {{#> screen-reader}}Danger alert:{{/screen-reader}}
           Danger alert title
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Button
+        {{#> button button--modifier="pf-m-link"}}
+          Action Button
         {{/button}}
       {{/alert-action}}
     {{/alert}}
@@ -40,13 +36,11 @@
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
         {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}
-            Info alert:
-          {{/accessibility}}
+          {{#> screen-reader}}Info alert:{{/screen-reader}}
           Info alert title
         {{/alert-title}}
         {{#> alert-description}}
-          This is a description of the alert content.
+          Info alert description. <a href="#">This is a link.</a>
         {{/alert-description}}
       {{/alert-body}}
     {{/alert}}

--- a/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
@@ -6,7 +6,7 @@
         {{#> alert-body alert-body--attribute='role="alert"'}}
           {{#> alert-title}}
             {{#> accessibility accessibility--type="sr-only"}}
-              Success: 
+              Success alert: 
             {{/accessibility}}
             Success notification title
         {{/alert-title}}
@@ -20,7 +20,9 @@
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
         {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
+          {{#> accessibility accessibility--type="sr-only"}}
+            Danger alert:
+          {{/accessibility}}
           Danger notification title
         {{/alert-title}}
       {{/alert-body}}
@@ -38,7 +40,9 @@
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
         {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
+          {{#> accessibility accessibility--type="sr-only"}}
+            Info alert:
+          {{/accessibility}}
           Info notification title
         {{/alert-title}}
         {{#> alert-description}}

--- a/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
@@ -1,44 +1,50 @@
 {{#> alert-group}}
-  {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
-    {{#> alert-icon alert-icon--success="true"}}
-    {{/alert-icon}}
+  {{#> alert-item}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
+      {{#> alert-icon alert-icon--success="true"}}
+      {{/alert-icon}}
+        {{#> alert-body alert-body--attribute='role="alert"'}}
+          {{#> alert-title}}
+            {{#> accessibility accessibility--type="sr-only"}}
+              Success: 
+            {{/accessibility}}
+            Success notification title
+        {{/alert-title}}
+      {{/alert-body}}
+    {{/alert}}
+  {{/alert-item}}
+
+  {{#> alert-item}}
+    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
+      {{#> alert-icon alert-icon--danger="true"}}
+      {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
         {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}
-            Success: 
-          {{/accessibility}}
-          Success notification title
-      {{/alert-title}}
-    {{/alert-body}}
-  {{/alert}}
+          {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
+          Danger notification title
+        {{/alert-title}}
+      {{/alert-body}}
+      {{#> alert-action}}
+        {{#> button button--modifier="pf-m-secondary"}}
+          Button 
+        {{/button}}
+      {{/alert-action}}
+    {{/alert}}
+  {{/alert-item}}
 
-  {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
-    {{#> alert-icon alert-icon--danger="true"}}
-    {{/alert-icon}}
-    {{#> alert-body alert-body--attribute='role="alert"'}}
-      {{#> alert-title}}
-        {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
-        Danger notification title
-      {{/alert-title}}
-    {{/alert-body}}
-    {{#> alert-action}}
-      {{#> button button--modifier="pf-m-secondary"}}
-        Button 
-      {{/button}}
-    {{/alert-action}}
-  {{/alert}}
-
-  {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
-    {{#> alert-icon alert-icon--info="true"}}
-    {{/alert-icon}}
-    {{#> alert-body alert-body--attribute='role="alert"'}}
-      {{#> alert-title}}
-        {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
-        Info notification title
-      {{/alert-title}}
-      {{#> alert-description}}
-        This is a description of the notification content.
-      {{/alert-description}}
-    {{/alert-body}}
-  {{/alert}}
+  {{#> alert-item}}
+    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
+      {{#> alert-icon alert-icon--info="true"}}
+      {{/alert-icon}}
+      {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> alert-title}}
+          {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
+          Info notification title
+        {{/alert-title}}
+        {{#> alert-description}}
+          This is a description of the notification content.
+        {{/alert-description}}
+      {{/alert-body}}
+    {{/alert}}
+  {{/alert-item}}
 {{/alert-group}}

--- a/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
@@ -1,0 +1,44 @@
+{{#> alert-group}}
+  {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
+    {{#> alert-icon alert-icon--success="true"}}
+    {{/alert-icon}}
+      {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> alert-title}}
+          {{#> accessibility accessibility--type="sr-only"}}
+            Success: 
+          {{/accessibility}}
+          Success notification title
+      {{/alert-title}}
+    {{/alert-body}}
+  {{/alert}}
+
+  {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
+    {{#> alert-icon alert-icon--danger="true"}}
+    {{/alert-icon}}
+    {{#> alert-body alert-body--attribute='role="alert"'}}
+      {{#> alert-title}}
+        {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
+        Danger notification title
+      {{/alert-title}}
+    {{/alert-body}}
+    {{#> alert-action}}
+      {{#> button button--modifier="pf-m-secondary"}}
+        Button 
+      {{/button}}
+    {{/alert-action}}
+  {{/alert}}
+
+  {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
+    {{#> alert-icon alert-icon--info="true"}}
+    {{/alert-icon}}
+    {{#> alert-body alert-body--attribute='role="alert"'}}
+      {{#> alert-title}}
+        {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
+        Info notification title
+      {{/alert-title}}
+      {{#> alert-description}}
+        This is a description of the notification content.
+      {{/alert-description}}
+    {{/alert-body}}
+  {{/alert}}
+{{/alert-group}}

--- a/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
@@ -26,7 +26,7 @@
       {{/alert-body}}
       {{#> alert-action}}
         {{#> button button--modifier="pf-m-secondary"}}
-          Button 
+          Button
         {{/button}}
       {{/alert-action}}
     {{/alert}}

--- a/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/alert-group-example.hbs
@@ -1,6 +1,6 @@
 {{#> alert-group}}
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Alert"'}}
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
         {{#> alert-body alert-body--attribute='role="alert"'}}
@@ -8,14 +8,14 @@
             {{#> accessibility accessibility--type="sr-only"}}
               Success alert: 
             {{/accessibility}}
-            Success notification title
+            Success alert title
         {{/alert-title}}
       {{/alert-body}}
     {{/alert}}
   {{/alert-item}}
 
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
+    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Alert"'}}
       {{#> alert-icon alert-icon--danger="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
@@ -23,7 +23,7 @@
           {{#> accessibility accessibility--type="sr-only"}}
             Danger alert:
           {{/accessibility}}
-          Danger notification title
+          Danger alert title
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
@@ -35,7 +35,7 @@
   {{/alert-item}}
 
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
+    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Alert"'}}
       {{#> alert-icon alert-icon--info="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
@@ -43,10 +43,10 @@
           {{#> accessibility accessibility--type="sr-only"}}
             Info alert:
           {{/accessibility}}
-          Info notification title
+          Info alert title
         {{/alert-title}}
         {{#> alert-description}}
-          This is a description of the notification content.
+          This is a description of the alert content.
         {{/alert-description}}
       {{/alert-body}}
     {{/alert}}

--- a/src/patternfly/components/AlertGroup/examples/index.js
+++ b/src/patternfly/components/AlertGroup/examples/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Documentation from '@siteComponents/Documentation';
+import Example from '@siteComponents/Example';
+
+// Raw
+import alertGroupExampleRaw from '!raw!./alert-group-example.hbs';
+import toastGroupExampleRaw from '!raw!./toast-group-example.hbs';
+
+// Alert Group example
+import AlertGroupExample from './alert-group-example.hbs';
+import alertGroupDocs from '../docs/alert-group.md';
+
+// Toast Group example
+import ToastGroupExample from './toast-group-example.hbs';
+import toastGroupDocs from '../docs/toast-group.md';
+
+import docs from '../docs/code.md';
+import '../alert-group.scss';
+
+export const headingText = 'Alert Group';
+export const Docs = docs;
+
+export default () => {
+  const alertGroupExample = AlertGroupExample();
+  const toastGroupExample = ToastGroupExample();
+
+  return (
+    <Documentation docs={Docs} heading={headingText}>
+      <Example heading="Alert Group" handlebars={alertGroupExampleRaw} docs={alertGroupDocs}>
+        {alertGroupExample}
+      </Example>
+      <Example heading="Toast Alert Group" fullPageOnly="true" handlebars={toastGroupExampleRaw} docs={toastGroupDocs}>
+        {toastGroupExample}
+      </Example>
+    </Documentation>
+  );
+};

--- a/src/patternfly/components/AlertGroup/examples/index.js
+++ b/src/patternfly/components/AlertGroup/examples/index.js
@@ -26,7 +26,7 @@ export default () => {
 
   return (
     <Documentation docs={Docs} heading={headingText}>
-      <Example heading="Alert Group" handlebars={alertGroupExampleRaw} docs={alertGroupDocs}>
+      <Example heading="Inline Alert Group" handlebars={alertGroupExampleRaw} docs={alertGroupDocs}>
         {alertGroupExample}
       </Example>
       <Example heading="Toast Alert Group" fullPageOnly="true" handlebars={toastGroupExampleRaw} docs={toastGroupDocs}>

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -1,6 +1,6 @@
 {{#> alert-group alert-group--modifier="pf-m-toast"}}
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Toast Alert"'}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='role="alert" aria-label="Success Toast Alert"'}}
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
@@ -16,7 +16,7 @@
   {{/alert-item}}
   
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Toast Alert"'}}
+    {{#> alert alert--modifier="pf-m-danger" alert--attribute='role="alert" aria-label="Danger Toast Alert"'}}
       {{#> alert-icon alert-icon--danger="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
@@ -32,7 +32,7 @@
   {{/alert-item}}
 
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Toast Alert"'}}
+    {{#> alert alert--modifier="pf-m-info" alert--attribute='role="alert" aria-label="Information Toast Alert"'}}
       {{#> alert-icon alert-icon--info="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -11,6 +11,11 @@
             Success notification title
         {{/alert-title}}
       {{/alert-body}}
+      {{#> alert-action}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
+          <i class="fas fa-times"></i> 
+        {{/button}}
+      {{/alert-action}}
     {{/alert}}
   {{/alert-item}}
 
@@ -25,8 +30,8 @@
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-secondary"}}
-          Button 
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
+          <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}
     {{/alert}}
@@ -42,9 +47,17 @@
           Info notification title
         {{/alert-title}}
         {{#> alert-description}}
-          This is a description of the notification content.
+          There are 2 more unread notifications. Open the notification drawer to see them.
         {{/alert-description}}
       {{/alert-body}}
+      {{#> alert-action}}
+        {{#> button button--modifier="pf-m-link" button--attribute='aria-label="View all notifications"'}}
+          View all
+        {{/button}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
+          <i class="fas fa-times"></i> 
+        {{/button}}
+      {{/alert-action}}
     {{/alert}}
   {{/alert-item}}
 {{/alert-group}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -1,0 +1,44 @@
+{{#> alert-group alert-group--modifier="pf-m-toast"}}
+  {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
+    {{#> alert-icon alert-icon--success="true"}}
+    {{/alert-icon}}
+      {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> alert-title}}
+          {{#> accessibility accessibility--type="sr-only"}}
+            Success: 
+          {{/accessibility}}
+          Success notification title
+      {{/alert-title}}
+    {{/alert-body}}
+  {{/alert}}
+
+  {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
+    {{#> alert-icon alert-icon--danger="true"}}
+    {{/alert-icon}}
+    {{#> alert-body alert-body--attribute='role="alert"'}}
+      {{#> alert-title}}
+        {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
+        Danger notification title
+      {{/alert-title}}
+    {{/alert-body}}
+    {{#> alert-action}}
+      {{#> button button--modifier="pf-m-secondary"}}
+        Button 
+      {{/button}}
+    {{/alert-action}}
+  {{/alert}}
+
+  {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
+    {{#> alert-icon alert-icon--info="true"}}
+    {{/alert-icon}}
+    {{#> alert-body alert-body--attribute='role="alert"'}}
+      {{#> alert-title}}
+        {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
+        Info notification title
+      {{/alert-title}}
+      {{#> alert-description}}
+        This is a description of the notification content.
+      {{/alert-description}}
+    {{/alert-body}}
+  {{/alert}}
+{{/alert-group}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -4,15 +4,15 @@
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
         {{#> alert-body alert-body--attribute='role="alert"'}}
-          {{#> alert-title}}
+          {{#> alert-title alert-title--attribute='id="notification_one_title"'}}
             {{#> accessibility accessibility--type="sr-only"}}
-              Success: 
+              Success notification: 
             {{/accessibility}}
             Success notification title
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="notification_one_title"'}}
           <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}
@@ -24,13 +24,15 @@
       {{#> alert-icon alert-icon--danger="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
+        {{#> alert-title alert-title--attribute='id="notification_two_title"'}}
+          {{#> accessibility accessibility--type="sr-only"}}
+            Danger notification: 
+          {{/accessibility}}
           Danger notification title
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="notification_two_title"'}}
           <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}
@@ -42,8 +44,10 @@
       {{#> alert-icon alert-icon--info="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
+        {{#> alert-title alert-title--attribute='id="notification_three_title"'}}
+          {{#> accessibility accessibility--type="sr-only"}}
+            Info notification: 
+          {{/accessibility}}
           Info notification title
         {{/alert-title}}
         {{#> alert-description}}
@@ -51,7 +55,7 @@
         {{/alert-description}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="notification_three_title"'}}
           <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -47,13 +47,10 @@
           Info notification title
         {{/alert-title}}
         {{#> alert-description}}
-          There are 2 more unread notifications. Open the notification drawer to see them.
+          This is a description of the notification content.
         {{/alert-description}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-link" button--attribute='aria-label="View all notifications"'}}
-          View all
-        {{/button}}
         {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss"'}}
           <i class="fas fa-times"></i> 
         {{/button}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -1,18 +1,18 @@
 {{#> alert-group alert-group--modifier="pf-m-toast"}}
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Toast Alert"'}}
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
         {{#> alert-body alert-body--attribute='role="alert"'}}
-          {{#> alert-title alert-title--attribute='id="notification_one_title"'}}
+          {{#> alert-title alert-title--attribute='id="alert_one_title"'}}
             {{#> accessibility accessibility--type="sr-only"}}
-              Success notification: 
+              Success alert: 
             {{/accessibility}}
-            Success notification title
+            Success alert title
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="notification_one_title"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_one_title"'}}
           <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}
@@ -20,19 +20,19 @@
   {{/alert-item}}
 
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
+    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Toast Alert"'}}
       {{#> alert-icon alert-icon--danger="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> alert-title alert-title--attribute='id="notification_two_title"'}}
+        {{#> alert-title alert-title--attribute='id="alert_two_title"'}}
           {{#> accessibility accessibility--type="sr-only"}}
-            Danger notification: 
+            Danger alert: 
           {{/accessibility}}
-          Danger notification title
+          Danger alert title
         {{/alert-title}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="notification_two_title"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_two_title"'}}
           <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}
@@ -40,22 +40,22 @@
   {{/alert-item}}
 
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
+    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Toast Alert"'}}
       {{#> alert-icon alert-icon--info="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> alert-title alert-title--attribute='id="notification_three_title"'}}
+        {{#> alert-title alert-title--attribute='id="alert_three_title"'}}
           {{#> accessibility accessibility--type="sr-only"}}
-            Info notification: 
+            Info alert: 
           {{/accessibility}}
-          Info notification title
+          Info alert title
         {{/alert-title}}
         {{#> alert-description}}
-          This is a description of the notification content.
+          This is a description of the alert content.
         {{/alert-description}}
       {{/alert-body}}
       {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="notification_three_title"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_three_title"'}}
           <i class="fas fa-times"></i> 
         {{/button}}
       {{/alert-action}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -3,39 +3,31 @@
     {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Toast Alert"'}}
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
-        {{#> alert-body alert-body--attribute='role="alert"'}}
-          {{#> alert-title alert-title--attribute='id="alert_one_title"'}}
-            {{#> accessibility accessibility--type="sr-only"}}
-              Success alert: 
-            {{/accessibility}}
-            Success alert title
+      {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_one_button alert_one_title" id="alert_one_button"'}}
+          {{> button-icon button-icon--type="times"}}
+        {{/button}}
+        {{#> alert-title alert-title--attribute='id="alert_one_title"'}}
+          {{#> screen-reader}}Success alert:{{/screen-reader}}
+          Success toast alert title
         {{/alert-title}}
       {{/alert-body}}
-      {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_one_title"'}}
-          <i class="fas fa-times"></i> 
-        {{/button}}
-      {{/alert-action}}
     {{/alert}}
   {{/alert-item}}
-
+  
   {{#> alert-item}}
     {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Toast Alert"'}}
       {{#> alert-icon alert-icon--danger="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_two_button alert_two_title" id="alert_two_button"'}}
+          {{> button-icon button-icon--type="times"}}
+        {{/button}}
         {{#> alert-title alert-title--attribute='id="alert_two_title"'}}
-          {{#> accessibility accessibility--type="sr-only"}}
-            Danger alert: 
-          {{/accessibility}}
-          Danger alert title
+          {{#> screen-reader}}Danger alert:{{/screen-reader}}
+          Danger toast alert title
         {{/alert-title}}
       {{/alert-body}}
-      {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_two_title"'}}
-          <i class="fas fa-times"></i> 
-        {{/button}}
-      {{/alert-action}}
     {{/alert}}
   {{/alert-item}}
 
@@ -44,21 +36,17 @@
       {{#> alert-icon alert-icon--info="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_three_button alert_three_title" id="alert_three_button"'}}
+          {{> button-icon button-icon--type="times"}}
+        {{/button}}
         {{#> alert-title alert-title--attribute='id="alert_three_title"'}}
-          {{#> accessibility accessibility--type="sr-only"}}
-            Info alert: 
-          {{/accessibility}}
-          Info alert title
+          {{#> screen-reader}}Info alert:{{/screen-reader}}
+          Info toast alert title
         {{/alert-title}}
         {{#> alert-description}}
-          This is a description of the alert content.
+          Info toast alert description. <a href="#">This is a link.</a>
         {{/alert-description}}
       {{/alert-body}}
-      {{#> alert-action}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_three_title"'}}
-          <i class="fas fa-times"></i> 
-        {{/button}}
-      {{/alert-action}}
     {{/alert}}
   {{/alert-item}}
 {{/alert-group}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -1,44 +1,50 @@
 {{#> alert-group alert-group--modifier="pf-m-toast"}}
-  {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
-    {{#> alert-icon alert-icon--success="true"}}
-    {{/alert-icon}}
+  {{#> alert-item}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Notification"'}}
+      {{#> alert-icon alert-icon--success="true"}}
+      {{/alert-icon}}
+        {{#> alert-body alert-body--attribute='role="alert"'}}
+          {{#> alert-title}}
+            {{#> accessibility accessibility--type="sr-only"}}
+              Success: 
+            {{/accessibility}}
+            Success notification title
+        {{/alert-title}}
+      {{/alert-body}}
+    {{/alert}}
+  {{/alert-item}}
+
+  {{#> alert-item}}
+    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
+      {{#> alert-icon alert-icon--danger="true"}}
+      {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
         {{#> alert-title}}
-          {{#> accessibility accessibility--type="sr-only"}}
-            Success: 
-          {{/accessibility}}
-          Success notification title
-      {{/alert-title}}
-    {{/alert-body}}
-  {{/alert}}
+          {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
+          Danger notification title
+        {{/alert-title}}
+      {{/alert-body}}
+      {{#> alert-action}}
+        {{#> button button--modifier="pf-m-secondary"}}
+          Button 
+        {{/button}}
+      {{/alert-action}}
+    {{/alert}}
+  {{/alert-item}}
 
-  {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Notification"'}}
-    {{#> alert-icon alert-icon--danger="true"}}
-    {{/alert-icon}}
-    {{#> alert-body alert-body--attribute='role="alert"'}}
-      {{#> alert-title}}
-        {{#> accessibility accessibility--type="sr-only"}}Danger: {{/accessibility}}
-        Danger notification title
-      {{/alert-title}}
-    {{/alert-body}}
-    {{#> alert-action}}
-      {{#> button button--modifier="pf-m-secondary"}}
-        Button 
-      {{/button}}
-    {{/alert-action}}
-  {{/alert}}
-
-  {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
-    {{#> alert-icon alert-icon--info="true"}}
-    {{/alert-icon}}
-    {{#> alert-body alert-body--attribute='role="alert"'}}
-      {{#> alert-title}}
-        {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
-        Info notification title
-      {{/alert-title}}
-      {{#> alert-description}}
-        This is a description of the notification content.
-      {{/alert-description}}
-    {{/alert-body}}
-  {{/alert}}
+  {{#> alert-item}}
+    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Notification"'}}
+      {{#> alert-icon alert-icon--info="true"}}
+      {{/alert-icon}}
+      {{#> alert-body alert-body--attribute='role="alert"'}}
+        {{#> alert-title}}
+          {{#> accessibility accessibility--type="sr-only"}}Info: {{/accessibility}}
+          Info notification title
+        {{/alert-title}}
+        {{#> alert-description}}
+          This is a description of the notification content.
+        {{/alert-description}}
+      {{/alert-body}}
+    {{/alert}}
+  {{/alert-item}}
 {{/alert-group}}

--- a/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
+++ b/src/patternfly/components/AlertGroup/examples/toast-group-example.hbs
@@ -1,10 +1,10 @@
 {{#> alert-group alert-group--modifier="pf-m-toast"}}
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-success" alert--attribute='role="alert" aria-label="Success Toast Alert"'}}
+    {{#> alert alert--modifier="pf-m-success" alert--attribute='aria-label="Success Toast Alert"'}}
       {{#> alert-icon alert-icon--success="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_one_button alert_one_title" id="alert_one_button"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close" aria-labelledby="alert_one_button alert_one_title" id="alert_one_button"'}}
           {{> button-icon button-icon--type="times"}}
         {{/button}}
         {{#> alert-title alert-title--attribute='id="alert_one_title"'}}
@@ -16,11 +16,11 @@
   {{/alert-item}}
   
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-danger" alert--attribute='role="alert" aria-label="Danger Toast Alert"'}}
+    {{#> alert alert--modifier="pf-m-danger" alert--attribute='aria-label="Danger Toast Alert"'}}
       {{#> alert-icon alert-icon--danger="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_two_button alert_two_title" id="alert_two_button"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close" aria-labelledby="alert_two_button alert_two_title" id="alert_two_button"'}}
           {{> button-icon button-icon--type="times"}}
         {{/button}}
         {{#> alert-title alert-title--attribute='id="alert_two_title"'}}
@@ -32,11 +32,11 @@
   {{/alert-item}}
 
   {{#> alert-item}}
-    {{#> alert alert--modifier="pf-m-info" alert--attribute='role="alert" aria-label="Information Toast Alert"'}}
+    {{#> alert alert--modifier="pf-m-info" alert--attribute='aria-label="Information Toast Alert"'}}
       {{#> alert-icon alert-icon--info="true"}}
       {{/alert-icon}}
       {{#> alert-body alert-body--attribute='role="alert"'}}
-        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Dismiss" aria-labelledby="alert_three_button alert_three_title" id="alert_three_button"'}}
+        {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close" aria-labelledby="alert_three_button alert_three_title" id="alert_three_button"'}}
           {{> button-icon button-icon--type="times"}}
         {{/button}}
         {{#> alert-title alert-title--attribute='id="alert_three_title"'}}


### PR DESCRIPTION
Alert Groups are used to contain and align consecutive alerts, either inline alongside a page's content or in the top-right corner as toast notifications.

This implementation is based on [this visual design](https://redhat.invisionapp.com/share/MFOCVXG3R5S#/screens/323130343):

![323130343](https://user-images.githubusercontent.com/9122899/50176523-a0c00200-02cd-11e9-9d62-64322ec95019.png)

## Implementation notes

The width of a toast group is set by `--pf-c-alert-group--MaxWidth` with an initial value of 600px. Regular alert groups are fullwidth.

Padding is used to space the toast group in the corner and keep it centered in smaller viewports. `pointer-events: none;` allows users to click through that padding (to click nav items, tabs, etc.) and `pointer-events: initial;` is applied to the group’s direct children to make sure alerts themselves are still clickable.

## Questions

- Do we want to enable developers to position toasts in places other than the top-right? Maybe centered toasts are a use case? We’d need to add two more variables for `bottom` and `left`.
- Should toast groups be vertically scrollable? Scrolling wasn't in PF3, but if developers don’t implement grouped notifications I can imagine some becoming impossible to view without clearing the top-most ones. Unfortunately the `box-shadow` around individual alerts makes any scrollbar position look awkward.

Closes #654.