### PR TITLE
fix(switch): remove label from css

### DIFF
--- a/src/patternfly/components/Switch/docs/code.md
+++ b/src/patternfly/components/Switch/docs/code.md
@@ -13,6 +13,7 @@ Use checkbox if your user has to perform additional steps for changes to become 
 | `aria-labelledby="..."` or `aria-label="..."` | `.pf-c-switch__input` | Indicates the action triggered by the switch. If an additional text label is included with the switch besides `.pf-c-switch__label.pf-m-on`, then `aria-labelledby` can reference the `id` of this text, or this text can be used as the value for `aria-label`. If the text included for `.pf-c-switch__label.pf-m-on` provides additional meaning to the primary label that's referenced, then it can also be represented as part of the `aria-labelledby` or `aria-label` attribute. **Required** |
 | `for` | `<label>` | Each `<label>` must have a `for` attribute that matches its input id. **Required** |
 | `id` | `<input type="checkbox">` | Each `<input>` must have an `id` attribute that matches its label's `for` value. **Required** |
+| `id` | `.pf-c-switch__label` | Each `.pf-c-switch__label` must have an `id` attribute that matches the `aria-labelledby` on `.pf-c-switch__input`. |
 | `checked` | `.pf-c-switch__input` |  Indicates that the input is checked |
 | `disabled` | `.pf-c-switch__input` |  Indicates that the input is disabled |
 | `aria-hidden="true"` | `.pf-c-switch__label` | Hides the text from the screen reader. |

--- a/src/patternfly/components/Switch/docs/code.md
+++ b/src/patternfly/components/Switch/docs/code.md
@@ -15,7 +15,6 @@ Use checkbox if your user has to perform additional steps for changes to become 
 | `id` | `<input type="checkbox">` | Each `<input>` must have an `id` attribute that matches its label's `for` value. **Required** |
 | `checked` | `.pf-c-switch__input` |  Indicates that the input is checked |
 | `disabled` | `.pf-c-switch__input` |  Indicates that the input is disabled |
-| `role=presentational` | `.pf-c-switch__label` | Hides the generated content from the screen reader. **Required** |
 | `aria-hidden="true"` | `.pf-c-switch__label` | Hides the text from the screen reader. |
 
 ## Usage
@@ -27,3 +26,5 @@ Use checkbox if your user has to perform additional steps for changes to become 
 | `.pf-c-switch__toggle` | `<span>` |  Initiates the toggle inside the switch. **required**  |
 | `.pf-c-switch__toggle-icon` | `<i>` | Initiates an icon inside the switch toggle. **required when the switch is used without a label** |
 | `.pf-c-switch__label` | `<span>` |  Initiates a label inside the switch. |
+| `.pf-m-on` | `.pf-c-switch__label` | Modifies the switch label to display the on message. |
+| `.pf-m-off` | `.pf-c-switch__label` | Modifies the switch label to display the off message. |

--- a/src/patternfly/components/Switch/docs/code.md
+++ b/src/patternfly/components/Switch/docs/code.md
@@ -10,7 +10,7 @@ Use checkbox if your user has to perform additional steps for changes to become 
 
 | Attribute | Applied To | Outcome |
 | -- | -- | -- |
-| `aria-labelledby="..."` | `.pf-c-switch__input` |  Indicates the action triggered by the switch. **required**  |
+| `aria-labelledby="..."` or `aria-label="..."` | `.pf-c-switch__input` | Indicates the action triggered by the switch. If an additional text label is included with the switch besides `.pf-c-switch__label.pf-m-on`, then `aria-labelledby` can reference the `id` of this text, or this text can be used as the value for `aria-label`. If the text included for `.pf-c-switch__label.pf-m-on` provides additional meaning to the primary label that's referenced, then it can also be represented as part of the `aria-labelledby` or `aria-label` attribute. **Required** |
 | `for` | `<label>` | Each `<label>` must have a `for` attribute that matches its input id. **Required** |
 | `id` | `<input type="checkbox">` | Each `<input>` must have an `id` attribute that matches its label's `for` value. **Required** |
 | `checked` | `.pf-c-switch__input` |  Indicates that the input is checked |

