### PR TITLE
Add icon in Data List 

### DIFF
--- a/src/patternfly/components/DataList/data-list-icon.hbs
+++ b/src/patternfly/components/DataList/data-list-icon.hbs
@@ -1,0 +1,8 @@
+<div class="pf-c-data-list__icon{{#if data-list-icon--modifier}} {{data-list-icon--modifier}}{{/if}}"
+  {{#if data-list-icon--attribute}}
+    {{{data-list-icon--attribute}}}
+  {{/if}}>
+  <i class="fas{{#if data-list-icon--type}} fa-{{data-list-icon--type}}{{/if}}"
+  aria-hidden="true">
+  </i>
+</div>

--- a/src/patternfly/components/DataList/data-list-icon.hbs
+++ b/src/patternfly/components/DataList/data-list-icon.hbs
@@ -1,8 +1,3 @@
-<div class="pf-c-data-list__icon{{#if data-list-icon--modifier}} {{data-list-icon--modifier}}{{/if}}"
-  {{#if data-list-icon--attribute}}
-    {{{data-list-icon--attribute}}}
-  {{/if}}>
-  <i class="fas{{#if data-list-icon--type}} fa-{{data-list-icon--type}}{{/if}}"
-  aria-hidden="true">
-  </i>
-</div>
+<i class="pf-c-data-list__icon fas{{#if data-list-icon--type}} fa-{{data-list-icon--type}}{{/if}}"
+aria-hidden="true">
+</i>

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -58,6 +58,14 @@ $pf-data-list--breakpoint--mobile: 380px;
     --pf-c-data-list__check--MarginRight: var(--pf-c-data-list__check--mobile--MarginRight);
   }
 
+  // Icon
+  --pf-c-data-list__icon--MarginRight: var(--pf-global--spacer--xl);
+  --pf-c-data-list__icon--mobile--MarginRight: var(--pf-global--spacer--md);
+
+  @media screen and (max-width: $pf-data-list--breakpoint--mobile) {
+    --pf-c-data-list__icon--MarginRight: var(--pf-c-data-list__icon--mobile--MarginRight);
+  }
+
   // Actions
   --pf-c-data-list__action--MarginLeft: var(--pf-global--spacer--lg);
   --pf-c-data-list__action--mobile--MarginLeft: var(--pf-global--spacer--sm);
@@ -135,6 +143,7 @@ $pf-data-list--breakpoint--mobile: 380px;
 // non-textual items
 .pf-c-data-list__toggle,
 .pf-c-data-list__check,
+.pf-c-data-list__icon,
 .pf-c-data-list__action {
   flex: none;
 }
@@ -160,6 +169,11 @@ $pf-data-list--breakpoint--mobile: 380px;
 .pf-c-data-list__check {
   display: flex;
   margin-right: var(--pf-c-data-list__check--MarginRight);
+}
+
+.pf-c-data-list__icon {
+  display: flex;
+  margin-right: var(--pf-c-data-list__icon--MarginRight);
 }
 
 // Content cells

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -167,12 +167,10 @@ $pf-data-list--breakpoint--mobile: 380px;
 
 // Checkbox
 .pf-c-data-list__check {
-  display: flex;
   margin-right: var(--pf-c-data-list__check--MarginRight);
 }
 
 .pf-c-data-list__icon {
-  display: flex;
   margin-right: var(--pf-c-data-list__icon--MarginRight);
 }
 

--- a/src/patternfly/components/DataList/docs/data-list-expandable.md
+++ b/src/patternfly/components/DataList/docs/data-list-expandable.md
@@ -19,4 +19,5 @@
 | Class | Applied To | Outcome |
 | -- | -- | -- |
 | `.pf-c-data-list__toggle`         | `<div>`               | Initiates a toggle button. |
+| `.pf-c-data-list__icon`  | `<i>` | Initiates a toggle icon. |
 | `.pf-m-expanded`                  | `.pf-c-table__item`   | Modifies for expanded state. |

--- a/src/patternfly/components/DataList/examples/data-list-expandable-example.hbs
+++ b/src/patternfly/components/DataList/examples/data-list-expandable-example.hbs
@@ -1,7 +1,7 @@
 {{#> data-list data-list--attribute='aria-label="Expandable data list example"'}}
   {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute='aria-labelledby="ex-item1"'}}
     {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle1 ex-item1" id="ex-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-1"'}}{{/data-list-toggle}}
-    {{#> data-list-check checkbox--attribute='name="ex-check1" aria-labelledby="ex-item1"'}}{{/data-list-check}}
+    {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
     {{#> data-list-cell}}
       <div id="ex-item1">Primary content</div>
       <a href="#">link</a>
@@ -17,16 +17,15 @@
 
   {{#> data-list-item data-list-item--attribute='aria-labelledby="ex-item2"'}}
     {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle2 ex-item2" id="ex-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="content-2"'}}{{/data-list-toggle}}
-    {{#> data-list-check checkbox--attribute='name="ex-check2" aria-labelledby="ex-item2"'}}{{/data-list-check}}
-    {{#> data-list-icon data-list-icon--type="box"}}{{/data-list-icon}}
+    {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
     {{#> data-list-cell}}
-      <div id="ex-item2">Primary content</div>
+      <div id="ex-item2">Secondary content</div>
     {{/data-list-cell}}
     {{#> data-list-cell}}
       <span>Lorem ipsum dolor sit amet.</span>
     {{/data-list-cell}}
     {{#> data-list-action id="dropdown-kebab-right-action-4"}}{{/data-list-action}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Primary Content Details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Secondary Content Details"'}}
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
     {{/data-list-expandable-content}}
   {{/data-list-item}}

--- a/src/patternfly/components/DataList/examples/data-list-expandable-example.hbs
+++ b/src/patternfly/components/DataList/examples/data-list-expandable-example.hbs
@@ -18,6 +18,7 @@
   {{#> data-list-item data-list-item--attribute='aria-labelledby="ex-item2"'}}
     {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle2 ex-item2" id="ex-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="content-2"'}}{{/data-list-toggle}}
     {{#> data-list-check checkbox--attribute='name="ex-check2" aria-labelledby="ex-item2"'}}{{/data-list-check}}
+    {{#> data-list-icon data-list-icon--type="box"}}{{/data-list-icon}}
     {{#> data-list-cell}}
       <div id="ex-item2">Primary content</div>
     {{/data-list-cell}}


### PR DESCRIPTION
Closes #1389 

Adds a class called `.pf-c-data-list__icon` which styles an icon similar to a checkbox in the data table. Added icon the expandable table example - but it would be good to clarify which examples should use this icon/if any.