### PR TITLE
fix(about-modal): fixes image stretch with scroll

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box-hero-image.hbs
+++ b/src/patternfly/components/AboutModalBox/about-modal-box-hero-image.hbs
@@ -1,4 +1,0 @@
-<img class="pf-c-about-modal-box__hero-image{{#if about-modal-box-hero-image--modifier}} {{about-modal-box-hero-image--modifier}}{{/if}}"
-  {{#if about-modal-box-hero-image--attribute}}
-    {{{about-modal-box-hero-image--attribute}}}
-  {{/if}}>

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -246,8 +246,8 @@
     background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
     background-repeat: no-repeat;
     background-attachment: fixed;
-    background-position: top right;
-    background-size: auto 100%;
+    background-position: top left;
+    background-size: auto;
     grid-area: hero;
   }
 }

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -73,6 +73,8 @@
 
   // hero image
   --pf-c-about-modal-box__hero--sm--BackgroundImage: url("#{$pf-global--image-path}/pfbg_992@2x.jpg");
+  --pf-c-about-modal-box__hero--sm--BackgroundPosition: top left;
+  --pf-c-about-modal-box__hero--sm--BackgroundPosition: cover;
 
   // Brand img
   --pf-c-about-modal-box__brand-image--Height: #{pf-size-prem(40px)};
@@ -198,8 +200,6 @@
 .pf-c-about-modal-box__close {
   grid-area: close;
   position: sticky;
-  top: 0;
-  right: 0;
   z-index: var(--pf-c-about-modal-box__close--ZIndex);
   display: flex;
   align-items: flex-start;
@@ -246,8 +246,8 @@
     background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
     background-repeat: no-repeat;
     background-attachment: fixed;
-    background-position: top left;
-    background-size: auto;
+    background-position: var(--pf-c-about-modal-box__hero--sm--BackgroundPosition);
+    background-size: var(--pf-c-about-modal-box__hero--sm--BackgroundSize);
     grid-area: hero;
   }
 }

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -71,6 +71,9 @@
   --pf-c-about-modal-box__close--c-button--BackgroundColor: #{$pf-color-black-1000}; // Close button uses a non-standard background color
   --pf-c-about-modal-box__close--c-button--hover--BackgroundColor: #{rgba($pf-color-black-1000, .4)};
 
+  // hero image
+  --pf-c-about-modal-box__hero--sm--BackgroundImage: url("#{$pf-global--image-path}/pfbg_992@2x.jpg");
+
   // Brand img
   --pf-c-about-modal-box__brand-image--Height: #{pf-size-prem(40px)};
 
@@ -114,6 +117,7 @@
   // This component always needs to be dark
   @extend %pf-t-dark;
 
+  position: relative;
   z-index: var(--pf-c-about-modal-box--ZIndex);
   display: grid;
   grid-template-rows: max-content max-content auto;
@@ -193,6 +197,9 @@
 // Close
 .pf-c-about-modal-box__close {
   grid-area: close;
+  position: sticky;
+  top: 0;
+  right: 0;
   z-index: var(--pf-c-about-modal-box__close--ZIndex);
   display: flex;
   align-items: flex-start;
@@ -233,16 +240,14 @@
 // Hero
 .pf-c-about-modal-box__hero {
   display: none; // Don't display the hero at the narrowest breakpoint
-  overflow: hidden;
 
   @media only screen and (min-width: $pf-global--breakpoint--sm) {
     display: block;
+    background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: top right;
+    background-size: auto 100%;
     grid-area: hero;
   }
-}
-
-.pf-c-about-modal-box__hero-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
 }

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -74,7 +74,7 @@
   // hero image
   --pf-c-about-modal-box__hero--sm--BackgroundImage: url("#{$pf-global--image-path}/pfbg_992@2x.jpg");
   --pf-c-about-modal-box__hero--sm--BackgroundPosition: top left;
-  --pf-c-about-modal-box__hero--sm--BackgroundPosition: cover;
+  --pf-c-about-modal-box__hero--sm--BackgroundSize: cover;
 
   // Brand img
   --pf-c-about-modal-box__brand-image--Height: #{pf-size-prem(40px)};

--- a/src/patternfly/components/AboutModalBox/docs/code.md
+++ b/src/patternfly/components/AboutModalBox/docs/code.md
@@ -24,7 +24,6 @@ About modal layout.
 | `.pf-c-about-modal-box__close`        |  `<div>`               |  Initiates a modal box close cell. |
 | `.pf-c-about-modal-box__header`       |  `<div>`, `<header>`   |  Initiates a modal box header cell. |
 | `.pf-c-about-modal-box__hero`         |  `<div>`               |  Initiates a modal box hero cell. |
-| `.pf-c-about-modal-box__hero-image`   |  `<img>`               |  Initiates a modal box hero image. |
 | `.pf-c-about-modal-box__content`      |  `<div>`               |  Initiates a modal box content cell. |
 | `.pf-c-content`                       |  `<div>`               |  Initiates the content component for the about modal content. |
 | `.pf-m-hover` | `.pf-c-about-modal-box__close .pf-c-button.pf-m-action` | Forces display of the hover state of the button. This state is primarily for demonstration purposes and would not normally be used in lieu of the `:hover` pseudo-class.

--- a/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
+++ b/src/patternfly/components/AboutModalBox/examples/about-modal-box-example.hbs
@@ -14,8 +14,6 @@
     {{/title}}
   {{/about-modal-box-header}}
   {{#> about-modal-box-hero}}
-    {{#> about-modal-box-hero-image about-modal-box-hero-image--attribute='src="/assets/images/pfbg_992.jpg" alt="Patternfly Background Image"'}}
-    {{/about-modal-box-hero-image}}
   {{/about-modal-box-hero}}
   {{#> about-modal-box-content}}
     {{#> content}}content{{/content}}

--- a/src/patternfly/components/AboutModalBox/examples/examples.scss
+++ b/src/patternfly/components/AboutModalBox/examples/examples.scss
@@ -1,0 +1,3 @@
+// Patternfly overrides for Gatsby site
+@import "../../../../site/gatsby-variables.scss";
+@import "../about-modal-box.scss";

--- a/src/patternfly/components/AboutModalBox/examples/index.js
+++ b/src/patternfly/components/AboutModalBox/examples/index.js
@@ -3,7 +3,7 @@ import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
 import docs from '../docs/code.md';
 import AboutModalBoxExample from './about-modal-box-example.hbs';
-import '../about-modal-box.scss';
+import './examples.scss';
 
 export const Docs = docs;
 
@@ -13,7 +13,9 @@ export default () => {
 
   return (
     <Documentation docs={Docs} heading={headingText}>
-      <Example heading={headingText}>{aboutModalBoxExample}</Example>
+      <Example fullPageOnly="true" heading={headingText}>
+        {aboutModalBoxExample}
+      </Example>
     </Documentation>
   );
 };

--- a/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
+++ b/src/patternfly/demos/AboutModal/examples/about-modal-example.hbs
@@ -17,8 +17,6 @@
           {{/title}}
         {{/about-modal-box-header}}
         {{#> about-modal-box-hero}}
-          {{#> about-modal-box-hero-image about-modal-box-hero-image--attribute='src="/assets/images/pfbg_992.jpg" alt="Patternfly Background Image"'}}
-          {{/about-modal-box-hero-image}}
         {{/about-modal-box-hero}}
         {{#> about-modal-box-content}}
           {{#> content}}


### PR DESCRIPTION
closes #1351 
I've also added in `position:sticky;` on the close button so it's stays in place when there is a lot of content and you scroll. 