### PR TITLE
Change padding around expandable rows.

### DIFF
--- a/src/patternfly/components/Table/docs/table-compound-expansion.md
+++ b/src/patternfly/components/Table/docs/table-compound-expansion.md
@@ -18,4 +18,5 @@
 | Class | Applied To | Outcome |
 | -- | -- | -- |
 | `.pf-m-expanded`                          | `<tbody>`, `.pf-c-table__compound-expansion-toggle` > `.pf-c-button` | Modifies a tbody with a row and an expandable row. |
+| `.pf-c-table__expandable-row-table` | `.pf-c-table__expandable-row` > `<td>` > `<div>`  | Initiates an expandable row content wrapper. |
 | `.pf-c-table__compound-expansion-toggle`  | `<td>` | Modifies a `<td>` on active/focus. |

--- a/src/patternfly/components/Table/docs/table-compound-expansion.md
+++ b/src/patternfly/components/Table/docs/table-compound-expansion.md
@@ -18,5 +18,4 @@
 | Class | Applied To | Outcome |
 | -- | -- | -- |
 | `.pf-m-expanded`                          | `<tbody>`, `.pf-c-table__compound-expansion-toggle` > `.pf-c-button` | Modifies a tbody with a row and an expandable row. |
-| `.pf-c-table__expandable-row-table` | `.pf-c-table__expandable-row` > `<td>` > `<div>`  | Initiates an expandable row content wrapper. |
 | `.pf-c-table__compound-expansion-toggle`  | `<td>` | Modifies a `<td>` on active/focus. |

--- a/src/patternfly/components/Table/docs/table-expandable.md
+++ b/src/patternfly/components/Table/docs/table-expandable.md
@@ -6,6 +6,8 @@
 <br>
 <mark>**All checkbox/action button accessibility and usage requirements apply.**</mark>
 
+Note: To apply padding to `.pf-c-table__expandable-row` wrap the content in `.pf-c-table__expandable-row-content`. 
+
 ### Accessibility
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/components/Table/docs/table-expandable.md
+++ b/src/patternfly/components/Table/docs/table-expandable.md
@@ -6,7 +6,7 @@
 <br>
 <mark>**All checkbox/action button accessibility and usage requirements apply.**</mark>
 
-Note: To apply padding to `.pf-c-table__expandable-row` wrap the content in `.pf-c-table__expandable-row-content`. 
+Note: To apply padding to `.pf-c-table__expandable-row`, wrap the content in `.pf-c-table__expandable-row-content`. 
 
 ### Accessibility
 | Attribute | Applied To | Outcome |

--- a/src/patternfly/components/Table/examples/table-compound-expansion-example.hbs
+++ b/src/patternfly/components/Table/examples/table-compound-expansion-example.hbs
@@ -56,21 +56,21 @@
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--modifier="pf-m-expanded"}}
+    {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-nested table-nested--id="nested-table-1"}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-nested table-nested--id="nested-table-2"}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-nested table-nested-id="nested-table-3"}}
         {{/table-nested}}
