### PR TITLE
feat(grid): add grid-gap responsive modifiers

### DIFF
--- a/src/patternfly/layouts/Grid/docs/code.md
+++ b/src/patternfly/layouts/Grid/docs/code.md
@@ -8,7 +8,7 @@ A Grid layout framework including responsive columns, row spans and gutters. Bre
 | -- | -- | -- |
 | `.pf-l-grid` | `<div>` | Initializes the grid layout. |
 | `.pf-l-grid__item` | `<div>` | Explicitly sets a child of the grid. This class isn't necessary, but it is included to keep inline with BEM convention, and to provide an entity that will later be used for applying modifiers. |
-| `.pf-m-gutter` | `.pf-l-grid` | Adds grid gutters. |
+| `.pf-m-gutter{-[size]{-on[breakpoint]}}` | `.pf-l-grid` | Adds grid gutters. |
 | `.pf-m-all-{1-12}-col{-on-[breakpoint]}` | `.pf-l-grid` | Defines grid item size on grid container. |
 | `.pf-m-{1-12}-col{-on-[breakpoint]}` | `.pf-l-grid__item` | Defines grid item size.  Although not required, they are strongly suggested. If not used, grid item will default to 12 col. |
 | `.pf-m-{2-x}-row{-on-[breakpoint]}` | `.pf-l-grid__item` | Defines grid item row span.  For row spans to function correctly, the value of of the current row plus the grid items to span must be equal to or less than 12. Example: .pf-m-8-col.pf-m-2-row + .pf-m-4-col + .pf-m-4-col. There is no limit to number of spanned rows. |

--- a/src/patternfly/layouts/Grid/examples/grid-base-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-base-example.hbs
@@ -3,33 +3,33 @@
       12 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-11-col"}}
-      11 col 
+      11 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-      1 col 
+      1 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-10-col"}}
-      10 col 
-  {{/grid-item}}    
+      10 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-      2 col 
-  {{/grid-item}}    
+      2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-9-col"}}
-      9 col 
-  {{/grid-item}}    
+      9 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      3 col 
-  {{/grid-item}}    
+      3 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-8-col"}}
       8 col
-  {{/grid-item}}    
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
       4 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-7-col"}}
       7 col
-  {{/grid-item}}  
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-5-col"}}
       5 col
