### PR TITLE
docs(readme): add pf3/pf4 compatibility css

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,16 @@ If you have any suggestions about ways that we can improve how we use this tool,
 
 [How do I use CSS variables to customize
 the library?](https://pf4.patternfly.org/guidelines#variables)
+
+### PatternFly 3 Compatibility
+
+Due to differences in how PatternFly 3 and PatternFly 4 CSS is written, there are cases where PatternFly 3 CSS may take precedence over PatternFly 4 CSS in an application that uses both systems. Below are some snippets that will help ensure PatternFly 4 components are displayed consistently.
+
+```
+.pf-c-dropdown__menu-item {
+  &:hover,
+  &:focus {
+    color: var(--pf-c-dropdown__menu-item--hover--Color);
+  }
+}
+```


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1567

@dgutride per our discussion, I added a blurb to the README for this. I think it's inevitable this will become a stylesheet, and I imagine anyone using PF3 and PF4 together will run into this issue and benefit from this CSS.

I was chatting with @seanforyou23 about it and he mentioned that this is really similar to https://github.com/patternfly/patternfly-next/wiki/IE11-Support#step-2-add-ie11-compatible-styling-overrides and we could host these in a common place. Just wanted to start the discussion about whether the README is the best spot for these, or if we want to explore other options.