--- a/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
@@ -1,5 +1,5 @@
 {{#> switch switch--attribute='for="switch-disabled-1"'}}
-  {{#> switch-input id="switch-disabled-1" switch-input--attribute='name="switchExample5" disabled checked'}}{{/switch-input}}
+  {{#> switch-input id="switch-disabled-1" aria-labelledby="switch-disabled-1-on" switch-input--attribute='name="switchExample5" disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
   {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
@@ -7,7 +7,7 @@
 <br/>
 <br/>
 {{#> switch switch--attribute='for="switch-disabled-2"'}}
-  {{#> switch-input id="switch-disabled-2" switch-input--attribute='name="switchExample6" disabled'}}{{/switch-input}}
+  {{#> switch-input id="switch-disabled-2" aria-labelledby="switch-disabled-2-off" switch-input--attribute='name="switchExample6" disabled'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
   {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}

--- a/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
@@ -1,12 +1,14 @@
 {{#> switch switch--attribute='for="on-disabled"'}}
   {{#> switch-input id="on-disabled" switch-input--attribute='name="switchExample1" disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--attribute='aria-hidden="true"'}}{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
 {{#> switch switch--attribute='for="off-disabled"'}}
   {{#> switch-input id="off-disabled" switch-input--attribute='name="switchExample2" disabled'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--attribute='aria-hidden="true"'}}{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}

--- a/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
@@ -1,14 +1,14 @@
 {{#> switch switch--attribute='for="switch-disabled-1"'}}
   {{#> switch-input id="switch-disabled-1" aria-labelledby="switch-disabled-1-on" switch-input--attribute='name="switchExample5" disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
-  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
+  {{#> switch-label id="switch-disabled-1-on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label id="switch-disabled-1-off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
 {{#> switch switch--attribute='for="switch-disabled-2"'}}
   {{#> switch-input id="switch-disabled-2" aria-labelledby="switch-disabled-2-off" switch-input--attribute='name="switchExample6" disabled'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
-  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
+  {{#> switch-label id="switch-disabled-2-on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label id="switch-disabled-2-off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}

--- a/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-disabled-example.hbs
@@ -1,13 +1,13 @@
-{{#> switch switch--attribute='for="on-disabled"'}}
-  {{#> switch-input id="on-disabled" switch-input--attribute='name="switchExample1" disabled checked'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-disabled-1"'}}
+  {{#> switch-input id="switch-disabled-1" switch-input--attribute='name="switchExample5" disabled checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
   {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
-{{#> switch switch--attribute='for="off-disabled"'}}
-  {{#> switch-input id="off-disabled" switch-input--attribute='name="switchExample2" disabled'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-disabled-2"'}}
+  {{#> switch-input id="switch-disabled-2" switch-input--attribute='name="switchExample6" disabled'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
   {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}

--- a/src/patternfly/components/Switch/examples/switch-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-example.hbs
@@ -1,14 +1,14 @@
-{{#> switch switch--attribute='for="on"'}}
-  {{#> switch-input id="on" switch-input--attribute='name="switchExample3" checked'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-label-1"'}}
+  {{#> switch-input id="switch-label-1" aria-labelledby="switch is on" switch-input--attribute='name="switchExample1" checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
-  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
+  {{#> switch-label id="on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label id="off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
-{{#> switch switch--attribute='for="off"'}}
-  {{#> switch-input id="off" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-label-2"'}}
+  {{#> switch-input id="switch-label-2" aria-labelledby="switch is off" switch-input--attribute='name="switchExample2"'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
-  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
+  {{#> switch-label id="on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label id="off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}

--- a/src/patternfly/components/Switch/examples/switch-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-example.hbs
@@ -1,12 +1,14 @@
 {{#> switch switch--attribute='for="on"'}}
-  {{#> switch-input id="on" switch-input--attribute='name="switchExample2" checked'}}{{/switch-input}}
+  {{#> switch-input id="on" switch-input--attribute='name="switchExample3" checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--attribute='aria-hidden="true"'}}{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
 {{#> switch switch--attribute='for="off"'}}
   {{#> switch-input id="off" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label switch-label--attribute='aria-hidden="true"'}}{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}

--- a/src/patternfly/components/Switch/examples/switch-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-example.hbs
@@ -1,13 +1,13 @@
-{{#> switch switch--attribute='for="switch-label-1"'}}
-  {{#> switch-input id="switch-label-1" aria-labelledby="switch is on" switch-input--attribute='name="switchExample1" checked'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-with-label-1"'}}
+  {{#> switch-input id="switch-with-label-1" aria-labelledby="switch-with-label-1-on" switch-input--attribute='name="switchExample1" checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
   {{#> switch-label id="on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label id="off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
-{{#> switch switch--attribute='for="switch-label-2"'}}
-  {{#> switch-input id="switch-label-2" aria-labelledby="switch is off" switch-input--attribute='name="switchExample2"'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-with-label-2"'}}
+  {{#> switch-input id="switch-with-label-2" aria-labelledby="switch-with-label-2-off" switch-input--attribute='name="switchExample2"'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
   {{#> switch-label id="on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
   {{#> switch-label id="off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}

--- a/src/patternfly/components/Switch/examples/switch-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-example.hbs
@@ -1,14 +1,14 @@
 {{#> switch switch--attribute='for="switch-with-label-1"'}}
   {{#> switch-input id="switch-with-label-1" aria-labelledby="switch-with-label-1-on" switch-input--attribute='name="switchExample1" checked'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label id="on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
-  {{#> switch-label id="off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
+  {{#> switch-label id="switch-with-label-1-on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label id="switch-with-label-1-off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}
 <br/>
 <br/>
 {{#> switch switch--attribute='for="switch-with-label-2"'}}
   {{#> switch-input id="switch-with-label-2" aria-labelledby="switch-with-label-2-off" switch-input--attribute='name="switchExample2"'}}{{/switch-input}}
   {{#> switch-toggle}}{{/switch-toggle}}
-  {{#> switch-label id="on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
-  {{#> switch-label id="off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
+  {{#> switch-label id="switch-with-label-2-on" switch-label--modifier="pf-m-on" switch-label--attribute='aria-hidden="true"'}}Message when on{{/switch-label}}
+  {{#> switch-label id="switch-with-label-2-off" switch-label--modifier="pf-m-off" switch-label--attribute='aria-hidden="true"'}}Message when off{{/switch-label}}
 {{/switch}}

--- a/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
@@ -1,13 +1,13 @@
 
-{{#> switch switch--attribute='for="on-no-label"'}}
-  {{#> switch-input id="on-no-label" switch-input--attribute='name="switchExample5" checked'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-icon-1"'}}
+  {{#> switch-input id="switch-icon-1" switch-input--attribute='name="switchExample3" checked'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}
 {{/switch}}
 
-{{#> switch switch--attribute='for="off-no-label"'}}
-  {{#> switch-input id="off-no-label" switch-input--attribute='name="switchExample6"'}}{{/switch-input}}
+{{#> switch switch--attribute='for="switch-icon-2"'}}
+  {{#> switch-input id="switch-icon-2" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}

--- a/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
@@ -1,13 +1,13 @@
 
 {{#> switch switch--attribute='for="switch-with-icon-1"'}}
-  {{#> switch-input id="switch-icon-1" switch-input--attribute='name="switchExample3" checked'}}{{/switch-input}}
+  {{#> switch-input id="switch-with-icon-1" switch-input--attribute='name="switchExample3" checked'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}
 {{/switch}}
 
 {{#> switch switch--attribute='for="switch-with-icon-2"'}}
-  {{#> switch-input id="switch-icon-2" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
+  {{#> switch-input id="switch-with-icon-2" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}

--- a/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
@@ -1,12 +1,12 @@
 
-{{#> switch switch--attribute='for="switch-icon-1"'}}
+{{#> switch switch--attribute='for="switch-with-icon-1"'}}
   {{#> switch-input id="switch-icon-1" switch-input--attribute='name="switchExample3" checked'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}
 {{/switch}}
 
-{{#> switch switch--attribute='for="switch-icon-2"'}}
+{{#> switch switch--attribute='for="switch-with-icon-2"'}}
   {{#> switch-input id="switch-icon-2" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
   {{#> switch-toggle}}
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}

--- a/src/patternfly/components/Switch/switch-input.hbs
+++ b/src/patternfly/components/Switch/switch-input.hbs
@@ -5,9 +5,5 @@
   {{#if switch-input--attribute}}
     {{{switch-input--attribute}}}
   {{/if}}
-  {{#if checked}}
-    {{{switch-label-on}}}
-  {{else}}
-    {{{switch-label-off}}}
-  {{/if}}
+  {{#if checked}} pf-m-checked{{/if}}
 >

--- a/src/patternfly/components/Switch/switch-input.hbs
+++ b/src/patternfly/components/Switch/switch-input.hbs
@@ -5,5 +5,4 @@
   {{#if switch-input--attribute}}
     {{{switch-input--attribute}}}
   {{/if}}
-  {{#if checked}} pf-m-checked{{/if}}
 >

--- a/src/patternfly/components/Switch/switch-input.hbs
+++ b/src/patternfly/components/Switch/switch-input.hbs
@@ -1,7 +1,19 @@
 <input class="pf-c-switch__input{{#if switch-input--modifier}} {{switch-input--modifier}}{{/if}}"
   type="checkbox"
-  id="{{id}}"
-  aria-labelledby="switch-is-{{id}}"
+  {{#if id}}
+    id="{{id}}"
+  {{/if}}
+  {{#if aria-labelledby}}
+    aria-labelledby="{{aria-labelledby}}"
+  {{/if}}
+  {{#if aria-labelledby}}
+  {{else}}
+    {{#if checked}}
+      aria-label="switch is on"
+    {{else}}
+      aria-label="switch is off"
+    {{/if}}
+  {{/if}}
   {{#if switch-input--attribute}}
     {{{switch-input--attribute}}}
   {{/if}}

--- a/src/patternfly/components/Switch/switch-label.hbs
+++ b/src/patternfly/components/Switch/switch-label.hbs
@@ -1,5 +1,5 @@
 <span class="pf-c-switch__label{{#if switch-label--modifier}} {{switch-label--modifier}}{{/if}}"
-  role="presentational"
+  id="{{id}}"
   {{#if switch-label--attribute}}
     {{{switch-label--attribute}}}
   {{/if}}

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -53,6 +53,12 @@
     &:checked {
       ~ .pf-c-switch__label {
         color: var(--pf-c-switch__input--checked__label--Color);
+
+        &:not(.pf-m-on):not(.pf-m-off) {
+          &::before {
+            content: "On";
+          }
+        }
       }
 
       ~ .pf-c-switch__toggle {
@@ -71,6 +77,12 @@
     &:not(:checked) {
       ~ .pf-c-switch__label {
         color: var(--pf-c-switch__input--not-checked__label--Color);
+
+        &:not(.pf-m-on):not(.pf-m-off) {
+          &::before {
+            content: "Off";
+          }
+        }
       }
 
       ~ .pf-c-switch__toggle {

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -53,10 +53,6 @@
     &:checked {
       ~ .pf-c-switch__label {
         color: var(--pf-c-switch__input--checked__label--Color);
-
-        &::before {
-          content: "On";
-        }
       }
 
       ~ .pf-c-switch__toggle {
@@ -66,15 +62,15 @@
           transform: var(--pf-c-switch__input--checked__toggle--before--Transform);
         }
       }
+
+      ~ .pf-m-off {
+        display: none;
+      }
     }
 
     &:not(:checked) {
       ~ .pf-c-switch__label {
         color: var(--pf-c-switch__input--not-checked__label--Color);
-
-        &::before {
-          content: "Off";
-        }
       }
 
       ~ .pf-c-switch__toggle {
@@ -82,6 +78,10 @@
           display: none;
           visibility: hidden;
         }
+      }
+
+      ~ .pf-m-on {
+        display: none;
       }
     }
 


### PR DESCRIPTION
Fix #1452 

Fixes what we discussed in CSS Army. The switch label is not written in the CSS anymore, it is in the html. I feel like there are many variations on how to do this, so if you have any suggestions let me know :)