### PR TITLE
feat(table): add inline editing + buttons

### DIFF
--- a/src/patternfly/_variables.scss
+++ b/src/patternfly/_variables.scss
@@ -5,11 +5,14 @@
   --pf-global--BackgroundColor--150: #{$pf-global--BackgroundColor--150};
   --pf-global--BackgroundColor--200: #{$pf-global--BackgroundColor--200};
   --pf-global--BackgroundColor--300: #{$pf-global--BackgroundColor--300};
+  --pf-global--BackgroundColor--hover: #{$pf-color-blue-50};
   --pf-global--BackgroundColor--light-100: #{$pf-global--BackgroundColor--light-100};
   --pf-global--BackgroundColor--light-200: #{$pf-global--BackgroundColor--light-200};
   --pf-global--BackgroundColor--light-300: #{$pf-global--BackgroundColor--light-300};
+  --pf-global--BackgroundColor--light-hover: #{$pf-color-blue-50};
   --pf-global--BackgroundColor--dark-100: #{$pf-global--BackgroundColor--dark-100};
   --pf-global--BackgroundColor--dark-200: #{$pf-global--BackgroundColor--dark-200};
+  --pf-global--BackgroundColor--dark-hover: #{$pf-color-blue-50};
   --pf-global--BackgroundColor--dark-transparent-100: #{$pf-global--BackgroundColor--dark-transparent-100};
   --pf-global--BackgroundColor--dark-transparent-200: #{$pf-global--BackgroundColor--dark-transparent-200};
 
@@ -120,9 +123,12 @@
   --pf-global--BorderWidth--md: #{$pf-global--BorderWidth--md};
   --pf-global--BorderWidth--lg: #{$pf-global--BorderWidth--lg};
   --pf-global--BorderColor: #{$pf-global--BorderColor};
+  --pf-global--BorderColor--hover: #{$pf-color-blue-200};
   --pf-global--BorderColor--dark: #{$pf-global--BorderColor--dark};
+  --pf-global--BorderColor--dark-hover: #{$pf-color-blue-200};
   --pf-global--BorderColor--light: #{$pf-global--BorderColor--light};
   --pf-global--BorderColor--light-200: #{$pf-global--BorderColor--light-200};
+  --pf-global--BorderColor--light-hover: #{$pf-color-blue-200};
   --pf-global--BorderRadius--sm: #{$pf-global--BorderRadius--sm};
   --pf-global--BorderRadius--lg: #{$pf-global--BorderRadius--lg};
 

--- a/src/patternfly/components/Table/docs/table-editable-column.md
+++ b/src/patternfly/components/Table/docs/table-editable-column.md
@@ -1,0 +1,10 @@
+### Table Editable Column Notes
+
+
+### Usage
+
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-c-table__editable-row`       | `<tr>`                        | Initiates an editable row. |
+| `.pf-m-table-editing-first-row`   | `.pf-c-table__editable-row`   | Editing of a table is in progress and the first row displays inline edit buttons. |
+| `.pf-m-table-editing-last-row`    | `.pf-c-table__editable-row`   | Editing of a table is in progress and the last row displays inline edit buttons. |

--- a/src/patternfly/components/Table/docs/table-editable.md
+++ b/src/patternfly/components/Table/docs/table-editable.md
@@ -1,0 +1,9 @@
+### Table Editable Notes
+
+
+### Usage
+
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-c-table__editable-row`   | `<tr>`                        | Initiates an editable row. |
+| `.pf-m-editing`               | `.pf-c-table__editable-row`   | Editing of a row is in progress. |

--- a/src/patternfly/components/Table/examples/index.js
+++ b/src/patternfly/components/Table/examples/index.js
@@ -5,6 +5,8 @@ import tableSimpleExampleRaw from '!raw!./table-simple-example.hbs';
 import tableSortableExampleRaw from '!raw!./table-sortable-example.hbs';
 import tableSimpleWithCheckboxesExampleRaw from '!raw!./table-simple-with-checkboxes-example.hbs';
 import tableExpandableExampleRaw from '!raw!./table-expandable-example.hbs';
+import tableEditableExampleRaw from '!raw!./table-editable-example.hbs';
+import tableEditableColumnExampleRaw from '!raw!./table-editable-column-example.hbs';
 import tableCompactExampleRaw from '!raw!./table-compact-example.hbs';
 import tableWidthExampleRaw from '!raw!./table-width-example.hbs';
 import tableCompoundExpansionExampleRaw from '!raw!./table-compound-expansion-example.hbs';
@@ -20,6 +22,12 @@ import tableCheckboxesActionsDoc from '../docs/table-checkboxes-actions.md';
 
 import TableExpandableExample from './table-expandable-example.hbs';
 import tableExpandableDoc from '../docs/table-expandable.md';
