### PR TITLE
fix(shield): Apply non-inheritable shield props to all .pf- class elements, add default props to elements for when base scss is not used

### DIFF
--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -59,6 +59,36 @@
   line-height: var(--pf-global--LineHeight--md);
   color: var(--pf-global--Color--100); // this color rule is set here to be able to use themes
   text-rendering: optimizeLegibility;
+}
+
+[class*="pf-c"],
+[class*="pf-u"],
+[class*="pf-l"] {
+  @at-root {
+    ul#{&} {
+      list-style: none;
+    }
+
+    button#{&},
+    input#{&},
+    optgroup#{&},
+    select#{&},
+    textarea#{&} {
+      font-family: var(--pf-global--FontFamily--sans-serif);
+      font-size: 100%;
+      line-height: var(--pf-global--LineHeight--md);
+    }
+
+    h1#{&},
+    h2#{&},
+    h3#{&},
+    h4#{&},
+    h5#{&},
+    h6#{&} {
+      font-size: 100%;
+      font-weight: var(--pf-global--FontWeight--normal);
+    }
+  }
 
   &,
   &::before,


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1326

This is a short-term fix. For the long term, I think we need to look at all of the styles that we apply in our base and make sure they're accounted for when the base styles aren't included. We might also consider conditionally loading either the base CSS or the shield CSS, and not both.