### PR TITLE
fix(table): update compact table check box

### DIFF
--- a/src/patternfly/components/Table/examples/table-compact-example.hbs
+++ b/src/patternfly/components/Table/examples/table-compact-example.hbs
@@ -19,7 +19,7 @@
       {{#> table-th table-th--attribute='scope="col"'}}
         Numbers
       {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"' table-th--modifier="pf-m-center"}}
+      {{#> table-th table-th--attribute='scope="col"'}}
         Icons
       {{/table-th}}
       {{#> table-th}}{{/table-th}}
@@ -32,8 +32,8 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow1" aria-labelledby="name1">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor Name"}}
-        <span id="name1">Andres Galant</span>
+      {{#> table-th table-th--data-label="Contributor"}}
+        <span id="name1">Sam Jones</span>
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         CSS Guru
@@ -41,17 +41,17 @@
       {{#> table-td table-td--data-label="Location"}}
         Not too sure
       {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
+      {{#> table-td table-td--data-label="Last Seen"}}
         May 9, 2018
       {{/table-td}}
-      {{#> table-td table-td--data-label="Last Commit"}}
+      {{#> table-td table-td--data-label="Numbers"}}
         0556
       {{/table-td}}
-      {{#> table-td table-td--data-label="Icon" table-td--modifier="pf-m-center"}}
+      {{#> table-td table-td--data-label="Icon" table-td--icon="true"}}
         <i class="fas fa-check"></i>
       {{/table-td}}
       {{#> table-td table-td--data-label="Action"}}
-        <a href="#">Link 1</a>
+        <a href="#">Action Link</a>
       {{/table-td}}
       {{#> table-td table-td--action="true"}}
         {{#> dropdown id="dropdown-kebab-right-aligned-8" dropdown--IsActionMenu="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
@@ -63,8 +63,8 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow2" aria-labelledby="name2">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor Name"}}
-        <span id="name2">Jenny Haines</span>
+      {{#> table-th table-th--data-label="Contributor"}}
+        <span id="name2">Amy Miller</span>
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         Visual Design
@@ -72,17 +72,17 @@
       {{#> table-td table-td--data-label="Location"}}
         Raleigh
       {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
+      {{#> table-td table-td--data-label="Last Seen"}}
         May 9, 2018
       {{/table-td}}
-      {{#> table-td table-td--data-label="Last Commit"}}
+      {{#> table-td table-td--data-label="Numbers"}}
         9492
       {{/table-td}}
-      {{#> table-td table-td--data-label="Icon" table-td--modifier="pf-m-center"}}
+      {{#> table-td table-td--data-label="Icon" table-td--icon="true"}}
         <i class="fas fa-check"></i>
       {{/table-td}}
       {{#> table-td table-td--data-label="Action"}}
-        <a href="#">Link 2</a>
+        <a href="#">Action Link</a>
       {{/table-td}}
       {{#> table-td table-td--action="true"}}
         {{#> dropdown id="dropdown-example-right-aligned-9" dropdown--IsActionMenu="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
@@ -94,8 +94,8 @@
       {{#> table-td table-td--check="true"}}
         <input type="checkbox" name="checkrow3" aria-labelledby="name3">
       {{/table-td}}
-      {{#> table-th table-th--data-label="Contributor Name"}}
-        <span id="name3">Kyle Baker</span>
+      {{#> table-th table-th--data-label="Contributor"}}
+        <span id="name3">Steve Wilson</span>
       {{/table-th}}
       {{#> table-td table-td--data-label="Position"}}
         Visual Design Lead
@@ -103,17 +103,17 @@
       {{#> table-td table-td--data-label="Location"}}
         Westford
       {{/table-td}}
-      {{#> table-td table-td--data-label="Workspaces"}}
+      {{#> table-td table-td--data-label="Last Seen"}}
         May 9, 2018
       {{/table-td}}
-      {{#> table-td table-td--data-label="Last Commit"}}
+      {{#> table-td table-td--data-label="Numbers"}}
         9929
       {{/table-td}}
-      {{#> table-td table-td--data-label="Icon" table-td--modifier="pf-m-center"}}
+      {{#> table-td table-td--data-label="Icon" table-td--icon="true"}}
         <i class="fas fa-check"></i>
       {{/table-td}}
       {{#> table-td table-td--data-label="Action"}}
-        <a href="#">Link 3</a>
+        <a href="#">Action Link</a>
       {{/table-td}}
       {{#> table-td table-td--action="true"}}
         {{#> dropdown id="dropdown-kebab-right-aligned-10" dropdown--IsActionMenu="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}

--- a/src/patternfly/components/Table/examples/table-compact-example.hbs
+++ b/src/patternfly/components/Table/examples/table-compact-example.hbs
@@ -19,7 +19,7 @@
       {{#> table-th table-th--attribute='scope="col"'}}
         Numbers
       {{/table-th}}
-      {{#> table-th table-th--attribute='scope="col"'}}
+      {{#> table-th table-th--attribute='scope="col"' table-th--icon="true"}}
         Icons
       {{/table-th}}
       {{#> table-th}}{{/table-th}}

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -150,6 +150,10 @@ $pf-c-table-xs-breakpoint: 380px;
     }
   }
 
+  .pf-c-table__icon > * {
+    text-align: left;
+  }
+
   // Standard td, in standard row (non-expandable)
   // exclude specifically styled tds, as they are placed explicitly within grid
   // :not(.pf-c-table__toggle):not(.pf-c-table__check):not(.pf-c-table__action):not(.pf-c-table__sort)

--- a/src/patternfly/components/Table/table-td.hbs
+++ b/src/patternfly/components/Table/table-td.hbs
@@ -1,6 +1,7 @@
 <td{{#if table-td--toggle}} class="pf-c-table__toggle"
     {{else if table-td--check}} class="pf-c-table__check"
     {{else if table-td--action}} class="pf-c-table__action"
+    {{else if table-td--icon}} class="pf-c-table__icon"
     {{else if table-td--compound-expansion-toggle}} class="pf-c-table__compound-expansion-toggle {{table-td--modifier}}"
     {{else if table-td--action}} class="pf-c-table__action"
     {{else if table-td--modifier}} class="{{table-td--modifier}}"

--- a/src/patternfly/components/Table/table-th.hbs
+++ b/src/patternfly/components/Table/table-th.hbs
@@ -1,6 +1,7 @@
 <th{{#if table-th--toggle}} class="pf-c-table__toggle {{table-th--modifier}}"
     {{else if table-th--check}} class="pf-c-table__check {{table-th--modifier}}"
     {{else if table-th--action}} class="pf-c-table__action {{table-th--modifier}}"
+    {{else if table-th--icon}} class="pf-c-table__icon {{table-th--modifier}}"
     {{else if table-th--sortable}} class="pf-c-table__sort {{#if table-th--selected}} pf-m-selected{{/if}} {{table-th--modifier}}"
     {{else if table-th--compound-expansion-toggle}} class="pf-c-table__compound-expansion-toggle {{table-th--modifier}}"
     {{else if table-th--modifier}} class="{{table-th--modifier}}"

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -459,6 +459,10 @@
     vertical-align: middle;
   }
 
+  .pf-c-table__icon {
+    text-align: center;
+  }
+
   // nested tables
   .pf-c-table & tr > * {
     &:first-child {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -148,6 +148,7 @@
     padding: var(--pf-c-table-cell--PaddingTop) var(--pf-c-table-cell--PaddingRight) var(--pf-c-table-cell--PaddingBottom) var(--pf-c-table-cell--PaddingLeft);
     font-size: var(--pf-c-table-cell--FontSize);
     font-weight: var(--pf-c-table--FontWeight);
+    vertical-align: baseline;
 
     // First child padding left
     &:first-child {
@@ -453,10 +454,6 @@
     --pf-c-table-cell--PaddingTop: var(--pf-c-table__action--PaddingTop);
     --pf-c-table-cell--PaddingBottom: var(--pf-c-table__action--PaddingBottom);
     --pf-c-table-cell--PaddingLeft: var(--pf-c-table__action--PaddingLeft);
-  }
-
-  .pf-c-table__check {
-    vertical-align: middle;
   }
 
   .pf-c-table__icon {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -455,6 +455,10 @@
     --pf-c-table-cell--PaddingLeft: var(--pf-c-table__action--PaddingLeft);
   }
 
+  .pf-c-table__check {
+    vertical-align: middle;
+  }
+
   // nested tables
   .pf-c-table & tr > * {
     &:first-child {


### PR DESCRIPTION
Fix #1450 

`.pf-c-table__check` is currently set to `vertical-align: top`. This works for "table with checkbox and actions" / "table expandable" because the checkbox lines up with the expandable arrow and the table columns are wider so it is less likely for the content to wrap more than 2 lines. However in the "compact table" the columns are so narrow that content will wrap over multiple lines - the checkbox set to top alignment looks visually off - note the image in #1450. Setting `.pf-c-table__check` to vertical-align: middle` for the compact table solves this problem. 




