### PR TITLE
feat(table): add support to hide/show cells at breakpoints

### DIFF
--- a/src/patternfly/components/Table/docs/table-hidden-visible.md
+++ b/src/patternfly/components/Table/docs/table-hidden-visible.md
@@ -1,0 +1,5 @@
+### Usage
+| Class | Applied To | Outcome |
+| -- | -- | -- |
+| `.pf-m-hidden{-on-[breakpoint]}` | `.pf-c-table tr > *` | Hides a table cell at a given breakpoint, or hides it at all breakpoints with `.pf-m-hidden`. **Note: Needs to apply to all cells in the column you want to hide.** |
+| `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-table tr > *` | Shows a table cell at a given breakpoint. |

--- a/src/patternfly/components/Table/examples/index.js
+++ b/src/patternfly/components/Table/examples/index.js
@@ -10,6 +10,7 @@ import tableCompactNoBorderRowsExampleRaw from '!raw!./table-compact-no-border-r
 import tableCompactExpandableExampleRaw from '!raw!./table-compact-expandable-example.hbs';
 import tableWidthExampleRaw from '!raw!./table-width-example.hbs';
 import tableCompoundExpansionExampleRaw from '!raw!./table-compound-expansion-example.hbs';
+import tableHiddenVisibleExampleRaw from '!raw!./table-hidden-visible-example.hbs';
 
 import TableSimpleExample from './table-simple-example.hbs';
 import tableSimpleDoc from '../docs/table-simple.md';
@@ -37,6 +38,9 @@ import tableWidthDoc from '../docs/table-width.md';
 import TableCompoundExpansionExample from './table-compound-expansion-example.hbs';
 import tableCompoundExpansionDoc from '../docs/table-compound-expansion.md';
 
+import TableHiddenVisibleExample from './table-hidden-visible-example.hbs';
+import tableHiddenVisibleDoc from '../docs/table-hidden-visible.md';
+
 import docs from '../docs/code.md';
 
 export const Docs = docs;
