### PR TITLE
fix(nav): vertical-align to fix horizontal nav shift in firefox

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -415,6 +415,7 @@
   display: inline-flex;
   max-width: 100%;
   overflow-x: auto;
+  vertical-align: bottom;
 
   .pf-c-nav__link {
     position: relative;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1794