+
+import TableEditableExample from './table-editable-example.hbs';
+import tableEditableDoc from '../docs/table-editable.md';
+
+import TableEditableColumnExample from './table-editable-column-example.hbs';
+import tableEditableColumnDoc from '../docs/table-editable-column.md';
 
 import TableCompactExample from './table-compact-example.hbs';
 import tableCompactDoc from '../docs/table-compact.md';
@@ -38,6 +46,8 @@ export default () => {
   const tableSimpleExample = TableSimpleExample();
   const tableSortableExample = TableSortableExample();
   const tableExpandableExample = TableExpandableExample();
+  const tableEditableExample = TableEditableExample();
+  const tableEditableColumnExample = TableEditableColumnExample();
   const tableCompactExample = TableCompactExample();
   const tableSimpleWithCheckboxesExample = TableSimpleWithCheckboxesExample();
   const tableWidthExample = TableWidthExample();
@@ -67,6 +77,12 @@ export default () => {
         docs={tableCompoundExpansionDoc}
       >
         {tableCompoundExpansionExample}
+      </Example>
+      <Example heading="Editable Table" handlebars={tableEditableExampleRaw} docs={tableEditableDoc}>
+        {tableEditableExample}
+      </Example>
+      <Example heading="Editable Column Table" handlebars={tableEditableColumnExampleRaw} docs={tableEditableColumnDoc}>
+        {tableEditableColumnExample}
       </Example>
       <Example heading="Compact Table" handlebars={tableCompactExampleRaw} docs={tableCompactDoc}>
         {tableCompactExample}

--- a/src/patternfly/components/Table/examples/table-editable-column-example.hbs
+++ b/src/patternfly/components/Table/examples/table-editable-column-example.hbs
@@ -1,0 +1,59 @@
+{{#> table table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a editable column table example"'}}
+  {{#> table-thead}}
+    <tr>
+      {{#> table-th}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th}}
+        Branches
+      {{/table-th}} 
+      {{#> table-th}}
+        Pull requests
+      {{/table-th}} 
+      {{#> table-th}}
+        Workspaces
+      {{/table-th}} 
+      {{#> table-th}}
+        Last Commit
+      {{/table-th}} 
+    </tr>
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+     <tr class="pf-c-table__editable-row pf-m-table-editing-first-row">
+      {{#> table-td table-td--data-label="Repository Name"}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+         <input type="number" value="10" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+         <input type="number" value="25" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        <input type="text" value="5" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        <input type="text" value="2 days ago" />
+      {{/table-td}}
+    </tr>
+
+     <tr class="pf-c-table__editable-row">
+      {{#> table-td table-td--data-label="Repository Name"}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+         <input type="number" value="10" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+         <input type="number" value="25" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        <input type="text" value="5" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        <input type="text" value="2 days ago" />
+      {{/table-td}}
+    </tr>
+  {{/table-tbody}}
+{{/table}}

--- a/src/patternfly/components/Table/examples/table-editable-example.hbs
+++ b/src/patternfly/components/Table/examples/table-editable-example.hbs
@@ -1,0 +1,58 @@
+{{#> table table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a editable table example"'}}
+  {{#> table-thead}}
+    <tr>
+      {{#> table-th}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th}}
+        Branches
+      {{/table-th}} 
+      {{#> table-th}}
+        Pull requests
+      {{/table-th}} 
+      {{#> table-th}}
+        Workspaces
+      {{/table-th}} 
+      {{#> table-th}}
+        Last Commit
+      {{/table-th}} 
+    </tr>
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    <tr class="pf-c-table__editable-row">
+      {{#> table-td table-td--data-label="Repository Name"}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}      
+      {{#> table-td table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}  
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}  
+      {{#> table-td table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}  
+    </tr>
+     <tr class="pf-c-table__editable-row pf-m-editing">
+      {{#> table-td table-td--data-label="Repository Name"}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+         <input type="number" value="10" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+         <input type="number" value="25" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        <input type="text" value="5" />
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        <input type="text" value="2 days ago" />
+      {{/table-td}}
+    </tr>
+  {{/table-tbody}}
+{{/table}}

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -77,6 +77,10 @@
   --pf-c-table__sort-indicator--hover--Color: var(--pf-global--Color--100);
   --pf-c-table__sort--c-button--Color: var(--pf-global--Color--100);
 
+  // Editable row
+  --pf-c-table__editable-row--BackgroundColor--hover: var(--pf-global--BackgroundColor--hover);
+  --pf-c-table__editable-row--BorderColor--hover: var(--pf-global--BorderColor--hover);
+
   // Icon inline
   --pf-c-table__icon-inline--MarginRight: var(--pf-global--spacer--sm);
 
@@ -131,6 +135,9 @@
     // content wraps. for those special cases, there must be an explicit height set on tr and table cell
     // for button height: 100% to work
     height: 1px;
+  }
+
+  tr:not(.pf-c-table__expandable-row):not(.pf-c-table__editable-row) {
     border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
   }
 
@@ -419,6 +426,76 @@
   &,
   .pf-c-table__expandable-row-content {
     padding: 0;
+  }
+}
+
+// Editable row
+// ==================================================================
+.pf-c-table__editable-row {
+  border: 1px solid transparent;
+
+  &:hover,
+  &.pf-m-editing {
+    td {
+      background: var(--pf-c-table__editable-row--BackgroundColor--hover);
+      border-top: 1px solid var(--pf-c-table__editable-row--BorderColor--hover);
+      border-bottom: 1px solid var(--pf-c-table__editable-row--BorderColor--hover);
+
+      &:first-child {
+        border-left: 1px solid var(--pf-c-table__editable-row--BorderColor--hover);
+      }
+
+      &:last-child {
+        border-right: 1px solid var(--pf-c-table__editable-row--BorderColor--hover);
+      }
+    }
+  }
+
+  &.pf-m-table-editing-first-row {
+    border-top: 3px solid var(--pf-c-table__editable-row--BorderColor--hover);
+  }
+
+  &.pf-m-table-editing-last-row {
+    border-bottom: 3px solid var(--pf-c-table__editable-row--BorderColor--hover);
+  }
+
+  input {
+    display: block;
+    background: var(--pf-global--BackgroundColor--100);
+    border: 1px solid var(--pf-global--BorderColor);
+
+    &:hover {
+      cursor: text;
+    }
+  }
+}
+
+.pf-c-table__inline-edit-buttons {
+  position: fixed;
+  z-index: 1000;
+  padding: 4px;
+  margin: 0;
+  background: var(--pf-global--BackgroundColor--hover);
+  border: 1px solid var(--pf-global--BorderColor--hover);
+
+  &.pf-m-top {
+    border-bottom: 0;
+  }
+
+  &.pf-m-bottom {
+    border-top: 0;
+  }
+
+  &.pf-m-bold {
+    border-width: 3px;
+  }
+
+  button {
+    margin-left: 4px;
+
+    &:first-child {
+      margin-left: 0;
+    }
   }
 }
 

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -23,16 +23,19 @@ $pf-global--BackgroundColor--100: $pf-color-white !default;
 $pf-global--BackgroundColor--150: $pf-color-black-150 !default;
 $pf-global--BackgroundColor--200: $pf-color-black-100 !default;
 $pf-global--BackgroundColor--300: $pf-color-black-200 !default;
+$pf-global--BackgroundColor--hover: $pf-color-blue-50 !default;
 
 // do not use - background colors for exceptions and defining theme
 // light theme
 $pf-global--BackgroundColor--light-100:     $pf-color-white !default;
 $pf-global--BackgroundColor--light-200:     $pf-color-black-100 !default;
 $pf-global--BackgroundColor--light-300:     $pf-color-black-200 !default;
+$pf-global--BackgroundColor--light-hover:   $pf-color-blue-50 !default;
 
 // dark theme
 $pf-global--BackgroundColor--dark-100:      $pf-color-black-900 !default;
 $pf-global--BackgroundColor--dark-200:      $pf-color-black-800 !default;
+$pf-global--BackgroundColor--dark-hover:    $pf-color-blue-50 !default;
 $pf-global--BackgroundColor--dark-transparent-100:  rgba($pf-color-black-1000, .62) !default;
 $pf-global--BackgroundColor--dark-transparent-200:  rgba($pf-color-black-1000, .32) !default;
 
@@ -160,9 +163,12 @@ $pf-global--BorderWidth--sm:     1px !default;
 $pf-global--BorderWidth--md:     2px !default;
 $pf-global--BorderWidth--lg:     3px !default;
 $pf-global--BorderColor:         $pf-color-black-600 !default;
+$pf-global--BorderColor--hover:  $pf-color-blue-200 !default;
 $pf-global--BorderColor--dark:   $pf-color-black-600 !default;
+$pf-global--BorderColor--dark-hover:  $pf-color-blue-200 !default;
 $pf-global--BorderColor--light:  $pf-color-black-400 !default;
 $pf-global--BorderColor--light-200: $pf-color-black-200 !default;
+$pf-global--BorderColor--light-hover:  $pf-color-blue-200 !default;
 $pf-global--BorderRadius--sm:        3px !default;
 $pf-global--BorderRadius--lg:        30em !default; // This is a sufficiently large number to ensure in most cases that the ends are evenly rounded.
 


### PR DESCRIPTION
Hello,

these are the styles for pf-react Table (https://github.com/patternfly/patternfly-react/pull/1227). 

It was inspired by pf3 inline-edit (https://github.com/patternfly/patternfly-react/blob/aa839a80a005f5d540faeb0e1a0320b7df1cc982/packages/patternfly-3/patternfly-react/less/inline-edit.less)

few issues:
- I didn't put the confirmation buttons into the examples because their location is computed (depends on scroll and resize)
- not sure if the colors should be the same as in pf3 (light/dark theme?)
- the borders seem to misbehave in firefox
