### PR TITLE
 refactor(base.scss): try writing the shield in a different way

### DIFF
--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -31,21 +31,24 @@
 .pf-c-table,
 .pf-c-tabs,
 .pf-c-title,
-.pf-c-tooltip {
-  &,
-  &::before,
-  &::after {
-    box-sizing: border-box;
-    padding: 0;
-    margin: 0;
-    font-family: var(--pf-global--FontFamily--sans-serif);
-    font-size: var(--pf-global--FontSize--md);
-    font-weight: var(--pf-global--FontWeight--normal);
-    line-height: var(--pf-global--LineHeight--md);
-    color: var(--pf-global--Color--100); // this color rule is set here to be able to use themes
-    background-color: transparent;
-    text-rendering: optimizeLegibility;
-  }
+.pf-c-tooltip,
+.pf-l-bullseye,
+.pf-l-gallery,
+.pf-l-grid,
+.pf-l-level,
+.pf-l-split,
+.pf-l-stack,
+.pf-l-toolbar {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  font-family: var(--pf-global--FontFamily--sans-serif);
+  font-size: var(--pf-global--FontSize--md);
+  font-weight: var(--pf-global--FontWeight--normal);
+  line-height: var(--pf-global--LineHeight--md);
+  color: var(--pf-global--Color--100); // this color rule is set here to be able to use themes
+  background-color: transparent;
+  text-rendering: optimizeLegibility;
 }
 
 // Since PF3 sets root font size to 10px, we need to unset it.

--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -1,23 +1,51 @@
 // CSS shild against PF 3
-[class*="pf-c-"],
-[class*="pf-l-"],
-[class*="pf-u-"],
-[class*="pf-c-"]::before,
-[class*="pf-l-"]::before,
-[class*="pf-u-"]::before,
-[class*="pf-c-"]::after,
-[class*="pf-l-"]::after,
-[class*="pf-u-"]::after {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-  font-family: var(--pf-global--FontFamily--sans-serif);
-  font-size: var(--pf-global--FontSize--md);
-  font-weight: var(--pf-global--FontWeight--normal);
-  line-height: var(--pf-global--LineHeight--md);
-  color: var(--pf-global--Color--100); // this color rule is set here to be able to use themes
-  background-color: transparent;
-  text-rendering: optimizeLegibility;
+.pf-c-about-modal-box,
+.pf-c-alert,
+.pf-c-avatar,
+.pf-c-backdrop,
+.pf-c-background-image,
+.pf-c-badge,
+.pf-c-brand,
+.pf-c-breadcrumb,
+.pf-c-button,
+.pf-c-card,
+.pf-c-check,
+.pf-c-chip,
+.pf-c-chip-group,
+.pf-c-content,
+.pf-c-data-list,
+.pf-c-dropdown,
+.pf-c-empty-state,
+.pf-c-form,
+.pf-c-form-control,
+.pf-c-input-group,
+.pf-c-label,
+.pf-c-list,
+.pf-c-login,
+.pf-c-modal-box,
+.pf-c-nav,
+.pf-c-page,
+.pf-c-popover,
+.pf-c-progress,
+.pf-c-switch,
+.pf-c-table,
+.pf-c-tabs,
+.pf-c-title,
+.pf-c-tooltip {
+  &,
+  &::before,
+  &::after {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    font-family: var(--pf-global--FontFamily--sans-serif);
+    font-size: var(--pf-global--FontSize--md);
+    font-weight: var(--pf-global--FontWeight--normal);
+    line-height: var(--pf-global--LineHeight--md);
+    color: var(--pf-global--Color--100); // this color rule is set here to be able to use themes
+    background-color: transparent;
+    text-rendering: optimizeLegibility;
+  }
 }
 
 // Since PF3 sets root font size to 10px, we need to unset it.
@@ -82,9 +110,13 @@ html {
 
   button,
   input,
+  optgroup,
   select,
   textarea {
     margin: 0;
+    font-family: inherit;
+    font-size: 100%;
+    line-height: var(--pf-global--LineHeight--md);
   }
 
   img,

--- a/src/patternfly/assets/fontawesome/solid.scss
+++ b/src/patternfly/assets/fontawesome/solid.scss
@@ -14,11 +14,7 @@
 
 // Need to add ::before, color, and font-size to override pf shield
 .fa,
-.fas,
-.fa::before,
-.fas::before {
+.fas {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900;
-  color: inherit;
-  font-size: inherit;
 }

--- a/src/patternfly/assets/fontawesome/solid.scss
+++ b/src/patternfly/assets/fontawesome/solid.scss
@@ -12,7 +12,6 @@
   url('#{$fa-font-path}/fa-solid-900.svg#fontawesome') format('svg');
 }
 
-// Need to add ::before, color, and font-size to override pf shield
 .fa,
 .fas {
   font-family: 'Font Awesome 5 Free';

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -341,5 +341,4 @@
 // Add spacing to an icon in the button
 .pf-c-button__icon {
   margin-right: var(--pf-c-button__icon--MarginRight);
-  color: inherit; // override the pf3 shield color so the color is inherited from the button's color
 }

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -16,7 +16,6 @@
   --pf-c-dropdown__toggle--BorderRightColor: var(--pf-global--BorderColor--light-200);
   --pf-c-dropdown__toggle--BorderBottomColor: var(--pf-global--BorderColor--dark);
   --pf-c-dropdown__toggle--BorderLeftColor: var(--pf-global--BorderColor--light-200);
-  --pf-c-dropdown__toggle--Color: var(--pf-global--Color--100);
   --pf-c-dropdown__toggle--hover--BorderBottomColor: var(--pf-global--active-color--100);
   --pf-c-dropdown__toggle--expanded--BorderBottomWidth: var(--pf-global--BorderWidth--md);
   --pf-c-dropdown__toggle--expanded--BorderBottomColor: var(--pf-global--active-color--100);
@@ -72,10 +71,6 @@
   background-color: var(--pf-c-dropdown__toggle--BackgroundColor);
   border: none;
 
-  & > * {
-    color: var(--pf-c-dropdown__toggle--Color);
-  }
-
   &::before {
     position: absolute;
     top: 0;
@@ -104,7 +99,7 @@
   }
 
   &.pf-m-plain {
-    --pf-c-dropdown__toggle--Color: var(--pf-c-dropdown__toggle--m-plain--Color);
+    color: var(--pf-c-dropdown__toggle--m-plain--Color);
 
     &::before {
       border-color: var(--pf-c-dropdown__toggle--m-plain--BorderColor);
@@ -115,7 +110,7 @@
     &:active,
     &.pf-m-active,
     .pf-m-expanded > & {
-      --pf-c-dropdown__toggle--Color: var(--pf-c-dropdown__toggle--m-plain--hover--Color);
+      --pf-c-dropdown__toggle--m-plain--Color: var(--pf-c-dropdown__toggle--m-plain--hover--Color);
 
       &::before {
         border-color: var(--pf-c-dropdown__toggle--m-plain--BorderColor);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/976

I created this branch from the workspace/FA updates I made in https://github.com/patternfly/patternfly-next/pull/1221

@dgutride we have this issue where any of the properties defined in the "PF shield" (the bit of CSS that lets you drop PF4 CSS on the page and it only applies reset styles to classes that start with `.pf-[cul]-`) where, if any of the properties in the shield are undefined on a patternfly component/layout element and are expected to inherit from it's ancestor elements, the shield breaks the inheritance by explicitly setting the property.

For example, the shield sets `font-family: var(--pf-global--FontFamily--sans-serif);` and `color: var(--pf-global--Color--100);` to any element with a `pf-[cul]-` class. If you have the following CSS/HTML:

```
.pf-c-thing {
  font-family: "FontAwesome";
  color: red;
}
<div class="pf-c-thing">
  <div class="pf-c-thing__element">
```

Then `font-family` for `.pf-c-thing__element` is set to `var(--pf-global--FontFamily--sans-serif)`, instead of `FontAwesome`, and the `color` is set to `var(--pf-global--Color--100)`, instead of `red`. That's not what one would expect just writing CSS. We would expect the styles from `.pf-c-thing` to be inherited by `.pf-c-thing__element`

The changes I'm proposing should effectively do the same thing as the shield, while setting these properties at the component/layout level instead of every individual thing that has a class of `.pf-[cul]-`.

And I suppose another question is, would it be possible to drop the shield? I'm assuming that's a no but wanted to ask. If I understand the shield's purpose, I think with it in place and `$pf-global--enable-reset: false;`, you could drop the PF4 stylesheet on a page, and the PF4 `font-size`, `font-weight`, `font-family`, `line-height`, and `color` would only apply to `.pf-[cul]` elements, leaving the rest of the page alone (meaning you could keep an overall look and feel of PF3, with a PF4 data table in the content). Though, in that case, would you really want to have the PF4 data table's font, color, etc be different from the rest of the page? Maybe there are other use cases of the PF shield?