### PR TITLE
fix(base.scss): add default color to form elements

### DIFF
--- a/src/patternfly/_base.scss
+++ b/src/patternfly/_base.scss
@@ -147,6 +147,7 @@ html {
     font-family: inherit;
     font-size: 100%;
     line-height: var(--pf-global--LineHeight--md);
+    color: var(--pf-global--Color--100);
   }
 
   img,


### PR DESCRIPTION
I considered just adding `color: var(--pf-global--Color--100;` to the `button,
  input,
  optgroup,
  select,
  textarea ` selector in `_base.scss`, since those elements don't inherit color anyways. This would just make those elements (not all in all browsers, but most) our default color instead of the browser's default. I put together an example to test at https://codepen.io/mcoker/pen/NoXwgd.

The only problem I could see with that approach is if someone loaded the pf4 CSS after their app's CSS, and if they had declared a unique button color in their CSS with the same specificity as our element selector, we would change the color of their buttons.  But we're already going to do that with a lot of things in our base scss, like setting `font-weight` on heading elements, `color` on `a`/`a:hover` elements, etc. 

What do y'all think?

fixes https://github.com/patternfly/patternfly-next/issues/1360