@@ -51,6 +55,7 @@ export default () => {
   const tableSimpleWithCheckboxesExample = TableSimpleWithCheckboxesExample();
   const tableWidthExample = TableWidthExample();
   const tableCompoundExpansionExample = TableCompoundExpansionExample();
+  const tableHiddenVisibleExample = TableHiddenVisibleExample();
   const headingText = 'Table';
   const variablesRoot = 'pf-c-table';
 
@@ -98,6 +103,13 @@ export default () => {
       </Example>
       <Example heading="Table with Width Modifiers" handlebars={tableWidthExampleRaw} docs={tableWidthDoc}>
         {tableWidthExample}
+      </Example>
+      <Example
+        heading="Table with hidden/visible breakpoint modifiers"
+        handlebars={tableHiddenVisibleExampleRaw}
+        docs={tableHiddenVisibleDoc}
+      >
+        {tableHiddenVisibleExample}
       </Example>
     </Documentation>
   );

--- a/src/patternfly/components/Table/examples/table-hidden-visible-example.hbs
+++ b/src/patternfly/components/Table/examples/table-hidden-visible-example.hbs
@@ -1,0 +1,95 @@
+{{#> table table--modifier="pf-m-grid-lg" table--id="simple-table" table--attribute='aria-label="Table with hidden and visible modifiers example"'}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--modifier="pf-m-hidden pf-m-visible-on-md pf-m-hidden-on-lg"}}
+        Repositories
+      {{/table-th}}
+      {{#> table-th}}
+        Branches
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-hidden-on-md pf-m-visible-on-lg"}}
+        Pull requests
+      {{/table-th}}
+      {{#> table-th}}
+        Workspaces
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-hidden pf-m-visible-on-sm"}}
+        Last Commit
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-md pf-m-hidden-on-lg" table-td--data-label="Repository Name"}}
+        Visible only on md breakpoint
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden-on-md pf-m-visible-on-lg" table-td--data-label="Pull Requests"}}
+        Hidden only on md breakpoint
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-sm" table-td--data-label="Last Commit"}}
+        Hidden on xs breakpoint
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-md pf-m-hidden-on-lg" table-td--data-label="Repository Name"}}
+        Repository 2
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden-on-md pf-m-visible-on-lg" table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-sm" table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-md pf-m-hidden-on-lg" table-td--data-label="Repository Name"}}
+        Repository 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden-on-md pf-m-visible-on-lg" table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-sm" table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-md pf-m-hidden-on-lg" table-td--data-label="Repository Name"}}
+        Repository 4
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Branches"}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden-on-md pf-m-visible-on-lg" table-td--data-label="Pull Requests"}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="Workspaces"}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--modifier="pf-m-hidden pf-m-visible-on-sm" table-td--data-label="Last Commit"}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -1,6 +1,8 @@
 /* stylelint-disable */
 @mixin pf-mobile-layout {
-  .pf-m-grid.pf-c-table { @content; }
+  .pf-m-grid.pf-c-table {
+    @content;
+  }
 
   .pf-m-grid-md.pf-c-table {
     @media screen and (max-width: $pf-global--breakpoint--md) {
@@ -58,6 +60,9 @@
   --pf-c-table-tr--responsive--nested-table--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-table-tr--responsive--nested-table--PaddingBottom: var(--pf-global--spacer--xl);
   --pf-c-table-tr--responsive--nested-table--PaddingLeft: var(--pf-global--spacer--lg);
+
+  // Cell
+  --pf-c-table-cell--m-grid--hidden-visible--Display: grid;
 
   // Td
   --pf-c-table-td--responsive--GridColumnGap: var(--pf-global--spacer--md);
@@ -194,11 +199,11 @@
   }
 
   // Standard td, in standard row (non-expandable)
-  // exclude specifically styled tds, as they are placed explicitly within grid
-  // :not(.pf-c-table__toggle):not(.pf-c-table__check):not(.pf-c-table__action):not(.pf-c-table__sort)
-  tr:not(.pf-c-table__expandable-row) > :not(.pf-c-table__toggle):not(.pf-c-table__check):not(.pf-c-table__action):not(.pf-c-table__sort) {
+  [data-label] {
+    // default pf-hidden-visible() mixin is called in table.scss. redefining variable here
+    --pf-c-table-cell--hidden-visible--Display: var(--pf-c-table-cell--m-grid--hidden-visible--Display);
+
     // responsive layout, set td to two column grid
-    display: grid;
     grid-column: 1;
     grid-column-gap: var(--pf-c-table-td--responsive--GridColumnGap);
     align-items: start;

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -34,6 +34,9 @@
   // Thead
   --pf-c-table-thead--FontSize: var(--pf-global--FontSize--sm);
 
+  // Cell
+  --pf-c-table-cell--hidden-visible--Display: table-cell;
+
   // Tr
   --pf-c-table-thead-cell--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-table-thead-cell--PaddingBottom: var(--pf-global--spacer--md);
@@ -152,6 +155,8 @@
 
   // Table row
   tr > * {
+    @include pf-hidden-visible(var(--pf-c-table-cell--hidden-visible--Display));
+
     // set position relative for ::before borders
     position: relative;
 
@@ -174,7 +179,6 @@
       --pf-c-table-cell--PaddingRight: var(--pf-c-table-cell--first-last-child--PaddingRight);
     }
 
-    /* stylelint-disable-next-line */
     &.pf-m-center {
       text-align: center;
     }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -152,3 +152,10 @@
   scrollbar-width: none; // hides scrollbars in Firefox 64 and up
   -ms-overflow-style: -ms-autohiding-scrollbar; // auto hides scrollbars in Edge
 }
+
+@mixin pf-hidden-visible($val: "block") {
+  /* stylelint-disable-next-line */
+  --pf-hidden-visible--visible--Display: #{$val};
+
+  @extend %pf-hidden-visible;
+}

--- a/src/patternfly/sass-utilities/placeholders.scss
+++ b/src/patternfly/sass-utilities/placeholders.scss
@@ -40,3 +40,43 @@
     --pf-c-button--m-secondary--active--BorderColor: var(--pf-global--Color--light-100);
   }
 }
+
+/* stylelint-disable */
+%pf-hidden-visible {
+  // base value for visible display property is set to 'block' by default and passed in to
+  // placeholder via `pf-hidden-visible` mixin
+  --pf-hidden-visible--visible--Visibility: visible;
+
+  // set hidden var values
+  --pf-hidden-visible--hidden--Display: none;
+  --pf-hidden-visible--hidden--Visibility: hidden;
+
+  // set visibile var values
+  --pf-hidden-visible--Display: var(--pf-hidden-visible--visible--Display);
+  --pf-hidden-visible--Visibility: var(--pf-hidden-visible--visible--Visibility);
+
+  // set default state to visible
+  display: var(--pf-hidden-visible--Display);
+  visibility: var(--pf-hidden-visible--Visibility);
+
+  // toggle values based on state
+  &.pf-m-hidden {
+    --pf-hidden-visible--Display: var(--pf-hidden-visible--hidden--Display);
+    --pf-hidden-visible--Visibility: var(--pf-hidden-visible--hidden--Visibility);
+  }
+
+  @each $size, $bp in $pf-global--breakpoint-name-map {
+    @media screen and (min-width: $bp) {
+      &.pf-m-hidden-on-#{$size} {
+        --pf-hidden-visible--Display: var(--pf-hidden-visible--hidden--Display);
+        --pf-hidden-visible--Visibility: var(--pf-hidden-visible--hidden--Visibility);
+      }
+
+      &.pf-m-visible-on-#{$size} {
+        --pf-hidden-visible--Display: var(--pf-hidden-visible--visible--Display);
+        --pf-hidden-visible--Visibility: var(--pf-hidden-visible--visible--Visibility);
+      }
+    }
+  }
+}
+/* stylelint-enable */

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -248,6 +248,14 @@ $pf-global--breakpoint-list: (
   "xl"
 );
 
+// Global breakpoint name map - used for %pf-hidden-visible
+$pf-global--breakpoint-name-map: (
+  "sm": $pf-global--breakpoint--sm,
+  "md": $pf-global--breakpoint--md,
+  "lg": $pf-global--breakpoint--lg,
+  "xl": $pf-global--breakpoint--xl
+);
+
 // Spacer properties
 $pf-global--spacer-properties-map: (
   "m":  "margin",


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1725

I had originally made this block of hidden/visible-on-* CSS a mixin that could be included in any component that takes an argument for the `display` property (for `block`, `table`, `flex`, etc). That might be a good idea in the future if we want to add this kind of functionality to other components.