### PR TITLE
fix(title): add hyphen

### DIFF
--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -29,6 +29,8 @@
   --pf-c-title--m-md--FontSize: var(--pf-global--FontSize--md);
   --pf-c-title--m-md--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
+  hyphens: auto;
+
   &.pf-m-4xl {
     font-size: var(--pf-c-title--m-4xl--FontSize);
     font-weight: var(--pf-c-title--m-4xl--FontWeight);


### PR DESCRIPTION
close #1762 

WIP
- still have to test across browsers
- test more cases
- use real words when testing

These are the components with titles that hyphen: auto would effect. I actually think that we should change the title in modal to not truncate using ellipsis for consistency. 


<img width="605" alt="Screen Shot 2019-05-15 at 9 35 58 AM" src="https://user-images.githubusercontent.com/20118816/57780522-6892e300-76f6-11e9-86b8-5634b0970705.png">
<img width="411" alt="Screen Shot 2019-05-15 at 9 38 03 AM" src="https://user-images.githubusercontent.com/20118816/57780523-6892e300-76f6-11e9-875d-2855836fb523.png">
<img width="537" alt="Screen Shot 2019-05-15 at 9 40 47 AM" src="https://user-images.githubusercontent.com/20118816/57780524-6892e300-76f6-11e9-8afd-a54fa9f3dfdd.png">
<img width="676" alt="Screen Shot 2019-05-15 at 9 41 56 AM" src="https://user-images.githubusercontent.com/20118816/57780525-6892e300-76f6-11e9-99d2-9cb7c1aefc94.png">
<img width="449" alt="Screen Shot 2019-05-15 at 9 42 37 AM" src="https://user-images.githubusercontent.com/20118816/57780526-6892e300-76f6-11e9-8b6f-d1db23082e40.png">
<img width="417" alt="Screen Shot 2019-05-15 at 9 44 05 AM" src="https://user-images.githubusercontent.com/20118816/57780528-6892e300-76f6-11e9-9108-95fba4197a8c.png">
