### PR TITLE
refactor(page): do not limit brand img width, use grid in header

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -10,7 +10,6 @@
   --pf-c-page__header-brand--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-page__header-brand--md--PaddingRight: var(--pf-global--spacer--xl);
   --pf-c-page__header-brand--md--PaddingLeft: var(--pf-global--spacer--xl);
-  --pf-c-page__header-brand--md--FlexBasis: #{pf-size-prem(290px)};
 
   @media (min-width: $pf-global--breakpoint--md) {
     --pf-c-page__header-brand--PaddingLeft: var(--pf-c-page__header-brand--md--PaddingLeft);
@@ -32,7 +31,6 @@
 
   // Header brand link
   --pf-c-page__header-brand-link--c-brand--MaxHeight: #{pf-size-prem(60px)};
-  --pf-c-page__header-brand-link--md--MaxWidth: #{pf-size-prem(150px)};
 
   // Header nav
   --pf-c-page__header-nav--PaddingLeft: var(--pf-global--spacer--md);
@@ -145,26 +143,29 @@
 .pf-c-page__header {
   @include pf-t-dark; // force the container to follow the dark theme
 
-  grid-area: header;
   z-index: var(--pf-c-page__header--ZIndex);
-  display: flex;
-  flex-wrap: wrap;
+  grid-template-columns: auto auto;
+  display: grid;
+  grid-area: header;
   align-items: center;
-  max-width: 100%;
   min-height: var(--pf-c-page__header--MinHeight);
 
   > * {
     display: flex;
     align-items: center;
   }
+
+  @media screen and (min-width: $pf-global--breakpoint--lg) {
+    grid-template-columns: auto 1fr auto;
+  }
 }
 
 // Brand
 .pf-c-page__header-brand {
+  grid-column: 1 / 2;
   padding-left: var(--pf-c-page__header-brand--PaddingLeft);
 
   @media (min-width: $pf-global--breakpoint--md) {
-    flex: 0 0 var(--pf-c-page__header-brand--md--FlexBasis); // Hardcode header brand width based on design spec, must match --pf-c-nav--Width
     align-self: stretch;
     padding-right: var(--pf-c-page__header-brand--md--PaddingRight); // set padding right here to allow mobile view to accomodate tools
   }
@@ -178,10 +179,6 @@
 
   .pf-c-brand {
     max-height: var(--pf-c-page__header-brand-link--c-brand--MaxHeight); // Hardcode brand image max-height so it always aligns with everthing else.
-  }
-
-  @media screen and (max-width: $pf-global--breakpoint--md) {
-    max-width: var(--pf-c-page__header-brand-link--md--MaxWidth);
   }
 }
 
@@ -198,13 +195,15 @@
 
 // Header navigation
 .pf-c-page__header-nav {
-  order: 1;
-  width: 100vw; // set width value for container to scale properly
+  grid-column: 1 / -1;
+  grid-row: 2 / 3;
   padding-left: var(--pf-c-page__header-nav--PaddingLeft);
   overflow: hidden;
   background-color: var(--pf-c-page__header-nav--BackgroundColor);
 
   @media screen and (min-width: $pf-global--breakpoint--lg) {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
     flex: 1;
     align-self: flex-end;
     order: initial;
@@ -216,6 +215,7 @@
 
 // Header tools
 .pf-c-page__header-tools {
+  grid-column: 2 / 3;
   align-items: center;
   margin-top: var(--pf-c-page__header-tools--MarginTop);
   margin-right: var(--pf-c-page__header-tools--MarginRight);
@@ -253,6 +253,10 @@
 
   .pf-c-avatar {
     margin-left: var(--pf-c-page__header-tools--c-avatar--MarginLeft);
+  }
+
+  @media screen and (min-width: $pf-global--breakpoint--lg) {
+    grid-column: 3 / 4;
   }
 }
 

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -166,7 +166,6 @@
   padding-left: var(--pf-c-page__header-brand--PaddingLeft);
 
   @media (min-width: $pf-global--breakpoint--md) {
-    align-self: stretch;
     padding-right: var(--pf-c-page__header-brand--md--PaddingRight); // set padding right here to allow mobile view to accomodate tools
   }
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1678

I've been testing with different image sizes by using placehold.it as the src. For example `http://placehold.it/800x50` or `http://placehold.it/350x50`