### PR TITLE
fix(a11y): fixes duplicate ids by moving SVG filter to scss

### DIFF
--- a/src/patternfly/components/BackgroundImage/background-image.hbs
+++ b/src/patternfly/components/BackgroundImage/background-image.hbs
@@ -3,20 +3,5 @@
     {{{background-image--attribute}}}
   {{/if}}>
   {{> @partial-block}}
-  <svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0">
-  <filter id="image_overlay" width="">
-    <feColorMatrix type="matrix"
-      values="1 0 0 0 0
-              1 0 0 0 0
-              1 0 0 0 0
-              0 0 0 1 0" />
-    
-    <feComponentTransfer color-interpolation-filters="sRGB" result="duotone">
-      <feFuncR type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncR>
-      <feFuncG type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncG>
-      <feFuncB type="table" tableValues="0.086274509803922 0.43921568627451"></feFuncB>
-      <feFuncA type="table" tableValues="0 1"></feFuncA>
-    </feComponentTransfer> 
-  </filter>
-</svg>
+
 </div>

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -5,7 +5,14 @@
   --pf-c-background-image--BackgroundImage--sm: url("#{$pf-global--image-path}/pfbg_768.jpg");
   --pf-c-background-image--BackgroundImage--sm-2x: url("#{$pf-global--image-path}/pfbg_768@2x.jpg");
   --pf-c-background-image--BackgroundImage--lg: url("#{$pf-global--image-path}/pfbg_2000.jpg");
-  --pf-c-background-image--Filter: url("#image_overlay");
+
+  // This moves the background filter SVG to the scss.
+  // However, in Safari, although the filter shows as there, it is not being applied.
+  // This works in Chrome and FF.
+  --pf-c-background-image--Filter:
+    url(
+      'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0"><filter id="image_overlay" width=""><feColorMatrix type="matrix" values="1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0 0 0 1 0"/><feComponentTransfer color-interpolation-filters="sRGB" result="duotone"><feFuncR type="table" tableValues="0.086274509803922 0.43921568627451"/><feFuncG type="table" tableValues="0.086274509803922 0.43921568627451"/><feFuncB type="table" tableValues="0.086274509803922 0.43921568627451"/><feFuncA type="table" tableValues="0 1"/></feComponentTransfer></filter></svg>#image_overlay'
+    );
 
   &::before {
     position: fixed;


### PR DESCRIPTION
Having the background filter SVG inline in the HTML causes duplicate IDs when the A11y checker is run. This PR moves the SVG out of the HTML and into the SCSS for the background image component. 

However, this fix works in Chrome and Firefox, but not in Safari. In Safari, the filter is correctly assigned to the variable, the variable is showing up for the filter property, however, the SVG is unaffected. In the inspector, everything appears to be properly escaped.

Turning the SVG to Base64 did not work for me at all, so I may have been doing it wrong. However, according to CSS-Tricks that should not be necessary.

Some relevant links:
https://stackoverflow.com/questions/10768451/inline-svg-in-css
https://stackoverflow.com/questions/13925736/inline-svg-filter-in-css
https://github.com/Fyrd/caniuse/issues/3803
https://benfrain.com/applying-multiple-svg-filter-effects-defined-in-css-or-html/
https://css-tricks.com/probably-dont-base64-svg/

Useful tools:
SVG minifier: https://jakearchibald.github.io/svgomg/
https://www.mobilefish.com/services/base64/base64.php

Would fix #1912  if it worked in Safari.