### PR TITLE
fix(about-modal): adds top to close button

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -200,6 +200,7 @@
 .pf-c-about-modal-box__close {
   grid-area: close;
   position: sticky;
+  top: 0;
   z-index: var(--pf-c-about-modal-box__close--ZIndex);
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
adds `top:0;` to get `position:sticky;` to work properly.