### PR TITLE
refactor(ChipListOrder): replacing ChipGroup and Chips markup list elements with ul/li elements

### DIFF
--- a/src/patternfly/components/Chip/chip.hbs
+++ b/src/patternfly/components/Chip/chip.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-chip{{#if chip--modifier}} {{chip--modifier}}{{/if}}"
+<li class="pf-c-chip{{#if chip--modifier}} {{chip--modifier}}{{/if}}"
   {{#if chip--attribute}}
     {{{chip--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</li>

--- a/src/patternfly/components/Chip/docs/chip.md
+++ b/src/patternfly/components/Chip/docs/chip.md
@@ -15,7 +15,7 @@ A Chip is used to display items that have been filtered or selected from a large
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-c-chip` | `<div>` | Initiates the body of a chip. |
+| `.pf-c-chip` | `<li>` | Initiates the body of a chip. |
 | `.pf-c-chip__text` | `<span>` | Initiates the text inside of the chip. **Required.** |
 | `.pf-c-button` | `<button>` | Initiates the button used to remove the chip. **Required.** |
 | `.pf-m-overflow` | `.pf-c-chip` | Applies styling of the overflow chip. |

--- a/src/patternfly/components/ChipGroup/chip-group.hbs
+++ b/src/patternfly/components/ChipGroup/chip-group.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-chip-group{{#if chip-group--modifier}} {{chip-group--modifier}}{{/if}}"
+<ul class="pf-c-chip-group{{#if chip-group--modifier}} {{chip-group--modifier}}{{/if}}"
   {{#if chip-group--attribute}}
     {{{chip-group--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-</div>
+</ul>

--- a/src/patternfly/components/ChipGroup/docs/chip-group-toolbar.md
+++ b/src/patternfly/components/ChipGroup/docs/chip-group-toolbar.md
@@ -11,7 +11,7 @@ A chip-group used in a toolbar require the modifier `.pf-m-toolbar` which styles
 
 | Class | Applied To | Outcome |
 | -- | -- | -- |
-| `.pf-c-chip-group` | `<div>` | Initiates the container used to group chips. **Required** |
+| `.pf-c-chip-group` | `<ul>` | Initiates the container used to group chips. **Required** |
 | `.pf-c-chip-group__label` | `<h4>` | Initiates the label for a group of chips. |
 | `.pf-c-button` | `<button>` | Initiates the button used to show overflown chips. |
 | `.pf-m-toolbar` | `.pf-c-chip-group` | Modifies `.pf-c-chip-group` to be used in a toolbar. **Required** |


### PR DESCRIPTION
## Objective
Refactoring Chip and ChipGroup markup elements to `ul` and `<li>` elements. 

## Implementation
- replacing ChipGroup (`pf-c-chip-group`) `div` tags with `<ul>` elements.
<img width="711" alt="screen shot 2019-01-10 at 1 27 12 pm" src="https://user-images.githubusercontent.com/1402829/50989622-decfd080-14dd-11e9-845c-2f9ba0afb3b0.png">

- replacing Chip (`pf-c-chip`) `div` tags with `<li>` elements.
<img width="668" alt="screen shot 2019-01-10 at 1 29 38 pm" src="https://user-images.githubusercontent.com/1402829/50989643-e98a6580-14dd-11e9-87fe-d4d718f25eee.png">


fixes #1149.