### PR TITLE
Replace Gatsby Links with anchor tags

### DIFF
--- a/src/site/_site/Documentation/index.js
+++ b/src/site/_site/Documentation/index.js
@@ -6,7 +6,7 @@ import './styles.scss';
 export default class Documentation extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { isFull: false };
+    this.state = { isFull: null };
   }
 
   componentDidMount() {
@@ -19,22 +19,25 @@ export default class Documentation extends React.Component {
   render() {
     const { children, className = '', docs = '', heading = '' } = this.props;
     const HTML_DOCS = { __html: docs };
-    return !this.state.isFull ? (
-      <Layout>
-        <div className={`Documentation ${className}`}>
-          <h3 className="Component_heading">{heading}</h3>
-          <div className="Documentation__section">{children}</div>
-          <h3 className="Documentation_heading">Documentation</h3>
-          <div className="Documentation__docsection" dangerouslySetInnerHTML={HTML_DOCS} />
-        </div>
-      </Layout>
-    ) : (
-      <FullPageExampleLayout>
-        <div className={className}>
-          <h1 className="pf-screen-reader">{this.props.heading} full example</h1>
-          {children}
-        </div>
-      </FullPageExampleLayout>
+    return (
+      this.state.isFull !== null &&
+      (!this.state.isFull ? (
+        <Layout>
+          <div className={`Documentation ${className}`}>
+            <h3 className="Component_heading">{heading}</h3>
+            <div className="Documentation__section">{children}</div>
+            <h3 className="Documentation_heading">Documentation</h3>
+            <div className="Documentation__docsection" dangerouslySetInnerHTML={HTML_DOCS} />
+          </div>
+        </Layout>
+      ) : (
+        <FullPageExampleLayout>
+          <div className={className}>
+            <h1 className="pf-screen-reader">{this.props.heading} full example</h1>
+            {children}
+          </div>
+        </FullPageExampleLayout>
+      ))
     );
   }
 }

--- a/src/site/_site/Preview/index.js
+++ b/src/site/_site/Preview/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { withPrefix } from 'gatsby';
 import './styles.scss';
 
 export default class Preview extends React.Component {
@@ -32,9 +32,14 @@ export default class Preview extends React.Component {
 
   renderFullPageLink() {
     return (
-      <Link to={this.state.fullPath} target="_blank" title="Open in new window" className="Preview__viewport-link">
+      <a
+        href={withPrefix(this.state.fullPath)}
+        target="_blank"
+        title="Open in new window"
+        className="Preview__viewport-link"
+      >
         <i className="fas fa-external-link-alt" />
-      </Link>
+      </a>
     );
   }
 
@@ -44,9 +49,10 @@ export default class Preview extends React.Component {
     const preview = this.props.fullPageOnly ? (
       <div className="Preview__body ">
         This Preview can only be accessed in&nbsp;
-        <Link to={this.state.fullPath} target="_blank">
+        <a href={withPrefix(this.state.fullPath)} target="_blank">
           full page mode
-        </Link>.
+        </a>
+        .
       </div>
     ) : (
       <div


### PR DESCRIPTION
* Wtih Gatsby v2, the target attribute is no longer passed through to
  the underlying anchor tag.

Do not render regular layout in full page view
* We do not determine whether or not we are in a full page view
  until after the component has mounted. The result is, when refreshing
  the browser while viewing a full page example, the regular layout will
  flash on the screen before being replaced with the full page layout.
* If we default the initial isFull state to null, we can initially
  render nothing while we determine what kind of view we're in. Then,
  once the component has mounted, render the appropriate view using the
  calculated state.

***NOTES***
1. Full page examples open a new tab again
2. I noticed that when refreshing the page while viewing a full page example, the regular layout was flashing on the screen before the expected view was rendered.
3. We are still experiencing FOUC in development.  Does not appear in production builds/deployments