### PR TITLE
fix(accordion): remove need for class on toggle icon

### DIFF
--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -54,6 +54,7 @@
 
   .pf-c-accordion__toggle {
     display: flex;
+    align-items: center;
     justify-content: space-between;
     width: 100%;
     padding: var(--pf-c-accordion__toggle--PaddingTop) var(--pf-c-accordion__toggle--PaddingRight) var(--pf-c-accordion__toggle--PaddingBottom) var(--pf-c-accordion__toggle--PaddingLeft);


### PR DESCRIPTION
Close #1887 

Follow up issue to remove the class on the icon: #1888
