### PR TITLE
fix(alert): spacing update

### DIFF
--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -17,13 +17,14 @@
   --pf-c-alert__title--Color: var(--pf-global--Color--100);
   --pf-c-alert__title--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-alert__title--PaddingRight: var(--pf-global--spacer--md);
-  --pf-c-alert__title--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-alert__title--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-alert__title--PaddingLeft: var(--pf-global--spacer--md);
 
   // description
   --pf-c-alert__description--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-alert__description--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-alert__description--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-alert__description--MarginTop: calc(-1 * var(--pf-global--spacer--sm));
 
   // action
   --pf-c-alert__action--PaddingTop: #{pf-size-prem(11px)}; // one off spacer to align properly.
@@ -106,6 +107,10 @@
   padding: var(--pf-c-alert__title--PaddingTop) var(--pf-c-alert__title--PaddingRight) var(--pf-c-alert__title--PaddingBottom)  var(--pf-c-alert__title--PaddingLeft);
   font-size: var(--pf-c-alert__title--FontSize);
   color: var(--pf-c-alert__title--Color);
+
+  & + .pf-c-alert__description {
+    margin-top: var(--pf-c-alert__description--MarginTop);
+  }
 }
 
 .pf-c-alert__description {

--- a/src/patternfly/components/Alert/docs/code.md
+++ b/src/patternfly/components/Alert/docs/code.md
@@ -23,7 +23,7 @@ Always add a modifier class. Do not use `.pf-c-alert` on its own.
 | -- | -- | -- |
 | `.pf-c-alert` | `<div>` |  Applies default alert styling. Always use with a modifier class. ** Required**|
 | `.pf-c-alert__icon` | `<div>` |  	Defines the alert icon. ** Required **|
-| `.pf-c-alert__title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Defines the alert title. |
+| `.pf-c-alert__title` | `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>` |  Defines the alert title. ** Required **|
 | `.pf-c-alert__description` | `<div>` |  Defines the alert description area. |
 | `.pf-c-alert__action` | `<div>` |  Defines the action button wrapper. Should contain `.pf-c-button.pf-m-plain` for close action or `.pf-c-button.pf-m-link` for link text. It should only include one action. |
 | `.pf-m-success` | `.pf-c-alert` |  Applies success styling. |


### PR DESCRIPTION
Bottom spacer for title was too small when text breaks to second line. This uses margin which breaks our rule but it seems like an appropriate way to break it :)