@@ -113,21 +113,21 @@
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="4"'}}
         {{#> table-nested table-nested--id="nested-table-4"}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="5"'}}
         {{#> table-nested table-nested--id="nested-table-5"}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="6"'}}
         {{#> table-nested table-nested--id="nested-table-6"}}
         {{/table-nested}}
@@ -170,21 +170,21 @@
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-nested table-nested--id="nested-table-7"}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-nested table-nested--id="nested-table-8"}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
+    {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
         {{#> table-nested table-nested--id="nested-table-9"}}
         {{/table-nested}}

--- a/src/patternfly/components/Table/examples/table-compound-expansion-example.hbs
+++ b/src/patternfly/components/Table/examples/table-compound-expansion-example.hbs
@@ -58,21 +58,21 @@
 
     {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        {{#> table-nested table-nested--id="nested-table-1"}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-1"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        {{#> table-nested table-nested--id="nested-table-2"}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-2"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        {{#> table-nested table-nested-id="nested-table-3"}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-3"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
@@ -114,22 +114,22 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="4"'}}
-        {{#> table-nested table-nested--id="nested-table-4"}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-4"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="5"'}}
-        {{#> table-nested table-nested--id="nested-table-5"}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-5"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
-      {{#> table-td table-td--attribute='colspan="6"'}}
-        {{#> table-nested table-nested--id="nested-table-6"}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-6"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
@@ -172,21 +172,21 @@
 
     {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        {{#> table-nested table-nested--id="nested-table-7"}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-7"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        {{#> table-nested table-nested--id="nested-table-8"}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-8"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        {{#> table-nested table-nested--id="nested-table-9"}}
+        {{#> table-nested table-nested--attribute=(concat 'aria-label="Nested table" id="' table--id '-nested-table-9"')}}
         {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}

--- a/src/patternfly/components/Table/examples/table-compound-expansion-example.hbs
+++ b/src/patternfly/components/Table/examples/table-compound-expansion-example.hbs
@@ -58,28 +58,22 @@
 
     {{#> table-tr table-tr--expandable="true" table-tr--modifier="pf-m-expanded"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-1">
-          {{#> table-nested table-nested-id="nested-table-1"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-1"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-2">
-          {{#> table-nested table-nested-id="nested-table-2"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-2"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-3">
-          {{#> table-nested table-nested-id="nested-table-3"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested-id="nested-table-3"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}
@@ -121,28 +115,22 @@
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="4"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-4">
-          {{#> table-nested table-nested-id="nested-table-4"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-4"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="5"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-5">
-          {{#> table-nested table-nested-id="nested-table-5"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-5"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="6"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-6">
-          {{#> table-nested table-nested-id="nested-table-6"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-6"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}
@@ -184,28 +172,22 @@
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-7">
-          {{#> table-nested table-nested-id="nested-table-7"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-7"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-8">
-          {{#> table-nested table-nested-id="nested-table-8"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-8"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
       {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-nested-table-9">
-          {{#> table-nested table-nested-id="nested-table-9"}}
-          {{/table-nested}}
-        </div>
+        {{#> table-nested table-nested--id="nested-table-9"}}
+        {{/table-nested}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/components/Table/examples/table-expandable-example.hbs
+++ b/src/patternfly/components/Table/examples/table-expandable-example.hbs
@@ -43,21 +43,16 @@
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--modifier="pf-m-expanded"}}
-      {{#> table-td table-td--attribute='colspan="7"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-content1">
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table-id '-content1"')}}
+        <div class="pf-c-table__expandable-row-content">
+          This content has padding.
         </div>
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}
 
-  {{#> table-tbody}}
+  {{#> table-tbody table-tbody--modifier="pf-m-expanded"}}
     {{#> table-tr}}
       {{#> table-td table-td--toggle="true" table-td--button--attribute=(concat 'aria-labelledby="' table--id '-node2 expandable-toggle2" id="expandable-toggle2" aria-label="Details" aria-controls="' table--id '-content2"')}}{{/table-td}}
       {{#> table-td table-td--check="true"}}
@@ -82,22 +77,9 @@
       {{/table-td}}
     {{/table-tr}}
 
-    {{#> table-tr table-tr--expandable="true" table-tr--attribute="hidden"}}
-      {{#> table-td}}
-      {{/table-td}}
-      {{#> table-td}}
-      {{/table-td}}
-      {{#> table-td table-td--attribute='colspan="4"'}}
-        <div class="pf-c-table__expandable-row-content" id="{{table--id}}-content2">
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </div>
-      {{/table-td}}
-      {{#> table-td}}
+    {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table-id '-content1"')}}
+        This content has no padding.
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/components/Table/examples/table-expandable-example.hbs
+++ b/src/patternfly/components/Table/examples/table-expandable-example.hbs
@@ -44,11 +44,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--modifier="pf-m-expanded"}}
-      {{#> table-td}}
-      {{/table-td}}
-      {{#> table-td}}
-      {{/table-td}}
-      {{#> table-td table-td--attribute='colspan="4"'}}
+      {{#> table-td table-td--attribute='colspan="7"'}}
         <div class="pf-c-table__expandable-row-content" id="{{table--id}}-content1">
           Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
@@ -57,8 +53,6 @@
           cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
           proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </div>
-      {{/table-td}}
-      {{#> table-td}}
       {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}

--- a/src/patternfly/components/Table/examples/table-expandable-example.hbs
+++ b/src/patternfly/components/Table/examples/table-expandable-example.hbs
@@ -44,7 +44,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table-id '-content1"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content1"')}}
         <div class="pf-c-table__expandable-row-content">
           This content has padding.
         </div>
@@ -78,7 +78,7 @@
     {{/table-tr}}
 
     {{#> table-tr table-tr--expandable="true" table-tr--IsExpanded="true"}}
-      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table-id '-content1"')}}
+      {{#> table-td table-td--attribute=(concat 'colspan="7" id="' table--id '-content1"')}}
         This content has no padding.
       {{/table-td}}
     {{/table-tr}}

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -280,6 +280,8 @@ $pf-c-table-xs-breakpoint: 380px;
     --pf-c-table__expandable-row-content--PaddingLeft: var(--pf-c-table__expandable-row-content--responsive--PaddingLeft);
 
     display: block;
+    max-height: var(--pf-c-table__expandable-row--MaxHeight);  // Overflow scroll should only happen on responsive
+    overflow-y: auto;
     border-bottom: none;
     box-shadow: none;
 
@@ -298,12 +300,10 @@ $pf-c-table-xs-breakpoint: 380px;
       // Border treatment
       display: none;
     }
-  }
 
-  // Overflow scroll should only happen on responsive
-  .pf-c-table__expandable-row-content {
-    max-height: var(--pf-c-table__expandable-row-content--MaxHeight);
-    overflow-y: auto;
+    &:not(.pf-m-expanded) {
+      display: none;
+    }
   }
 
   // Set defaults

--- a/src/patternfly/components/Table/table-nested.hbs
+++ b/src/patternfly/components/Table/table-nested.hbs
@@ -1,4 +1,4 @@
-{{#> table newcontext table--id=table-nested--id table--modifier="pf-m-compact" table--grid="true" table--attribute='aria-label="Nested table"'}}
+{{#> table newcontext table--attribute=table-nested--attribute table--modifier="pf-m-compact" table--grid="true"}}
   {{#> table-thead}}
     {{#> table-tr}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}Description{{/table-th}}

--- a/src/patternfly/components/Table/table-nested.hbs
+++ b/src/patternfly/components/Table/table-nested.hbs
@@ -1,4 +1,4 @@
-{{#> table newcontext table-nested--id=table-nested-id table--modifier="pf-m-compact" table--grid="true" table--attribute='aria-label="Nested table"'}}
+{{#> table newcontext table--id=table-nested--id table--modifier="pf-m-compact" table--grid="true" table--attribute='aria-label="Nested table"'}}
   {{#> table-thead}}
     {{#> table-tr}}
       {{#> table-th table-th--attribute='scope="col"' table-th--sortable="true"}}Description{{/table-th}}

--- a/src/patternfly/components/Table/table-tr.hbs
+++ b/src/patternfly/components/Table/table-tr.hbs
@@ -1,4 +1,4 @@
-<tr{{#if table-tr--expandable}} class="pf-c-table__expandable-row{{#if table-tr--modifier}} {{table-tr--modifier}}{{/if}}"{{/if}}
+<tr{{#if table-tr--expandable}} class="pf-c-table__expandable-row{{#if table-tr--IsExpanded}} pf-m-expanded{{/if}}{{#if table-tr--modifier}} {{table-tr--modifier}}{{/if}}"{{/if}}
   {{#if table-tr--attribute}}
     {{{table-tr--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Table/table.hbs
+++ b/src/patternfly/components/Table/table.hbs
@@ -4,6 +4,9 @@
   {{/if}}
   {{#if table--attribute}}
     {{{table--attribute}}}
+  {{/if}}
+  {{#if table--id}}
+    id="{{{table--id}}}"
   {{/if}}>
   {{> @partial-block}}
 </table>

--- a/src/patternfly/components/Table/table.hbs
+++ b/src/patternfly/components/Table/table.hbs
@@ -5,6 +5,9 @@
   {{#if table--attribute}}
     {{{table--attribute}}}
   {{/if}}
+  {{#if table-nested--attribute}}
+    {{{table-nested--attribute}}}
+  {{/if}}
   {{#if table--id}}
     id="{{{table--id}}}"
   {{/if}}>

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -414,13 +414,13 @@
   /* stylelint-enable */
 }
 
-.pf-c-table td:only-child,
-.pf-c-table th:only-child {
-  &,
-  .pf-c-table__expandable-row-content {
-    padding: 0;
-  }
-}
+// .pf-c-table td:only-child,
+// .pf-c-table th:only-child {
+//   &,
+//   .pf-c-table__expandable-row-content {
+//     padding: 0;
+//   }
+// }
 
 // Nested table
 // ==================================================================

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -59,17 +59,12 @@
   --pf-c-table__expandable-row--before--Width: var(--pf-global--BorderWidth--lg);
   --pf-c-table__expandable-row--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-table__expandable-row--before--ZIndex: var(--pf-global--ZIndex--sm);
-
-  // Table rows
-  // Padding vars must be individual as they are contextually reset
-  --pf-c-table__expandable-row-content--PaddingTop: 0;
-  --pf-c-table__expandable-row-content--PaddingRight: 0;
-  --pf-c-table__expandable-row-content--PaddingBottom: 0;
-  --pf-c-table__expandable-row-content--PaddingLeft: 0;
-  --pf-c-table__expandable-row-content--MaxHeight: #{pf-size-prem(450px)};
+  --pf-c-table__expandable-row--MaxHeight: #{pf-size-prem(450px)};
   --pf-c-table__expandable-row-content--Transition: var(--pf-global--Transition);
-  --pf-c-table__expandable-row-content--m-expanded--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-table__expandable-row-content--m-expanded--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-table__expandable-row-content--PaddingTop: var(--pf-global--spacer--xl);
+  --pf-c-table__expandable-row-content--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-table__expandable-row-content--PaddingBottom: var(--pf-global--spacer--xl);
+  --pf-c-table__expandable-row-content--PaddingLeft: var(--pf-global--spacer--xl);
 
   // Sort indicator
   --pf-c-table__sort-indicator--MarginLeft: var(--pf-global--spacer--md);
@@ -375,9 +370,13 @@
     transition: var(--pf-c-table__expandable-row--Transition);
   }
 
-  // Td
-  td {
-    position: relative;
+  // no padding on standard td
+  td:only-child {
+    padding: 0;
+  }
+
+  .pf-c-table__expandable-row-content {
+    padding: var(--pf-c-table__expandable-row-content--PaddingTop) var(--pf-c-table__expandable-row-content--PaddingRight) var(--pf-c-table__expandable-row-content--PaddingBottom) var(--pf-c-table__expandable-row-content--PaddingLeft);
   }
 
   // Modifier - Expanded tr
@@ -389,38 +388,10 @@
   }
 
   &:not(.pf-m-expanded) {
-    .pf-c-table__expandable-row-content {
-      display: none;
-    }
+    display: none;
   }
 }
 
-// Expandable row content
-// ==================================================================
-.pf-c-table__expandable-row-content {
-  // set base variables to reset later
-  padding: var(--pf-c-table__expandable-row-content--PaddingTop) var(--pf-c-table__expandable-row-content--PaddingRight) var(--pf-c-table__expandable-row-content--PaddingBottom) var(--pf-c-table__expandable-row-content--PaddingLeft);
-  word-break: break-word;
-  border-top-color: transparent;
-  border-top-width: 0;
-  transition: var(--pf-c-table__expandable-row-content--Transition);
-
-  // Modifier on td- Expanded
-  /* stylelint-disable */
-  tr.pf-m-expanded & {
-    --pf-c-table__expandable-row-content--PaddingTop: var(--pf-c-table__expandable-row-content--m-expanded--PaddingTop);
-    --pf-c-table__expandable-row-content--PaddingBottom: var(--pf-c-table__expandable-row-content--m-expanded--PaddingBottom);
-  }
-  /* stylelint-enable */
-}
-
-// .pf-c-table td:only-child,
-// .pf-c-table th:only-child {
-//   &,
-//   .pf-c-table__expandable-row-content {
-//     padding: 0;
-//   }
-// }
 
 // Nested table
 // ==================================================================

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -373,6 +373,7 @@
   // no padding on standard td
   td:only-child {
     padding: 0;
+    padding-left: var(--pf-c-table__expandable-row--before--Width); // set padding-left to adjust for left border.
   }
 
   .pf-c-table__expandable-row-content {


### PR DESCRIPTION
Fix #1424 

Expandable rows in tables should have the same padding as expandable rows in data lists. Currently in tables, we use the columns from the above row to determine spacing around content, but this is not robust enough for products to use.

Fix: expandable rows by default have no padding i.e. if you want to include something that has its own padding / the nested table in compound expansion / or when there is no required padding. 
using `.pf-c-table__expandable-row-content` as the child of `.pf-c-table__expandable-row` will apply the necessary spacing.