### PR TITLE
fix(table): media query matches border

### DIFF
--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -34,6 +34,9 @@
   // Responsive vars
   // ==================================================================
 
+  // Table
+  --pf-c-table--responsive--BorderColor: var(--pf-global--BorderColor--300);
+
   // Body
   --pf-c-table-tbody--responsive--MarginTop: var(--pf-global--spacer--xs);
   --pf-c-table-tbody--m-expanded--before--Top: var(--pf-global--spacer--sm);
@@ -107,10 +110,8 @@
   tbody {
     display: block;
 
-    @media screen and (max-width: $pf-global--breakpoint--sm) {
-      &:first-of-type {
-        border-top: var(--pf-c-table-tbody--responsive--BorderWidth) solid var(--pf-c-table--BorderColor);
-      }
+    &:first-of-type {
+      border-top: var(--pf-c-table-tbody--responsive--BorderWidth) solid var(--pf-c-table--responsive--BorderColor);
     }
   }
 
@@ -120,12 +121,8 @@
   }
 
   // Table row
-  tr {
-    @media screen and (max-width: $pf-global--breakpoint--sm) {
-      &:not(.pf-c-table__expandable-row) {
-        border-bottom-width: var(--pf-c-table-tr--responsive--BorderWidth);
-      }
-    }
+  tr:not(.pf-c-table__expandable-row) {
+    border-bottom: var(--pf-c-table-tr--responsive--BorderWidth) solid var(--pf-c-table--responsive--BorderColor);
   }
 
   // The last tr should always have a border width of 1px
@@ -135,20 +132,12 @@
   }
 
   tbody.pf-m-expanded {
-    @media screen and (max-width: $pf-global--breakpoint--xl) {
-      border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
-    }
-
-    @media screen and (max-width: $pf-global--breakpoint--xl) {
-      tr:not(.pf-c-table__expandable-row) {
-        border-bottom: 0;
-      }
+    tr:not(.pf-c-table__expandable-row) {
+      border-bottom: 0;
     }
 
     &:not(:last-of-type) {
-      @media screen and (max-width: $pf-global--breakpoint--sm) {
-        border-bottom: var(--pf-c-table-tbody--responsive--BorderWidth) solid var(--pf-c-table--BorderColor);
-      }
+      border-bottom: var(--pf-c-table-tbody--responsive--BorderWidth) solid var(--pf-c-table--responsive--BorderColor);
     }
   }
 

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -132,6 +132,8 @@
   }
 
   tbody.pf-m-expanded {
+    border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor);
+
     tr:not(.pf-c-table__expandable-row) {
       border-bottom: 0;
     }

--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -30,7 +30,7 @@ $pf-chart-color-purple-300: #5752d1 !default;
 $pf-chart-color-purple-400: #3c3d99 !default;
 $pf-chart-color-purple-500: #2a265f !default;
 
-// gold
+// yellow
 $pf-chart-color-gold-100: $pf-color-gold-100;
 $pf-chart-color-gold-200: $pf-color-gold-200;
 $pf-chart-color-gold-300: $pf-color-gold-300;
@@ -44,7 +44,7 @@ $pf-chart-color-orange-300: $pf-color-orange-300;
 $pf-chart-color-orange-400: $pf-color-orange-400;
 $pf-chart-color-orange-500: $pf-color-orange-500;
 
-// black
+// gray
 $pf-chart-color-black-100: $pf-color-black-300;
 $pf-chart-color-black-200: $pf-color-black-400;
 $pf-chart-color-black-300: $pf-color-black-500;

--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -30,7 +30,7 @@ $pf-chart-color-purple-300: #5752d1 !default;
 $pf-chart-color-purple-400: #3c3d99 !default;
 $pf-chart-color-purple-500: #2a265f !default;
 
-// yellow
+// gold
 $pf-chart-color-gold-100: $pf-color-gold-100;
 $pf-chart-color-gold-200: $pf-color-gold-200;
 $pf-chart-color-gold-300: $pf-color-gold-300;
@@ -44,7 +44,7 @@ $pf-chart-color-orange-300: $pf-color-orange-300;
 $pf-chart-color-orange-400: $pf-color-orange-400;
 $pf-chart-color-orange-500: $pf-color-orange-500;
 
-// gray
+// black
 $pf-chart-color-black-100: $pf-color-black-300;
 $pf-chart-color-black-200: $pf-color-black-400;
 $pf-chart-color-black-300: $pf-color-black-500;


### PR DESCRIPTION
fix #1823 

Fixes the table so that when the table breaks to grid form, the border width changes to 8px, and the border color matches the background color.

<img width="709" alt="Screen Shot 2019-06-03 at 3 48 32 PM" src="https://user-images.githubusercontent.com/20118816/58829944-18cd7a80-8617-11e9-83db-7ccdf5c29abd.png">
