### PR TITLE
feat(ie11): add ie11 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - npm run lint:styles
   - npm run build-ghpages
   - npm run build-patternfly
+  - npm run build:ie11
 
 after_success:
   - ./build/deploy.sh

--- a/build/npm-scripts/ie-conversion-utils.js
+++ b/build/npm-scripts/ie-conversion-utils.js
@@ -102,7 +102,7 @@ function transform(stylesheet, globalsStylesheetPath, excludeBase) {
 /**
  * Constructs an array of stylesheets to be processed, in an optimal order for post-processing
  * @param basePfCssGlob: a fileGlob pattern that selects patternfly stylesheet we want to include
- * @example { 'myEndpoint': '/exployees/list/{role}/{name}' }
+ * @example { 'myEndpoint': '/Path/to/patternfly-next/dist/{components,layouts,utilities}/**.css' }
  * @param excludes: an array of stylesheets to exclude, use the Uppercase directory name
  * @example ['Table', 'Stack', 'BoxShadow']
  * @param appStylesheets: an array of paths to stylesheets to append, comes last in the cascade

--- a/build/npm-scripts/ie-convert-all.js
+++ b/build/npm-scripts/ie-convert-all.js
@@ -14,7 +14,12 @@ getStylesheetPaths(pfStylesheetsGlob, [], [])
     }, '')
   )
   .then(concatCss => transform(concatCss, patternflyBasePath))
-  .then(transformedCss => transformedCss.replace(/\.\.\/\.\.\/assets/gm, './assets'))
+  .then(transformedCss => {
+    if (transformedCss.indexOf('undefined') >= 0) {
+      throw new Error('Stylesheet contains undefined');
+    }
+    return transformedCss.replace(/\.\.\/\.\.\/assets/gm, './assets');
+  })
   .then(ie11ReadyStylesheet => fs.writeFileSync(outPath, ie11ReadyStylesheet))
   .catch(error => {
     throw new Error(error);

--- a/build/npm-scripts/ie-convert-all.js
+++ b/build/npm-scripts/ie-convert-all.js
@@ -26,8 +26,9 @@ getStylesheetPaths(pfStylesheetsGlob, [], [])
   })
   .then(transformedCss => {
     transformedCss.split('\n').forEach((line, index) => {
+      console.error(`\x1b[31m%s\x1b[0m`, `Problem in ${outPath}:${index + 1}\n`);
       if (line.indexOf('undefined') >= 0) {
-        throw new Error(`Stylesheet contains undefined at line ${index + 1}`);
+        throw new Error(`Stylesheet ${outPath} contains undefined at line ${index + 1}`);
       }
     });
     return transformedCss.replace(/\.\.\/\.\.\/assets/gm, './assets');

--- a/build/npm-scripts/ie-convert-all.js
+++ b/build/npm-scripts/ie-convert-all.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const fs = require('fs');
+const { getStylesheetPaths, transform } = require('./ie-conversion-utils');
+
+const pfStylesheetsGlob = path.resolve(__dirname, '../../dist/{components,layouts,utilities}/**/*.css');
+const patternflyBasePath = path.resolve(__dirname, '../../dist/patternfly-base.css');
+const outPath = path.resolve(__dirname, '../../dist/patternfly-ie11.css');
+
+getStylesheetPaths(pfStylesheetsGlob, [], [])
+  .then(files =>
+    files.reduce((acc, file) => {
+      acc += `${fs.readFileSync(file, 'utf8')}\n`;
+      return acc;
+    }, '')
+  )
+  .then(concatCss => transform(concatCss, patternflyBasePath))
+  .then(transformedCss => transformedCss.replace(/\.\.\/\.\.\/assets/gm, './assets'))
+  .then(ie11ReadyStylesheet => fs.writeFileSync(outPath, ie11ReadyStylesheet))
+  .catch(error => {
+    throw new Error(error);
+  });

--- a/build/npm-scripts/ie-convert-all.js
+++ b/build/npm-scripts/ie-convert-all.js
@@ -26,8 +26,8 @@ getStylesheetPaths(pfStylesheetsGlob, [], [])
   })
   .then(transformedCss => {
     transformedCss.split('\n').forEach((line, index) => {
-      console.error(`\x1b[31m%s\x1b[0m`, `Problem in ${outPath}:${index + 1}\n`);
       if (line.indexOf('undefined') >= 0) {
+        console.error(`\x1b[31m%s\x1b[0m`, `Problem in ${outPath}:${index + 1}\n`);
         throw new Error(`Stylesheet ${outPath} contains undefined at line ${index + 1}`);
       }
     });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:pficons": "node ./src/icons/generateIcons.js",
     "build:pficonfont": "gulp build-pficonfont",
     "build-ghpages": "gatsby build --prefix-paths",
+    "build:ie11": "node build/npm-scripts/ie-convert-all.js",
     "cli:setup": "cd build/patternfly-cli && npm install && cd ../../ && npm link ./build/patternfly-cli",
     "dev": "gatsby develop",
     "dev:expose": "gatsby develop -H 0.0.0.0",


### PR DESCRIPTION
Use existing conversion utilities to write `patternfly-ie.css` which contains all components + base styles.

Closes https://github.com/patternfly/patternfly-react/issues/2092