### PR TITLE
fix(table): remove ascending and descending modifiers from sortable table heads

### DIFF
--- a/src/patternfly/components/Table/docs/table-sortable.md
+++ b/src/patternfly/components/Table/docs/table-sortable.md
@@ -12,8 +12,6 @@
 | -- | -- | -- |
 | `.pf-c-table__sort`           | `<th>`                                      | Initiates a sort table cell. **Required for sortable table columns** |
 | `.pf-m-selected`             | `.pf-c-table__sort`                          | Modifies for sort selected state. **Required for sortable table columns** |
-| `.pf-m-ascending`             | `.pf-c-table__sort`                         | Modifies for sort ascending state. **Must be used with the .pf-m-selected modifier. Required for sortable table columns** |
-| `.pf-m-descending`            | `.pf-c-table__sort`                         | Modifies for sort descending state. **Must be used with the .pf-m-selected modifier. Required for sortable table columns** |
 | `.pf-c-table__sort-indicator` | `.pf-c-table__sort > button > span`         | Initiates a sort indicator. **Required for sortable table columns** |
 | `.fa-arrows-alt-v`                    | `.pf-c-table__sort > button > span > .fas`  | Initiates icon within unsorted, sortable table header. **Required for sortable table columns** |
 | `.fa-long-arrow-alt-up`                | `.pf-c-table__sort > button > span > .fas`  | Initiates icon within ascending sorted and selected, sortable table header. **Required for sortable table columns** |

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -1,7 +1,7 @@
 <th{{#if table-th--toggle}} class="pf-c-table__toggle {{table-th--modifier}}"
     {{else if table-th--check}} class="pf-c-table__check {{table-th--modifier}}"
     {{else if table-th--action}} class="pf-c-table__action {{table-th--modifier}}"
-    {{else if table-th--sortable}} class="pf-c-table__sort {{#if table-th--selected}} pf-m-selected{{/if}}{{#if table-th--asc}} pf-m-ascending{{/if}}{{#if table-th--desc}} pf-m-descending{{/if}} {{table-th--modifier}}"
+    {{else if table-th--sortable}} class="pf-c-table__sort {{#if table-th--selected}} pf-m-selected{{/if}} {{table-th--modifier}}"
     {{else if table-th--compound-expansion-toggle}} class="pf-c-table__compound-expansion-toggle {{table-th--modifier}}"
     {{else if table-th--modifier}} class="{{table-th--modifier}}"
   {{/if}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -114,7 +114,7 @@
   // Modifier - Expandable row expanded
   --pf-c-table__expandable-row--m-expanded--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
 
-  // Modifier - Sort ascending/descending
+  // Modifier - Sort 
   --pf-c-table__sort--sorted--Color: var(--pf-global--active-color--100);
 
   /* stylelint-enable */

--- a/src/site/pages/modifiers.md
+++ b/src/site/pages/modifiers.md
@@ -5,7 +5,6 @@
 - pf-m-active
 - pf-m-align-right
 - pf-m-all
-- pf-m-ascending
 - pf-m-block
 - pf-m-bottom
 - pf-m-collapsed
@@ -15,7 +14,6 @@
 - pf-m-dark
 - pf-m-dark-100
 - pf-m-dark-200
-- pf-m-descending
 - pf-m-disabled
 - pf-m-end
 - pf-m-end-current


### PR DESCRIPTION
Fix #1355 