### PR TITLE
fix(switch): add focus indicator

### DIFF
--- a/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
+++ b/src/patternfly/components/Switch/examples/switch-no-label-example.hbs
@@ -5,7 +5,8 @@
     {{#> switch-toggle-icon}}{{/switch-toggle-icon}}
   {{/switch-toggle}}
 {{/switch}}
-
+<br/>
+<br/>
 {{#> switch switch--attribute='for="switch-with-icon-2"'}}
   {{#> switch-input id="switch-with-icon-2" switch-input--attribute='name="switchExample4"'}}{{/switch-input}}
   {{#> switch-toggle}}

--- a/src/patternfly/components/Switch/switch.scss
+++ b/src/patternfly/components/Switch/switch.scss
@@ -12,6 +12,9 @@
   --pf-c-switch__input--disabled__label--Color: var(--pf-global--disabled-color--100);
   --pf-c-switch__input--disabled__toggle--BackgroundColor: var(--pf-global--Color--dark-200);
   --pf-c-switch__input--disabled__toggle--before--BackgroundColor: var(--pf-global--disabled-color--200);
+  --pf-c-switch__input--focus__toggle--OutlineWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-switch__input--focus__toggle--OutlineOffset: var(--pf-global--spacer--sm);
+  --pf-c-switch__input--focus__toggle--OutlineColor: var(--pf-global--primary-color--100);
 
   // Switch toggle
   --pf-c-switch__toggle--BackgroundColor: var(--pf-global--disabled-color--200);
@@ -48,6 +51,11 @@
     position: absolute;
     cursor: pointer;
     opacity: 0;
+
+    &:focus ~ .pf-c-switch__toggle {
+      outline: var(--pf-c-switch__input--focus__toggle--OutlineWidth) solid var(--pf-c-switch__input--focus__toggle--OutlineColor);
+      outline-offset: var(--pf-c-switch__input--focus__toggle--OutlineOffset);
+    }
 
     /* stylelint-disable */
     &:checked {


### PR DESCRIPTION
This adds a focus indicator to the switch component. 
After discussion with @mceledonia, we'll go with a 2px #06C border, 8 px from the edge, but no fill. This allows us to use the outline property rather than creating a pseudo-element, which would have potentially caused z-index problems.

Fixes #1824