### PR TITLE
fix(base.scss): enable -moz-focus-inner on buttons

### DIFF
--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -219,9 +219,15 @@ html {
   [type="button"],
   [type="reset"],
   [type="submit"] {
+    // Remove the inner border and padding in Firefox.
     &::-moz-focus-inner {
       padding: 0;
       border-style: none;
+    }
+
+    // Restore the focus styles unset by the previous rule.
+    &:-moz-focusring {
+      outline: 1px dotted ButtonText;
     }
   }
 } // ends if


### PR DESCRIPTION
We disabled `-moz-focus-inner` for a reason a while back, but I can't recall what the reason was. I removed that CSS and tested in Firefox and everything looks OK to me. Please give everything a good look and focus on buttons and make sure nothing breaks :)

fixes https://github.com/patternfly/patternfly-next/issues/1023