### PR TITLE
feat(form control): remove box shadow for firefox

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -81,6 +81,7 @@ $pf-c-form-control__select--ViewBox: "320" !default;
   /* stylelint-disable */
   -moz-appearance: none;
   -webkit-appearance: none;
+  box-shadow: none;
   /* stylelint-enable */
 
   &::placeholder {


### PR DESCRIPTION
css fix for patternfly/patternfly-react#1039 - Firefox renders a red box shadow on forms by default when it should only indicate any errors on validation.