### PR TITLE
fix(table): remove min-height from buttons in expansion toggle

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -250,9 +250,6 @@
 
     .pf-c-button {
       width: 100%;
-
-      // hack: use min-height instead of height as FireFox doesn't like height
-      min-height: 100%;
       padding: var(--pf-c-table-cell--PaddingTop) var(--pf-c-table-cell--PaddingRight) var(--pf-c-table-cell--PaddingBottom) var(--pf-c-table-cell--PaddingLeft);
       font-size: inherit;
       font-weight: inherit;


### PR DESCRIPTION
Close #1770 

I think min-height was added to the button to increase the focus ring, but this was causing issues with `vertical-align: baseline`.

So removed the min-height which also fixes how the text in the cells align.