### PR TITLE
feat(clipboardcopy): add ellipsis when text overflows in the input box

### DIFF
--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -90,6 +90,9 @@ $pf-c-form-control__select--ViewBox: "320" !default;
 
   &:not(textarea) {
     height: var(--pf-c-form-control--Height);
+
+    // truncate overflow text
+    text-overflow: ellipsis;
   }
 
   &[readonly] {


### PR DESCRIPTION

![Screenshot_2019-03-26 PatternFly 4(1)](https://user-images.githubusercontent.com/2453279/54994939-31ddfd80-4fce-11e9-8aab-4a6449f1002e.png)
![Screenshot_2019-03-26 PatternFly 4](https://user-images.githubusercontent.com/2453279/54994942-330f2a80-4fce-11e9-8b8c-f5d579f2f6bf.png)

closes #1618 
