### PR TITLE
refactor(card): make card header a lg title

### DIFF
--- a/src/patternfly/components/Card/card-header.hbs
+++ b/src/patternfly/components/Card/card-header.hbs
@@ -1,4 +1,4 @@
-<div class="pf-c-card__header{{#if card-header--modifier}} {{card-header--modifier}}{{/if}}"
+<div class="pf-c-card__header pf-c-title pf-m-lg{{#if card-header--modifier}} {{card-header--modifier}}{{/if}}"
   {{#if card-header--attribute}}
     {{{card-header--attribute}}}
   {{/if}}>


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1465

I don't think we're doing this where we combine BEM blocks/elements, but looks like it's a supported BEM technique called a mix.

http://getbem.com/faq/#can-i-create-global-modifier

https://en.bem.info/methodology/key-concepts/#mix