### PR TITLE
feat(error-handling): add missing error handlers, upgrade a11y pkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
   local_dir: public
 
 before_script:
-  - wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/2.45/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip -d /home/travis/bin/
   - export CHROME_BIN=chromium-browser
   - npm install -g gulp-cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -4950,9 +4950,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.0.3.tgz",
-      "integrity": "sha512-Xj6LLvybA1g0kAZQ+eGifzbvY4nB/BUZq3z7eWmaEvTj1xp54aaB79cCC5eQjbTlH8n0CWI2CNBpidELUe2w9Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
+      "integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==",
       "dev": true
     },
     "axe-webdriverjs": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {},
   "devDependencies": {
     "@fortawesome/fontawesome": "^1.1.8",
-    "axe-core": "^3.0.3",
+    "axe-core": "^3.1.2",
     "axe-webdriverjs": "^2.0.1",
     "axios": "^0.18.0",
     "babel-eslint": "^8.2.3",

--- a/test-a11y/config.js
+++ b/test-a11y/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  toleranceThreshold: 18,
+  toleranceThreshold: 22,
   host: 'localhost',
   port: '8000',
   protocol: 'http',


### PR DESCRIPTION
This PR aims to further stablize our a11y test suite by upgrading related packages to the latest version and adding some strategic timeouts before running each page audit so that we can be sure we're auditing pages when they are in an ideal state, and not still in the process of rendering. I also added some missing catch() handlers to some of the reporter internals, these were resulting in `UnhandledPromiseRejectionWarning` errors being thrown in some of the builds from earlier today. This change should make those occurrences produce friendlier error messages. 

Before I added the these waits, the reporter reported a different number of errors most of the times I ran it locally. After the adjustments, I'm getting reports of 19 errors each run.

bump version of chromedriver
bump version of axe-core
wait for gastby root to receive child nodes
allow adequate time for CSS to paint DOM nodes
add missing catch handlers
refactor audit, cleanup