### PR TITLE
fix(formcontrol): add height property for browser consistency

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -17,6 +17,7 @@ $pf-c-form-control__select--ViewBox: "320" !default;
   --pf-c-form-control--BorderLeftColor: var(--pf-global--BorderColor--light-200);
   --pf-c-form-control--BorderRadius: 0;
   --pf-c-form-control--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
+  --pf-c-form-control--Height: calc(var(--pf-c-form-control--FontSize) * var(--pf-c-form-control--LineHeight) + var(--pf-c-form-control--BorderWidth) * 2 + var(--pf-c-form-control--PaddingTop) + var(--pf-c-form-control--PaddingBottom)); // Needed for various browsers that compute height of form elements differently
 
   // padding
   // Note for top/bottom padding, subtracting the border height so the height of the input is consistent with buttons and dropdowns that use the same spacing but draw their borders with pseudo elements
@@ -87,6 +88,10 @@ $pf-c-form-control__select--ViewBox: "320" !default;
 
   &::placeholder {
     --pf-c-form-control--Color: var(--pf-c-form-control--placeholder--Color);
+  }
+
+  &:not(textarea) {
+    height: var(--pf-c-form-control--Height);
   }
 
   &[readonly] {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/674

browsers handle the font-size and line-height differently in form elements. setting a height using the existing variables that should define the ultimate height works consistently across browsers. verified in chrome, safari, firefox, edge.