### PR TITLE
fix(multiple components): add visibility:hidden where there is display: none

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -238,15 +238,16 @@
 
 // Hero
 .pf-c-about-modal-box__hero {
-  display: none; // Don't display the hero at the narrowest breakpoint
+  display: block;
+  background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: var(--pf-c-about-modal-box__hero--sm--BackgroundPosition);
+  background-size: var(--pf-c-about-modal-box__hero--sm--BackgroundSize);
+  grid-area: hero;
 
-  @media only screen and (min-width: $pf-global--breakpoint--sm) {
-    display: block;
-    background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-position: var(--pf-c-about-modal-box__hero--sm--BackgroundPosition);
-    background-size: var(--pf-c-about-modal-box__hero--sm--BackgroundSize);
-    grid-area: hero;
+  @media only screen and (max-width: $pf-global--breakpoint--sm) {
+    display: none; // Don't display the hero at the narrowest breakpoint
+    visibility: hidden;
   }
 }

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -238,16 +238,17 @@
 
 // Hero
 .pf-c-about-modal-box__hero {
-  display: block;
-  background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-position: var(--pf-c-about-modal-box__hero--sm--BackgroundPosition);
-  background-size: var(--pf-c-about-modal-box__hero--sm--BackgroundSize);
-  grid-area: hero;
+  display: none; // Don't display the hero at the narrowest breakpoint
+  visibility: hidden;
 
-  @media only screen and (max-width: $pf-global--breakpoint--sm) {
-    display: none; // Don't display the hero at the narrowest breakpoint
-    visibility: hidden;
+  @media only screen and (min-width: $pf-global--breakpoint--sm) {
+    display: block;
+    visibility: visible;
+    background-image: var(--pf-c-about-modal-box__hero--sm--BackgroundImage);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: var(--pf-c-about-modal-box__hero--sm--BackgroundPosition);
+    background-size: var(--pf-c-about-modal-box__hero--sm--BackgroundSize);
+    grid-area: hero;
   }
 }

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -149,6 +149,7 @@
 
   &.pf-m-inactive {
     display: none;
+    visibility: hidden;
   }
 
   &.pf-m-hidden {

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -176,6 +176,7 @@
   // Hide scrollbars
   &::-webkit-scrollbar {
     display: none;
+    visibility: hidden;
   }
 
   // Disable underline
@@ -522,6 +523,7 @@
   // Hide scrollbars
   &::-webkit-scrollbar {
     display: none;
+    visibility: hidden;
   }
 
   // Expanded list item

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -228,6 +228,7 @@
 
     @media screen and (min-width: $pf-global--breakpoint--lg) {
       display: none;
+      visibility: hidden;
     }
   }
 

--- a/src/patternfly/components/Progress/progress.scss
+++ b/src/patternfly/components/Progress/progress.scss
@@ -85,6 +85,7 @@
 
     .pf-c-progress__description {
       display: none;
+      visibility: hidden;
     }
 
     .pf-c-progress__bar {

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -80,6 +80,7 @@
       ~ .pf-c-switch__toggle {
         .pf-c-switch__toggle-icon {
           display: none;
+          visibility: hidden;
         }
       }
     }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -80,6 +80,7 @@ $pf-c-table-xs-breakpoint: 380px;
   // Thead
   thead {
     display: none;
+    visibility: hidden;
   }
 
   // Tbody
@@ -299,10 +300,12 @@ $pf-c-table-xs-breakpoint: 380px;
     td:first-child::before {
       // Border treatment
       display: none;
+      visibility: hidden;
     }
 
     &:not(.pf-m-expanded) {
       display: none;
+      visibility: hidden;
     }
   }
 

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -390,6 +390,7 @@
 
   &:not(.pf-m-expanded) {
     display: none;
+    visibility: hidden;
   }
 }
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -76,6 +76,7 @@
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     display: none;
+    visibility: hidden;
   }
 }
 
@@ -88,9 +89,11 @@
 
   @media screen and (max-width: $pf-global--breakpoint--lg) {
     display: none;
+    visibility: hidden;
 
     &.pf-m-expanded {
       display: flex;
+      visibility: visible;
     }
   }
 
@@ -117,10 +120,11 @@
 }
 
 .pf-c-toolbar__action-group {
-  display: none;
+  display: flex;
 
-  @media screen and (min-width: $pf-global--breakpoint--xl) {
-    display: flex;
+  @media screen and (max-width: $pf-global--breakpoint--xl) {
+    display: none;
+    visibility: hidden;
   }
 
   > * + * {
@@ -148,9 +152,11 @@
   padding-left: 0;
   margin-top: var(--pf-c-toolbar__filter-list--MarginTop);
   margin-left: 0;
+  visibility: hidden;
 
   &.pf-m-expanded {
     display: block;
+    visibility: visible;
   }
 }
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -120,11 +120,12 @@
 }
 
 .pf-c-toolbar__action-group {
-  display: flex;
+  display: none;
+  visibility: hidden;
 
-  @media screen and (max-width: $pf-global--breakpoint--xl) {
-    display: none;
-    visibility: hidden;
+  @media screen and (min-width: $pf-global--breakpoint--xl) {
+    display: flex;
+    visibility: visible;
   }
 
   > * + * {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -201,13 +201,14 @@
 }
 
 .pf-c-wizard__description {
-  display: block;
-  padding-top: var(--pf-c-wizard__description--PaddingTop);
-  color: var(--pf-c-wizard__description--Color);
+  display: none;
+  visibility: hidden;
 
-  @media screen and (max-width: $pf-global--breakpoint--lg) {
-    display: none;
-    visibility: hidden;
+  @media screen and (min-width: $pf-global--breakpoint--lg) {
+    display: block;
+    padding-top: var(--pf-c-wizard__description--PaddingTop);
+    color: var(--pf-c-wizard__description--Color);
+    visibility: visible;
   }
 }
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -202,12 +202,12 @@
 
 .pf-c-wizard__description {
   display: none;
+  padding-top: var(--pf-c-wizard__description--PaddingTop);
+  color: var(--pf-c-wizard__description--Color);
   visibility: hidden;
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
     display: block;
-    padding-top: var(--pf-c-wizard__description--PaddingTop);
-    color: var(--pf-c-wizard__description--Color);
     visibility: visible;
   }
 }

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -201,12 +201,13 @@
 }
 
 .pf-c-wizard__description {
-  display: none;
+  display: block;
   padding-top: var(--pf-c-wizard__description--PaddingTop);
   color: var(--pf-c-wizard__description--Color);
 
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    display: block;
+  @media screen and (max-width: $pf-global--breakpoint--lg) {
+    display: none;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
Fix #1421 but also addresses every component where this applies:
- about-modal
- form
- nav
- page
- pagination --- addressed this in #1482 
- progress
- switch
- table
- toolbar
- wizard

Note: `visibility: hidden` has to be set second in the case of breakpoints, but for modifiers use `visibility: visible` to make the element visible again. 