### PR TITLE
refactor(base.scss): create mixin/extend for elements that get shield attr selector styles

### DIFF
--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -64,32 +64,6 @@
 [class*="pf-c"],
 [class*="pf-u"],
 [class*="pf-l"] {
-  @at-root {
-    ul#{&} {
-      list-style: none;
-    }
-
-    button#{&},
-    input#{&},
-    optgroup#{&},
-    select#{&},
-    textarea#{&} {
-      font-family: var(--pf-global--FontFamily--sans-serif);
-      font-size: 100%;
-      line-height: var(--pf-global--LineHeight--md);
-    }
-
-    h1#{&},
-    h2#{&},
-    h3#{&},
-    h4#{&},
-    h5#{&},
-    h6#{&} {
-      font-size: 100%;
-      font-weight: var(--pf-global--FontWeight--normal);
-    }
-  }
-
   &,
   &::before,
   &::after {
@@ -99,6 +73,50 @@
     background-color: transparent;
   }
 }
+
+// Attributes for shield element attr selectors
+$shield-attrs: '[class*="pf-c"]', '[class*="pf-u"]', '[class*="pf-l"]';
+
+@mixin buildShieldAttrSel($els) {
+  @each $el in $els {
+    @each $attr in $shield-attrs {
+      #{$el}#{$attr} {
+        @content;
+      }
+    }
+  }
+}
+
+// Lists
+%list-styles {
+  list-style: none;
+}
+
+@include buildShieldAttrSel(ul) {
+  @extend %list-styles;
+}
+
+// Form elements
+%form-el-styles {
+  font-family: var(--pf-global--FontFamily--sans-serif);
+  font-size: 100%;
+  line-height: var(--pf-global--LineHeight--md);
+}
+
+@include buildShieldAttrSel(button input optgroup select textarea) {
+  @extend %form-el-styles;
+}
+
+// Headings
+%heading-styles {
+  font-size: 100%;
+  font-weight: var(--pf-global--FontWeight--normal);
+}
+
+@include buildShieldAttrSel(h1 h2 h3 h4 h5 h6) {
+  @extend %heading-styles;
+}
+
 
 // Since PF3 sets root font size to 10px, we need to unset it.
 // This doesn't affect PF3.


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1334

Verified in my local version of Openshift Console. 