### PR TITLE
docs(readme): update the readme to include css checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,10 @@ If you want to set host to a specific IP address for example `172.17.12.1` run `
 
 ## Guidelines for CSS Development
 
-- For issues created in Core that will affect a component in PF-React, a follow up issue must be created in PF-React once the Pull Request is merged.
-- The UX/Visual designer and CSS developer of a component/enhancement should be involved in the review process throughout the life cycle of that component/enhancement.
+- For issues created in Core that will affect a component in PF-React, a follow up issue must be created in PF-React once the Pull Request is merged. The issue should include the Core PR #, the Core Release, a link to the component in https://pf4.patternfly.org, and information detailing the change.
 - If global variables are modified in Core, a React issue should be opened to address this.
 - CSS developers should ensure that animation is well documented and communicated to the respective React developer.
-- CSS developers should communicate any design changes back to the design team, so that the changes can be updated in the master Sketch file.
+- Once the component/enhancement is complete it should receive sign off from a visual designer who can then update the master sketch file with any changes.
 
 ## Testing for Accessibility
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ If you want to set host to a specific IP address for example `172.17.12.1` run `
 
 *To view visit http://localhost:8000/demos/<name>*
 
+## Guidelines for CSS Development
+
+- For issues created in Core that will affect a component in PF-React, a follow up issue must be created in PF-React once the Pull Request is merged.
+- The UX/Visual designer and CSS developer of a component/enhancement should be involved in the review process throughout the life cycle of that component/enhancement.
+- If global variables are modified in Core, a React issue should be opened to address this.
+- CSS developers should ensure that animation is well docume ted and communicated to the respective Reacted developer.
+- CSS developers should communicate with the Sketch file lead about any design changes, so that it can be updated in the Sketch file.
+
 ## Testing for Accessibility
 
 PatternFly uses [aXe: The Accessibility Engine](https://www.deque.com/axe/) to check for accessibility violations. Our goal is to meet WCAG 2.0 AA requirements, as noted in our [Accessibility Guide](https://pf4.patternfly.org/accessibility-guide).

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ If you want to set host to a specific IP address for example `172.17.12.1` run `
 - For issues created in Core that will affect a component in PF-React, a follow up issue must be created in PF-React once the Pull Request is merged.
 - The UX/Visual designer and CSS developer of a component/enhancement should be involved in the review process throughout the life cycle of that component/enhancement.
 - If global variables are modified in Core, a React issue should be opened to address this.
-- CSS developers should ensure that animation is well docume ted and communicated to the respective Reacted developer.
-- CSS developers should communicate with the Sketch file lead about any design changes, so that it can be updated in the Sketch file.
+- CSS developers should ensure that animation is well documented and communicated to the respective React developer.
+- CSS developers should communicate any design changes back to the design team, so that the changes can be updated in the master Sketch file.
 
 ## Testing for Accessibility
 


### PR DESCRIPTION
Closes #893 

I opened this issue a few months ago. The idea was to harden CSS/React implementation. 

Do we think this is still necessary/is there anything to add?