### PR TITLE
fix(a11y): fixes aria tagging on options menu

### DIFF
--- a/src/patternfly/components/OptionsMenu/examples/options-menu-align-right-example.hbs
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu-align-right-example.hbs
@@ -1,4 +1,4 @@
-{{#> options-menu options-menu--IsExpanded="true" id="options-menu-align-right-example" options-menu--label-text="Items per page" options-menu--HasToggleIcon="true" options-menu--modifier="pf-m-align-right"}}
+{{#> options-menu options-menu--IsExpanded="true" id="options-menu-align-right-example" options-menu--HasToggleIcon="true" options-menu--modifier="pf-m-align-right"}}
   {{#> options-menu-toggle}}
     <span class="pf-c-options-menu__toggle-text">
       Options Menu

--- a/src/patternfly/components/OptionsMenu/examples/options-menu-multiple-example.hbs
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu-multiple-example.hbs
@@ -1,4 +1,4 @@
-{{#> options-menu id="options-menu-multiple-example" options-menu--label-text="Sort methods"  options-menu--HasToggleIcon="true"}}
+{{#> options-menu id="options-menu-multiple-example" options-menu--HasToggleIcon="true"}}
   {{#> options-menu-toggle}}
     <span class="pf-c-options-menu__toggle-text">
       Sort by
@@ -7,7 +7,7 @@
   {{> options-menu-multiple}}
 {{/options-menu}}
 
-{{#> options-menu options-menu--IsExpanded="true" id="options-menu-multiple-expanded-example" options-menu--label-text="Sort methods"  options-menu--HasToggleIcon="true"}}
+{{#> options-menu options-menu--IsExpanded="true" id="options-menu-multiple-expanded-example" options-menu--HasToggleIcon="true"}}
   {{#> options-menu-toggle}}
     <span class="pf-c-options-menu__toggle-text">
       Sort by

--- a/src/patternfly/components/OptionsMenu/examples/options-menu-plain-example.hbs
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu-plain-example.hbs
@@ -1,11 +1,11 @@
-{{#> options-menu id="options-menu-plain-example" options-menu--label-text="Sort methods"}}
+{{#> options-menu id="options-menu-plain-example"}}
   {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
     <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
   {{/options-menu-toggle}}
   {{> options-menu-single}}
 {{/options-menu}}
 
-{{#> options-menu options-menu--IsExpanded="true" id="options-menu-plain-expanded-example" options-menu--label-text="Sort methods"}}
+{{#> options-menu options-menu--IsExpanded="true" id="options-menu-plain-expanded-example"}}
   {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
     <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
   {{/options-menu-toggle}}

--- a/src/patternfly/components/OptionsMenu/examples/options-menu-plain-text-example.hbs
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu-plain-text-example.hbs
@@ -1,19 +1,19 @@
-{{#> options-menu id="options-menu-plain-text-example" options-menu--label-text="Items per page" options-menu--IsText="true"}}
+{{#> options-menu id="options-menu-plain-text-example" options-menu--IsText="true"}}
   {{#> options-menu-toggle options-menu-toggle--type="div" options-menu-toggle--modifier="pf-m-plain"}}
     <span class="pf-c-options-menu__toggle-text">
-      Option 2
+      Custom text
     </span>
-    {{> options-menu-toggle-button aria-label="Select"}}
+    {{> options-menu-toggle-button aria-label="Options menu"}}
   {{/options-menu-toggle}}
   {{> options-menu-single}}
 {{/options-menu}}
 
-{{#> options-menu options-menu--IsExpanded="true" id="options-menu-plain-text-expanded-example" options-menu--label-text="Items per page" options-menu--IsText="true"}}
+{{#> options-menu options-menu--IsExpanded="true" id="options-menu-plain-text-expanded-example" options-menu--IsText="true"}}
   {{#> options-menu-toggle options-menu-toggle--type="div" options-menu-toggle--modifier="pf-m-plain"}}
     <span class="pf-c-options-menu__toggle-text">
-      Option 2
+      Custom text
     </span>
-    {{> options-menu-toggle-button aria-label="Select"}}
+    {{> options-menu-toggle-button aria-label="Options menu"}}
   {{/options-menu-toggle}}
   {{> options-menu-single}}
 {{/options-menu}}

--- a/src/patternfly/components/OptionsMenu/examples/options-menu-single-example.hbs
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu-single-example.hbs
@@ -1,4 +1,4 @@
-{{#> options-menu id="options-menu-single-example" options-menu--label-text="Items per page" options-menu--HasToggleIcon="true"}}
+{{#> options-menu id="options-menu-single-example" options-menu--HasToggleIcon="true"}}
   {{#> options-menu-toggle}}
     <span class="pf-c-options-menu__toggle-text">
       Options Menu
@@ -7,7 +7,7 @@
   {{> options-menu-single}}
 {{/options-menu}}
 
-{{#> options-menu options-menu--IsExpanded="true" id="options-menu-single-expanded-example" options-menu--label-text="Items per page" options-menu--HasToggleIcon="true"}}
+{{#> options-menu options-menu--IsExpanded="true" id="options-menu-single-expanded-example" options-menu--HasToggleIcon="true"}}
   {{#> options-menu-toggle}}
     <span class="pf-c-options-menu__toggle-text">
       Options Menu

--- a/src/patternfly/components/OptionsMenu/examples/options-menu-top-example.hbs
+++ b/src/patternfly/components/OptionsMenu/examples/options-menu-top-example.hbs
@@ -1,4 +1,4 @@
-{{#> options-menu options-menu--IsExpanded="true" options-menu--modifier="pf-m-top" id="options-menu-top-example" options-menu--label-text="Items per page" options-menu--HasToggleIcon="true" options-menu--modifier="pf-m-align-right"}}
+{{#> options-menu options-menu--IsExpanded="true" options-menu--modifier="pf-m-top" id="options-menu-top-example" options-menu--HasToggleIcon="true" options-menu--modifier="pf-m-align-right"}}
   {{#> options-menu-toggle}}
     <span class="pf-c-options-menu__toggle-text">
       Options Menu

--- a/src/patternfly/components/OptionsMenu/options-menu-menu.hbs
+++ b/src/patternfly/components/OptionsMenu/options-menu-menu.hbs
@@ -1,5 +1,5 @@
 <ul class="pf-c-options-menu__menu{{#if options-menu--modifier}} {{options-menu--modifier}}{{/if}}"
-  aria-labelledby="{{id}}-label"
+  aria-labelledby="{{id}}-toggle"
   {{#unless options-menu--IsExpanded}}hidden{{/unless}}
   {{#if options-menu--attribute}}
     {{{options-menu--attribute}}}

--- a/src/patternfly/components/OptionsMenu/options-menu-toggle-button.hbs
+++ b/src/patternfly/components/OptionsMenu/options-menu-toggle-button.hbs
@@ -2,7 +2,6 @@
   id="{{id}}-toggle"
   aria-haspopup="listbox"
   aria-expanded="{{#if options-menu--IsExpanded}}true{{else}}false{{/if}}"
-  aria-labelledby="{{id}}-label {{id}}-toggle"
   {{#if aria-label}}
     aria-label="{{aria-label}}"
   {{/if}}

--- a/src/patternfly/components/OptionsMenu/options-menu-toggle.hbs
+++ b/src/patternfly/components/OptionsMenu/options-menu-toggle.hbs
@@ -3,7 +3,6 @@
     id="{{id}}-toggle"
     aria-haspopup="listbox"
     aria-expanded="{{#if options-menu--IsExpanded}}true{{else}}false{{/if}}"
-    aria-labelledby="{{id}}-label {{id}}-toggle"
   {{/unless}}
 	{{#if options-menu-toggle--attribute}}
 		{{{options-menu-toggle--attribute}}}

--- a/src/patternfly/components/OptionsMenu/options-menu.hbs
+++ b/src/patternfly/components/OptionsMenu/options-menu.hbs
@@ -2,6 +2,5 @@
   {{#if options-menu--attribute}}
     {{{options-menu--attribute}}}
   {{/if}}>
-  <span id="{{id}}-label" hidden>{{options-menu--label-text}}:</span>
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/Pagination/examples/pagination-bottom-example.hbs
+++ b/src/patternfly/components/Pagination/examples/pagination-bottom-example.hbs
@@ -1,5 +1,5 @@
 {{#> pagination pagination--modifier="pf-m-footer"}}
-  {{> pagination-options-menu id="pagination-options-menu-bottom-example" options-menu--label-text="Items per page" options-menu--IsText="true"}}
+  {{> pagination-options-menu id="pagination-options-menu-bottom-example"  options-menu--IsText="true"}}
 
   {{#> pagination-nav}}
     {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}

--- a/src/patternfly/components/Pagination/examples/pagination-top-example.hbs
+++ b/src/patternfly/components/Pagination/examples/pagination-top-example.hbs
@@ -3,7 +3,7 @@
     <b>1 - 10</b> of <b>37</b>
   {{/pagination-total-items}}
 
-  {{> pagination-options-menu options-menu id="pagination-options-menu-top-example" options-menu--label-text="Items per page" options-menu--IsText="true"}}
+  {{> pagination-options-menu options-menu id="pagination-options-menu-top-example"  options-menu--IsText="true"}}
 
   {{#> pagination-nav}}
     {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}

--- a/src/patternfly/components/Pagination/examples/pagination-top-expanded-example.hbs
+++ b/src/patternfly/components/Pagination/examples/pagination-top-expanded-example.hbs
@@ -3,7 +3,7 @@
     <b>1 - 10</b> of <b>37</b>
   {{/pagination-total-items}}
 
-  {{> pagination-options-menu options-menu--IsExpanded="true" id="pagination-options-menu-top-expanded-example" options-menu--label-text="Items per page" options-menu--IsText="true"}}
+  {{> pagination-options-menu options-menu--IsExpanded="true" id="pagination-options-menu-top-expanded-example"  options-menu--IsText="true"}}
 
   {{#> pagination-nav}}
     {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-expanded-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-expanded-example.hbs
@@ -12,7 +12,7 @@
       Status
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort" options-menu--IsExpanded="true"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort" options-menu--IsExpanded="true"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}
@@ -33,7 +33,7 @@
       37 Items
     {{/pagination-total-items}}
 
-    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu') options-menu--IsExpanded="true" options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu') options-menu--IsExpanded="true"  options-menu--IsText="true"}}
 
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-checked-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-checked-example.hbs
@@ -13,7 +13,7 @@
       Status
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-example.hbs
@@ -12,7 +12,7 @@
       Status
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-checked-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-checked-example.hbs
@@ -13,7 +13,7 @@
       Status
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-example.hbs
@@ -12,7 +12,7 @@
       Status
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-pagination-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-pagination-example.hbs
@@ -12,7 +12,7 @@
       Status
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}
@@ -33,7 +33,7 @@
       37 Items
     {{/pagination-total-items}}
 
-    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu') options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu')  options-menu--IsText="true"}}
 
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-simple-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-simple-example.hbs
@@ -12,7 +12,7 @@
       Filter
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}

--- a/src/patternfly/demos/DataList/data-list-pagination.hbs
+++ b/src/patternfly/demos/DataList/data-list-pagination.hbs
@@ -1,6 +1,6 @@
 {{#> toolbar toolbar--id=(concat page--id '-toolbar-bottom')}}
   {{#> pagination pagination--attribute='aria-label="Element pagination"' pagination--modifier="pf-m-footer"}}
-    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu-text') options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu-text')  options-menu--IsText="true"}}
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}
         {{> button-icon button-icon--type="angle-double-left"}}

--- a/src/patternfly/demos/DataList/data-list-toolbar.hbs
+++ b/src/patternfly/demos/DataList/data-list-toolbar.hbs
@@ -12,7 +12,7 @@
         Name
       {{/select}}
     {{/toolbar-filter}}
-    {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+    {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}
@@ -32,7 +32,7 @@
     {{#> pagination-total-items}}
       <b>1 - 10</b> of <b>37</b>
     {{/pagination-total-items}}
-    {{> pagination-options-menu options-menu id=(concat toolbar--id '-pagination-options-menu') options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu options-menu id=(concat toolbar--id '-pagination-options-menu')  options-menu--IsText="true"}}
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}
         {{> button-icon button-icon--type="angle-double-left"}}

--- a/src/patternfly/demos/DataList/data-list-without-pagination-toolbar.hbs
+++ b/src/patternfly/demos/DataList/data-list-without-pagination-toolbar.hbs
@@ -8,7 +8,7 @@
       Name
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}

--- a/src/patternfly/demos/DataTable/data-table-pagination.hbs
+++ b/src/patternfly/demos/DataTable/data-table-pagination.hbs
@@ -1,6 +1,6 @@
 {{#> toolbar toolbar--id=(concat page--id '-toolbar-bottom')}}
   {{#> pagination pagination--attribute='aria-label="Element pagination"' pagination--modifier="pf-m-footer"}}
-    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu-text') options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu-text')  options-menu--IsText="true"}}
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}
         {{> button-icon button-icon--type="angle-double-left"}}

--- a/src/patternfly/demos/DataTable/data-table-toolbar-no-sort.hbs
+++ b/src/patternfly/demos/DataTable/data-table-toolbar-no-sort.hbs
@@ -22,7 +22,7 @@
     {{#> pagination-total-items}}
       <b>1 - 5</b> of <b>10</b>
     {{/pagination-total-items}}
-    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu') options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu')  options-menu--IsText="true"}}
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}
         {{> button-icon button-icon--type="angle-double-left"}}

--- a/src/patternfly/demos/DataTable/data-table-toolbar.hbs
+++ b/src/patternfly/demos/DataTable/data-table-toolbar.hbs
@@ -8,7 +8,7 @@
       Name
     {{/select}}
   {{/toolbar-filter}}
-  {{#> options-menu id=(concat toolbar--id '-options-menu') options-menu--label-text="Sort methods" options-menu--modifier="pf-c-toolbar__sort"}}
+  {{#> options-menu id=(concat toolbar--id '-options-menu')  options-menu--modifier="pf-c-toolbar__sort"}}
     {{#> options-menu-toggle options-menu-toggle--modifier="pf-m-plain" options-menu-toggle--attribute='aria-label="Sort by"'}}
       <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
     {{/options-menu-toggle}}
@@ -28,7 +28,7 @@
     {{#> pagination-total-items}}
       <b>1 - 5</b> of <b>10</b>
     {{/pagination-total-items}}
-    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu') options-menu--label-text="Items per page" options-menu--IsText="true"}}
+    {{> pagination-options-menu id=(concat toolbar--id '-pagination-options-menu')  options-menu--IsText="true"}}
     {{#> pagination-nav}}
       {{#> button button--modifier="pf-m-plain pf-m-disabled" button--attribute='aria-label="Go to first page" aria-disabled="true"'}}
         {{> button-icon button-icon--type="angle-double-left"}}


### PR DESCRIPTION
This removes the hidden span labeling the options menu, and adjusts the aria-labelled by attribute to point to the toggle.
This meant that the handlebars parameter `options-menu--label-text` was unused and has been removed both from the options menu component and wherever the options menu was used (pagination, toolbar, data list, and data table)

Fixes #1758 