-  {{/grid-item}}  
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-gutter-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-gutter-example.hbs
@@ -1,167 +1,183 @@
+<h2 class="example-title"><code>.pf-m-gutter</code> (same as <code>.pf-m-gutter-lg</code>)</h2>
+
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter (same as .pf-m-gutter-lg)</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-xs</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-xs"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-xs</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-sm</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-sm"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-sm</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-md</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-md"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-md</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-lg</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-lg"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-lg</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-xl</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-xl"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-xl</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-2xl</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-2xl"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-2xl</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-3xl</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-3xl"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-3xl</strong> - Item 1
+    Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      Item 2
+    Item 2
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 3
+    Item 3
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 4
+    Item 4
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 5
+    Item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      Item 6
+    Item 6
   {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-gutter-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-gutter-example.hbs
@@ -1,23 +1,167 @@
 {{#> grid grid--modifier="pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-12-col"}}
-      12 col
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter (same as .pf-m-gutter-lg)</strong> - Item 1
   {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-11-col"}}
-      11 col 
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
   {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-      1 col 
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-10-col"}}
-      10 col 
-  {{/grid-item}}    
-  {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-      2 col 
-  {{/grid-item}}    
-  {{#> grid-item grid-item--modifier="pf-m-9-col"}}
-      9 col 
-  {{/grid-item}}    
   {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-      3 col 
-  {{/grid-item}}    
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-xs"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-xs</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-sm"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-sm</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-md"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-md</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-lg"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-lg</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-xl"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-xl</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-2xl"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-2xl</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-3xl"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-3xl</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-nested-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-nested-example.hbs
@@ -3,23 +3,23 @@
     12 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-10-col"}}
-    10 col 
+    10 col
       {{#> grid grid--modifier="pf-m-gutter"}}
         {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-            6 col 
-        {{/grid-item}}    
+            6 col
+        {{/grid-item}}
         {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-            6 col 
-        {{/grid-item}}    
+            6 col
+        {{/grid-item}}
         {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-            4 col 
-        {{/grid-item}}    
+            4 col
+        {{/grid-item}}
         {{#> grid-item grid-item--modifier="pf-m-8-col"}}
-            8 col 
-        {{/grid-item}}    
-      {{/grid}}      
-  {{/grid-item}}    
+            8 col
+        {{/grid-item}}
+      {{/grid}}
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-      2 col 
-  {{/grid-item}}   
+      2 col
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-offsets-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-offsets-example.hbs
@@ -7,8 +7,8 @@
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-9-col pf-m-offset-3-col"}}
       9 col, offset 3
-  {{/grid-item}}    
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-8-col pf-m-offset-4-col"}}
       8 col, offset 4
-  {{/grid-item}}  
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-responsive-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-responsive-example.hbs
@@ -6,27 +6,27 @@
       11 / 6 / 1 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col pf-m-6-col-on-md pf-m-10-col-on-xl"}}
-      2 / 6 / 10 col 
+      2 / 6 / 10 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-10-col pf-m-6-col-on-md pf-m-2-col-on-xl"}}
-      10 / 6 / 2 col 
-  {{/grid-item}}    
+      10 / 6 / 2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-3-col pf-m-6-col-on-md pf-m-9-col-on-xl"}}
-      3 / 6 / 9 col 
+      3 / 6 / 9 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-9-col pf-m-6-col-on-md pf-m-3-col-on-xl"}}
-      9 / 6 / 3 col 
-  {{/grid-item}}   
+      9 / 6 / 3 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col pf-m-6-col-on-md pf-m-8-col-on-xl"}}
-      4 / 6 / 8 col 
+      4 / 6 / 8 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-8-col pf-m-6-col-on-md pf-m-4-col-on-xl"}}
-      8 / 6 / 4 col 
-  {{/grid-item}}   
+      8 / 6 / 4 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-5-col pf-m-6-col-on-md pf-m-7-col-on-xl"}}
-      5 / 6 / 7 col 
+      5 / 6 / 7 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-7-col pf-m-6-col-on-md pf-m-5-col-on-xl"}}
-      7 / 6 / 5 col 
-  {{/grid-item}} 
+      7 / 6 / 5 col
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-responsive-gutters-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-responsive-gutters-example.hbs
@@ -1,6 +1,8 @@
+<h2 class="example-title"><code>.pf-m-gutter.pf-m-gutter-3xl-on-lg</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter pf-m-gutter-3xl-on-lg"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter.pf-m-gutter-3xl-on-lg</strong> - Item 1
+      Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
       Item 2
@@ -18,10 +20,12 @@
       Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
+
+<h2 class="example-title"><code>.pf-m-gutter-on-md</code></h2>
+
 {{#> grid grid--modifier="pf-m-gutter-on-md"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-on-md</strong> - Item 1
+      Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
       Item 2
@@ -39,10 +43,12 @@
       Item 6
   {{/grid-item}}
 {{/grid}}
-<br><br>
-{{#> grid grid--modifier="pf-m-gutter-xl pf-m-gutter-xs-on-md pf-m-gutter-3xl-on-lg"}}
+
+<h2 class="example-title"><code>.pf-m-gutter-xl.pf-m-gutter-xs-on-md.pf-m-gutter-2xl-on-lg</code></h2>
+
+{{#> grid grid--modifier="pf-m-gutter-xl pf-m-gutter-xs-on-md pf-m-gutter-2xl-on-lg"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
-      <strong>.pf-m-gutter-xl.pf-m-gutter-xs-on-md.pf-m-gutter-3xl-on-lg</strong> - Item 1
+      Item 1
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
       Item 2

--- a/src/patternfly/layouts/Grid/examples/grid-responsive-gutters-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-responsive-gutters-example.hbs
@@ -44,9 +44,9 @@
   {{/grid-item}}
 {{/grid}}
 
-<h2 class="example-title"><code>.pf-m-gutter-xl.pf-m-gutter-xs-on-md.pf-m-gutter-2xl-on-lg</code></h2>
+<h2 class="example-title"><code>.pf-m-gutter-sm.pf-m-gutter-none-on-md.pf-m-gutter-2xl-on-lg</code></h2>
 
-{{#> grid grid--modifier="pf-m-gutter-xl pf-m-gutter-xs-on-md pf-m-gutter-2xl-on-lg"}}
+{{#> grid grid--modifier="pf-m-gutter-sm pf-m-gutter-none-on-md pf-m-gutter-2xl-on-lg"}}
   {{#> grid-item grid-item--modifier="pf-m-6-col"}}
       Item 1
   {{/grid-item}}

--- a/src/patternfly/layouts/Grid/examples/grid-responsive-gutters-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-responsive-gutters-example.hbs
@@ -1,0 +1,62 @@
+{{#> grid grid--modifier="pf-m-gutter pf-m-gutter-3xl-on-lg"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter.pf-m-gutter-3xl-on-lg</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-on-md"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-on-md</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}
+<br><br>
+{{#> grid grid--modifier="pf-m-gutter-xl pf-m-gutter-xs-on-md pf-m-gutter-3xl-on-lg"}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      <strong>.pf-m-gutter-xl.pf-m-gutter-xs-on-md.pf-m-gutter-3xl-on-lg</strong> - Item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-6-col"}}
+      Item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      Item 6
+  {{/grid-item}}
+{{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-rowspan-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-rowspan-example.hbs
@@ -1,6 +1,6 @@
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-8-col"}}
-    8 col 
+    8 col
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col pf-m-2-row"}}
     4 col, 2 row
@@ -9,30 +9,30 @@
     2 col, 3 row
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-    2 col 
-  {{/grid-item}}  
+    2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    4 col 
-  {{/grid-item}}  
+    4 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-    2 col 
-  {{/grid-item}}  
+    2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-    2 col 
-  {{/grid-item}}  
+    2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-    2 col 
-  {{/grid-item}}  
+    2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    4 col 
-  {{/grid-item}}  
+    4 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-    2 col 
-  {{/grid-item}}  
+    2 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    4 col 
-  {{/grid-item}}  
+    4 col
+  {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    4 col 
-  {{/grid-item}}  
+    4 col
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/grid-smart-grid-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-smart-grid-example.hbs
@@ -28,7 +28,7 @@
   {{/grid-item}}
   {{#> grid-item}}
     item 10
-  {{/grid-item}}  
+  {{/grid-item}}
   {{#> grid-item}}
     item 11
   {{/grid-item}}

--- a/src/patternfly/layouts/Grid/examples/grid-smart-grid-overrides-example.hbs
+++ b/src/patternfly/layouts/Grid/examples/grid-smart-grid-overrides-example.hbs
@@ -28,7 +28,7 @@
   {{/grid-item}}
   {{#> grid-item}}
     item 10
-  {{/grid-item}}  
+  {{/grid-item}}
   {{#> grid-item}}
     item 11
   {{/grid-item}}
@@ -37,8 +37,8 @@
   {{/grid-item}}
   {{#> grid-item}}
     item 13
-  {{/grid-item}}  
+  {{/grid-item}}
   {{#> grid-item}}
     item 14
-  {{/grid-item}}  
+  {{/grid-item}}
 {{/grid}}

--- a/src/patternfly/layouts/Grid/examples/index.js
+++ b/src/patternfly/layouts/Grid/examples/index.js
@@ -47,13 +47,13 @@ export default () => {
       <Example heading="Base grid" handlebars={GridBaseRaw}>
         {gridBase}
       </Example>
-      <Example heading="Grid gutters" handlebars={GridGutterRaw}>
+      <Example heading="Grid gutters" handlebars={GridGutterRaw} className="grid-documentation">
         {gridGutter}
       </Example>
       <Example heading="Responsive grid" handlebars={GridResponsiveRaw}>
         {gridResponsive}
       </Example>
-      <Example heading="Responsive grid gutters" handlebars={GridResponsiveGuttersRaw}>
+      <Example heading="Responsive grid gutters" handlebars={GridResponsiveGuttersRaw} className="grid-documentation">
         {gridResponsiveGutters}
       </Example>
       <Example heading="Nested grids" handlebars={GridNestedRaw}>

--- a/src/patternfly/layouts/Grid/examples/index.js
+++ b/src/patternfly/layouts/Grid/examples/index.js
@@ -8,6 +8,7 @@ import GridSmartOverridesRaw from '!raw!./grid-smart-grid-overrides-example.hbs'
 import GridNestedRaw from '!raw!./grid-nested-example.hbs';
 import GridOffsetsRaw from '!raw!./grid-offsets-example.hbs';
 import GridResponsiveRaw from '!raw!./grid-responsive-example.hbs';
+import GridResponsiveGuttersRaw from '!raw!./grid-responsive-gutters-example.hbs';
 import GridRowspanRaw from '!raw!./grid-rowspan-example.hbs';
 import GridBase from './grid-base-example.hbs';
 import GridGutter from './grid-gutter-example.hbs';
@@ -16,6 +17,7 @@ import GridSmartOverrides from './grid-smart-grid-overrides-example.hbs';
 import GridNested from './grid-nested-example.hbs';
 import GridOffsets from './grid-offsets-example.hbs';
 import GridResponsive from './grid-responsive-example.hbs';
+import GridResponsiveGutters from './grid-responsive-gutters-example.hbs';
 import GridRowspan from './grid-rowspan-example.hbs';
 import docs from '../docs/code.md';
 
@@ -29,6 +31,7 @@ export default () => {
   const gridNested = GridNested();
   const gridOffsets = GridOffsets();
   const gridResponsive = GridResponsive();
+  const gridResponsiveGutters = GridResponsiveGutters();
   const gridRowspan = GridRowspan();
   const headingText = 'Grid';
   const variablesRoot = 'pf-l-grid';
@@ -44,11 +47,14 @@ export default () => {
       <Example heading="Base grid" handlebars={GridBaseRaw}>
         {gridBase}
       </Example>
-      <Example heading="Grid gutter" handlebars={GridGutterRaw}>
+      <Example heading="Grid gutters" handlebars={GridGutterRaw}>
         {gridGutter}
       </Example>
       <Example heading="Responsive grid" handlebars={GridResponsiveRaw}>
         {gridResponsive}
+      </Example>
+      <Example heading="Responsive grid gutters" handlebars={GridResponsiveGuttersRaw}>
+        {gridResponsiveGutters}
       </Example>
       <Example heading="Nested grids" handlebars={GridNestedRaw}>
         {gridNested}

--- a/src/patternfly/layouts/Grid/examples/index.js
+++ b/src/patternfly/layouts/Grid/examples/index.js
@@ -47,11 +47,11 @@ export default () => {
       <Example heading="Base grid" handlebars={GridBaseRaw}>
         {gridBase}
       </Example>
-      <Example heading="Grid gutters" handlebars={GridGutterRaw} className="grid-documentation">
-        {gridGutter}
-      </Example>
       <Example heading="Responsive grid" handlebars={GridResponsiveRaw}>
         {gridResponsive}
+      </Example>
+      <Example heading="Grid gutters" handlebars={GridGutterRaw} className="grid-documentation">
+        {gridGutter}
       </Example>
       <Example heading="Responsive grid gutters" handlebars={GridResponsiveGuttersRaw} className="grid-documentation">
         {gridResponsiveGutters}

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -1,4 +1,3 @@
-// URL.com/guidelines#layout
 // Generate smart grid layout
 // @parameter {Suffix} xs, sm, md, lg, xl, null
 @mixin pf-smart-grid($suffix: null) {
@@ -76,13 +75,15 @@
     }
   }
 
-  $pf-u-spacing--spacer-map: (
-    "": "var(--pf-l-grid--m-gutter--GridGap)"
+  // Custom spacer values
+  $pf-l-grid--spacer-map: (
+    "": "var(--pf-l-grid--m-gutter--GridGap)",
+    "-none": "0"
   );
 
   // Loop through $pf-global--spacer-map to generate different gutter spacers
   @each $breakpoint, $value in $pf-global--breakpoint-map {
-    @each $spacer, $spacer-value in map-merge($pf-u-spacing--spacer-map, $pf-global--spacer-map) {
+    @each $spacer, $spacer-value in map-merge($pf-l-grid--spacer-map, $pf-global--spacer-map) {
       @include pf-media-query($breakpoint) {
         @include pf-grid-gutter-modifier($spacer, $spacer-value, $value);
       }

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -36,15 +36,23 @@
   }
 }
 
+// Creates grid gutter
+@mixin pf-grid-gutter-modifier($spacer: null, $spacer-value: null, $suffix: null) {
+  &.pf-m-gutter#{$spacer}#{$suffix} {
+    --pf-l-grid--GridGap: #{$spacer-value};
+  }
+}
 
 // Grid base
 .pf-l-grid {
+  --pf-l-grid--GridGap: 0;
   --pf-l-grid--m-gutter--GridGap: var(--pf-global--gutter);
   --pf-l-grid__item--GridColumnStart: auto;
   --pf-l-grid__item--GridColumnEnd: span 12;
 
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
+  grid-gap: var(--pf-l-grid--GridGap);
 
   > *,
   .pf-l-grid__item {
@@ -68,7 +76,16 @@
     }
   }
 
-  &.pf-m-gutter {
-    grid-gap: var(--pf-l-grid--m-gutter--GridGap);
+  $pf-u-spacing--spacer-map: (
+    "": "var(--pf-l-grid--m-gutter--GridGap)"
+  );
+
+  // Loop through $pf-global--spacer-map to generate different gutter spacers
+  @each $breakpoint, $value in $pf-global--breakpoint-map {
+    @each $spacer, $spacer-value in map-merge($pf-u-spacing--spacer-map, $pf-global--spacer-map) {
+      @include pf-media-query($breakpoint) {
+        @include pf-grid-gutter-modifier($spacer, $spacer-value, $value);
+      }
+    }
   }
 }

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -276,8 +276,6 @@ $pf-global--spacer-properties-map: (
 
 // Spacer values
 $pf-global--spacer-map: (
-  "-auto": "auto",
-  "-0": 0,
   "-xs": "var(--pf-global--spacer--xs)",
   "-sm": "var(--pf-global--spacer--sm)",
   "-md": "var(--pf-global--spacer--md)",

--- a/src/patternfly/utilities/Spacing/spacing.scss
+++ b/src/patternfly/utilities/Spacing/spacing.scss
@@ -1,5 +1,10 @@
 /* stylelint-disable */
 
+$pf-u-spacing--spacer-map: (
+  "-auto": "auto",
+  "-0": 0
+);
+
 // Build spacing values
 @mixin pf-spacer-builder() {
 
@@ -10,7 +15,7 @@
     @each $property, $property-value in $pf-global--spacer-properties-map {
 
       // Loop through spacer values
-      @each $spacer, $spacer-value in $pf-global--spacer-map {
+      @each $spacer, $spacer-value in map-merge($pf-u-spacing--spacer-map, $pf-global--spacer-map) {
 
         // If breakpoint != null, append responsive value
         .pf-u-#{$property}#{$spacer}#{$breakpoint-value} {

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -536,8 +536,10 @@ html {
   .example-border {
     padding: .5rem;
   }
+}
 
-
+.grid-documentation,
+.flex-documentation {
   .example-title {
     margin-bottom: var(--pf-global--spacer--xl);
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1739

also removed the spacing utility specific items in `$pf-global--spacer-map` and left that var as a global var that maps to our spacers so we can use it elsewhere and am using `map-merge()` to add things to that map in specific utilities/layouts.