### PR TITLE
fix(content): change margin bottom for small element

### DIFF
--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -51,7 +51,6 @@
   --pf-c-content--h6--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
   // Small text
-  --pf-c-content--small--MarginBottom: var(--pf-global--spacer--md);
   --pf-c-content--small--LineHeight: var(--pf-global--LineHeight--md);
   --pf-c-content--small--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-content--small--Color: var(--pf-global--Color--200);
@@ -211,10 +210,6 @@
     font-size: var(--pf-c-content--small--FontSize);
     line-height: var(--pf-c-content--small--LineHeight);
     color: var(--pf-c-content--small--Color);
-
-    &:not(:last-child) {
-      margin-bottom: var(--pf-c-content--small--MarginBottom);
-    }
   }
 
   blockquote {

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -208,10 +208,13 @@
 
   small {
     display: block;
-    margin-bottom: var(--pf-c-content--small--MarginBottom);
     font-size: var(--pf-c-content--small--FontSize);
     line-height: var(--pf-c-content--small--LineHeight);
     color: var(--pf-c-content--small--Color);
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--small--MarginBottom);
+    }
   }
 
   blockquote {

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -51,6 +51,7 @@
   --pf-c-content--h6--FontWeight: var(--pf-global--FontWeight--semi-bold);
 
   // Small text
+  --pf-c-content--small--MarginBottom: var(--pf-global--spacer--md);
   --pf-c-content--small--LineHeight: var(--pf-global--LineHeight--md);
   --pf-c-content--small--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-content--small--Color: var(--pf-global--Color--200);
@@ -210,6 +211,10 @@
     font-size: var(--pf-c-content--small--FontSize);
     line-height: var(--pf-c-content--small--LineHeight);
     color: var(--pf-c-content--small--Color);
+
+    &:not(:last-child) {
+      margin-bottom: var(--pf-c-content--small--MarginBottom);
+    }
   }
 
   blockquote {


### PR DESCRIPTION
Close #1841 

@mcoker not sure how you expected this to go, `<small>` was already added to lines 117 - 130 but the small element already has a margin bottom set, so I just added in the last-child selector there. 