### PR TITLE
fix(build): blueprint index.js should import {{nameDasherized}}.scss instead of {{nameCamelized}}.scss

### DIFF
--- a/build/blueprints/template/files/src/patternfly/__typeDirectory__/__namePascalized__/examples/index.js
+++ b/build/blueprints/template/files/src/patternfly/__typeDirectory__/__namePascalized__/examples/index.js
@@ -7,7 +7,7 @@ import {{moduleName}}SimpleExample from './{{nameDasherized}}-simple-example.hbs
 import {{moduleName}}ComplexExample from './{{nameDasherized}}-complex-example.hbs';
 import {{nameCamelized}}ComplexExampleDoc from '../docs/{{nameDasherized}}-complex.md';
 import docs from '../docs/code.md';
-import '../{{nameCamelized}}.scss';
+import '../{{nameDasherized}}.scss';
 
 export const Docs = docs;
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1214