### PR TITLE
fix(docs): update CDN url

### DIFF
--- a/src/site/_site/CodepenButton/index.js
+++ b/src/site/_site/CodepenButton/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import editIcon from './edit.svg';
 import './styles.scss';
 
+// https://blog.codepen.io/documentation/api/prefill/
 export default ({
   title = 'PatternFly 4 Pen',
   description = 'PatternFly 4 Pen',
@@ -9,7 +10,7 @@ export default ({
   html = '',
   css = '',
   js = '',
-  cssExternal = 'https://pf4.patternfly.org/styles.css',
+  cssExternal = 'https://unpkg.com/@patternfly/patternfly/patternfly.min.css',
   jsExternal = '',
   height = 40,
   width = 40
@@ -30,13 +31,7 @@ export default ({
   return (
     <form action="https://codepen.io/pen/define" method="POST" target="_blank">
       <input type="hidden" name="data" value={data} />
-      <input
-        type="image"
-        src={editIcon}
-        alt="Edit on CodePen"
-        width={width}
-        height={height}
-      />
+      <input type="image" src={editIcon} alt="Edit on CodePen" width={width} height={height} />
     </form>
   );
 };


### PR DESCRIPTION
Use unpkg as our CDN instead of https://pf4.patternfly.org/styles.css. Reference #1435.

Example [codepen.](https://codepen.io/anon/pen/wNOJre?&editable=true) There's still the detail of figuring out assets other than CSS, like the Patternfly logo.