### PR TITLE
fix(modal): update heading types

### DIFF
--- a/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
+++ b/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
@@ -14,7 +14,7 @@
           Trademark and copyright information here
       {{/title}}
     {{/about-modal-box-header-strapline}} 
-    {{#> title titleType="h2" title--modifier="pf-m-4xl" title--attribute='id="about-modal-title"'}}
+    {{#> title titleType="h1" title--modifier="pf-m-4xl" title--attribute='id="about-modal-title"'}}
         Product Name
     {{/title}}
   {{/about-modal-box-header}}

--- a/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
+++ b/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
@@ -10,11 +10,11 @@
   {{/about-modal-box-close}}
   {{#> about-modal-box-header}} 
     {{#> about-modal-box-header-strapline}}
-      {{#> title titleType="h2" title--modifier="pf-m-md"}}
+      {{#> title titleType="p" title--modifier="pf-m-md"}}
           Trademark and copyright information here
       {{/title}}
     {{/about-modal-box-header-strapline}} 
-    {{#> title titleType="h1" title--modifier="pf-m-4xl" title--attribute='id="about-modal-title"'}}
+    {{#> title titleType="h2" title--modifier="pf-m-4xl" title--attribute='id="about-modal-title"'}}
         Product Name
     {{/title}}
   {{/about-modal-box-header}}

--- a/src/patternfly/components/Title/docs/code.md
+++ b/src/patternfly/components/Title/docs/code.md
@@ -16,7 +16,7 @@ The content component defines margin on headers. To regain the same spacing use 
 
 | Class | Applied | Outcome |
 | -- | -- | -- |
-| `.pf-c-title` | `<h1>`,`<h2>`,`<h3>`,`<h4>`,`<h5>`,`<h6>` |  Initiates a title. Always use it with a modifier class. |
+| `.pf-c-title` | `*` |  Initiates a title. Always use it with a modifier class. |
 | `.pf-m-4xl` | `.pf-c-title` | Modifies for 4xl size |
 | `.pf-m-3xl` | `.pf-c-title` | Modifies for 3xl size |
 | `.pf-m-2xl` | `.pf-c-title` | Modifies for 2xl size |

--- a/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
+++ b/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
@@ -17,7 +17,7 @@
             Trademark and copyright information here
           {{/title}}
           {{/about-modal-box-header-strapline}} 
-          {{#> title titleType="h2" title--modifier="pf-m-4xl" title--ID="about-modal-title"}}
+          {{#> title titleType="h1" title--modifier="pf-m-4xl" title--ID="about-modal-title"}}
               Red Hat OpenShift Container Platform
           {{/title}}
         {{/about-modal-box-header}}

--- a/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
+++ b/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
@@ -13,11 +13,11 @@
         {{/about-modal-box-close}}
         {{#> about-modal-box-header}}
          {{#> about-modal-box-header-strapline}}
-          {{#> title titleType="h2" title--modifier="pf-m-md"}}
+          {{#> title titleType="p" title--modifier="pf-m-md"}}
             Trademark and copyright information here
           {{/title}}
           {{/about-modal-box-header-strapline}} 
-          {{#> title titleType="h1" title--modifier="pf-m-4xl" title--ID="about-modal-title"}}
+          {{#> title titleType="h2" title--modifier="pf-m-4xl" title--ID="about-modal-title"}}
               Red Hat OpenShift Container Platform
           {{/title}}
         {{/about-modal-box-header}}


### PR DESCRIPTION
closes #1190 

@jgiardino I think you are right, it doesn't seem like the right move to have an H1 in a dialog. From what I've read it is an acceptable approach but could lead to issues with assistive technologies. I've changed this to an `<h2>` but I wonder if we should be also documenting this? Can we be that prescriptive if it's more just a suggestion?
 