### PR TITLE
fix(table): refactor table row borders, workspace styles

### DIFF
--- a/src/patternfly/components/Table/examples/table-simple-example.hbs
+++ b/src/patternfly/components/Table/examples/table-simple-example.hbs
@@ -26,17 +26,17 @@
       {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         10
-      {{/table-td}}      
+      {{/table-td}}
       {{#> table-td table-td--data-label="Pull Requests"}}
         25
-      {{/table-td}}  
+      {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
         5
-      {{/table-td}}  
+      {{/table-td}}
       {{#> table-td table-td--data-label="Last Commit"}}
         2 days ago
-      {{/table-td}}  
-    {{/table-tr}}    
+      {{/table-td}}
+    {{/table-tr}}
 
     {{#> table-tr}}
       {{#> table-td table-td--data-label="Repository Name"}}
@@ -44,16 +44,34 @@
       {{/table-td}}
       {{#> table-td table-td--data-label="Branches"}}
         10
-      {{/table-td}}      
+      {{/table-td}}
       {{#> table-td table-td--data-label="Pull Requests"}}
         25
-      {{/table-td}}  
+      {{/table-td}}
       {{#> table-td table-td--data-label="Workspaces"}}
         5
-      {{/table-td}}  
+      {{/table-td}}
       {{#> table-td table-td--data-label="Last Commit"}}
         2 days ago
-      {{/table-td}}  
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository Name"}}
+        Repository 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
     {{/table-tr}}
   {{/table-tbody}}
 {{/table}}

--- a/src/patternfly/components/Table/examples/table-simple-with-checkboxes-example.hbs
+++ b/src/patternfly/components/Table/examples/table-simple-with-checkboxes-example.hbs
@@ -74,5 +74,31 @@
         {{/dropdown}}
       {{/table-td}}
     {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--check="true"}}
+        <input type="checkbox" name="checkrow3" aria-labelledby="{{concat table--id '-node3'}}">
+      {{/table-td}}
+      {{#> table-th table-th--data-label="Repository Name"}}
+        <div id="{{table--id}}-node3">Node 3</div>
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
+      {{#> table-td table-td--action="true"}}
+        {{#> dropdown id="dropdown-kebab-right-aligned-3" dropdown--IsActionMenu="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+        {{/dropdown}}
+      {{/table-td}}
+    {{/table-tr}}
   {{/table-tbody}}
 {{/table}}

--- a/src/patternfly/components/Table/examples/table-sortable-example.hbs
+++ b/src/patternfly/components/Table/examples/table-sortable-example.hbs
@@ -55,5 +55,23 @@
         2 days ago
       {{/table-td}}
     {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="Repository Name"}}
+        Repository 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
   {{/table-tbody}}
 {{/table}}

--- a/src/patternfly/components/Table/examples/table-width-example.hbs
+++ b/src/patternfly/components/Table/examples/table-width-example.hbs
@@ -65,5 +65,27 @@
         2 days ago
       {{/table-td}}
     {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--check="true"}}
+        <input type="checkbox" name="checkrow2" aria-labelledby="width-node2">
+      {{/table-td}}
+      {{#> table-th table-th--data-label="Repository Name"}}
+        <div id="width-node2">Node 2</div>
+        <a href="#">siemur/test-space</a>
+      {{/table-th}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
   {{/table-tbody}}
 {{/table}}

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -104,7 +104,11 @@ $pf-c-table-xs-breakpoint: 380px;
 
   tbody.pf-m-expanded {
     tr:not(.pf-c-table__expandable-row) {
-      border-bottom: 0;
+      > * {
+        &::after {
+          border-bottom: 0;
+        }
+      }
     }
   }
 
@@ -124,7 +128,14 @@ $pf-c-table-xs-breakpoint: 380px;
 
     // Reset td padding
     & > * {
+      position: static;
       padding: var(--pf-c-table-cell--responsive--PaddingTop) var(--pf-c-table-cell--responsive--PaddingRight) var(--pf-c-table-cell--responsive--PaddingBottom) var(--pf-c-table-cell--responsive--PaddingLeft);
+
+      &:not(:last-child) {
+        &::after {
+          border: 0;
+        }
+      }
     }
 
     // remove padding from first th to align with kebab
@@ -202,7 +213,9 @@ $pf-c-table-xs-breakpoint: 380px;
     }
   }
 
-  .pf-c-table__compound-expansion-toggle {
+  td.pf-c-table__compound-expansion-toggle {
+    position: relative;
+
     // Compound expansion toggle
     // reset compound expansion toggle::before
     &::before {
@@ -215,11 +228,6 @@ $pf-c-table-xs-breakpoint: 380px;
       top: auto;
       right: 0;
       left: 0;
-    }
-
-    // add bottom border to expansion toggle::after
-    &.pf-m-expanded::after {
-      border-bottom: var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderColor);
     }
 
     // reset button padding

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -126,7 +126,17 @@
     // content wraps. for those special cases, there must be an explicit height set on tr and table cell
     // for button height: 100% to work
     height: 1px;
-    border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
+
+    > * {
+      &::after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        content: "";
+        border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
+      }
+    }
   }
 
   // undo default styling for each even child
@@ -284,10 +294,14 @@
 // using this method because the button may not always be full height of the parent cell if siblings wrap
 // ==================================================================
 .pf-c-table__compound-expansion-toggle {
-  position: relative;
+  @at-root .pf-c-table & {  // increase specificity
+    position: relative;
 
-  &.pf-m-expanded {
-    border-bottom: var(--pf-c-table__compound-expansion-toggle--BorderBottom--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderBottom--BorderColor);
+    &.pf-m-expanded {
+      &::after {
+        border-bottom: var(--pf-c-table__compound-expansion-toggle--BorderBottom--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderBottom--BorderColor);
+      }
+    }
   }
 
   &.pf-m-expanded,

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -39,23 +39,54 @@ html {
 
 .Example__documentation {
   margin: 2rem 0;
+}
 
-  .Example__documentation--text {
-    h1,
-    h2,
-    h3,
-    h4 {
-      margin-bottom: 1rem;
-      font-weight: 600;
+.Example__documentation--text,
+.Example__documentation,
+.Documentation__docsection {
+  h1,
+  h2,
+  h3,
+  h4 {
+    margin-bottom: 1rem;
+    font-weight: 600;
+  }
+
+  p {
+    margin-bottom: 1rem;
+  }
+
+  table {
+    margin-bottom: 3rem;
+  }
+
+  table {
+    width: 100%;
+    margin-bottom: 1rem;
+
+    td,
+    th,
+    tr {
+      padding: .5em;
+      vertical-align: top;
+      border: 1px solid #ccc;
     }
 
-    p {
-      margin-bottom: 1rem;
+    tr:nth-child(even) {
+      background: #f1f1f1;
     }
+  }
 
-    table {
-      margin-bottom: 3rem;
-    }
+  code {
+    padding: .25em .75em;
+    color: #004368;
+    white-space: nowrap;
+    background-color: #def3ff;
+    border-radius: .5em;
+  }
+
+  mark {
+    background-color: #ffe995;
   }
 }
 
@@ -210,12 +241,10 @@ html {
     margin-top: .5rem;
   }
 
-  table {
+  table:not(.pf-c-table) {
     width: 100%;
     margin-bottom: 1rem;
-  }
 
-  table:not(.pf-c-table) {
     &,
     td,
     th,
@@ -348,48 +377,6 @@ html {
   &__section {
     margin-bottom: 2rem;
   }
-
-  code {
-    padding: .25em .75em;
-    color: #004368;
-    white-space: nowrap;
-    background-color: #def3ff;
-    border-radius: .5em;
-  }
-
-  mark {
-    background-color: #ffe995;
-  }
-
-  table {
-    width: 100%;
-    margin-bottom: 1rem;
-  }
-
-  table:not(.pf-c-table) {
-    td,
-    th,
-    tr {
-      padding: .5em;
-      vertical-align: top;
-      border: 1px solid #ccc;
-    }
-  }
-
-  .pf-c-table {
-    margin-bottom: 0;
-
-    // td,
-    // th:not(.pf-c-table__sort) {
-    //   border: none;
-    // }
-
-    tr:nth-child(even) {
-      background-color: transparent;
-    }
-  }
-
-  tr:nth-child(even) { background: #f1f1f1; }
 
   &-container {
     &-tall {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1520

I couldn't get borders on `tr` or `td` to behave reliably, but a pseudo element seems to work everywhere. You'll need to test in Firefox on windows to verify the borders no longer disappear.