### PR TITLE
fix(clipboardcopy): fix focus ring and add content editable to expanded

### DIFF
--- a/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
@@ -1,4 +1,4 @@
-<div class="pf-c-clipboard-copy__expandable-content{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
+<div contenteditable="true" class="pf-c-clipboard-copy__expandable-content{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
   {{#unless clipboard-copy--IsExpanded}}hidden{{/unless}}
   {{#if clipboard-copy-expandable-content--attribute}}
     {{{clipboard-copy-expandable-content--attribute}}}

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy-expandable-content.hbs
@@ -1,4 +1,4 @@
-<div contenteditable="true" class="pf-c-clipboard-copy__expandable-content{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
+<div class="pf-c-clipboard-copy__expandable-content{{#if clipboard-copy-expandable-content--modifier}} {{clipboard-copy-expandable-content--modifier}}{{/if}}"
   {{#unless clipboard-copy--IsExpanded}}hidden{{/unless}}
   {{#if clipboard-copy-expandable-content--attribute}}
     {{{clipboard-copy-expandable-content--attribute}}}

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -14,6 +14,7 @@
   --pf-c-clipboard-copy__group-toggle--focus--BorderBottomColor: var(--pf-global--active-color--100);
   --pf-c-clipboard-copy__group-toggle--m-expanded--BorderBottomWidth: var(--pf-global--BorderWidth--md);
   --pf-c-clipboard-copy__group-toggle--m-expanded--BorderBottomColor: var(--pf-global--active-color--100);
+  --pf-c-clipboard-copy__group-toggle--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
 
   // Clipboard copy copy
   --pf-c-clipboard-copy__group-copy--PaddingRight: var(--pf-global--spacer--md);
@@ -65,6 +66,7 @@
   padding-right: var(--pf-c-clipboard-copy__group-toggle--PaddingRight);
   padding-left: var(--pf-c-clipboard-copy__group-toggle--PaddingLeft);
   border: none;
+  outline-offset: var(--pf-c-clipboard-copy__group-toggle--OutlineOffset);
 
   &::before {
     position: absolute;

--- a/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
+++ b/src/patternfly/components/ClipboardCopy/clipboard-copy.scss
@@ -38,6 +38,7 @@
   --pf-c-clipboard-copy__expandable-content--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-clipboard-copy__expandable-content--BorderWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-clipboard-copy__expandable-content--BoxShadow: var(--pf-global--BoxShadow--md);
+  --pf-c-clipboard-copy__expandable-content--OutlineOffset: calc(-1 * var(--pf-global--spacer--xs));
 
   // Toggle button expanded
   &.pf-m-expanded .pf-c-clipboard-copy__group-toggle {
@@ -154,5 +155,6 @@
   background-color: var(--pf-c-clipboard-copy__expandable-content--BackgroundColor);
   background-clip: padding-box;
   border: var(--pf-c-clipboard-copy__expandable-content--BorderWidth) solid transparent;
+  outline-offset: var(--pf-c-clipboard-copy__expandable-content--OutlineOffset);
   box-shadow: var(--pf-c-clipboard-copy__expandable-content--BoxShadow);
 }

--- a/src/patternfly/components/ClipboardCopy/examples/clipboard-copy-expansion-example.hbs
+++ b/src/patternfly/components/ClipboardCopy/examples/clipboard-copy-expansion-example.hbs
@@ -1,14 +1,16 @@
+Editable
+<br>
 {{#> clipboard-copy clipboard-copy--id="3"}}
 	{{#> clipboard-copy-group}}
     {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-toggle}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
 	  {{/form-control}}
 	  {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-copy}}
 	{{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="content-' clipboard-copy--id '"')}}
-    Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}
 <br>
@@ -17,12 +19,44 @@
 	{{#> clipboard-copy-group}}
     {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-toggle}}
-    {{#> form-control controlType="input" form-control--attribute=(concat 'readonly type="text" value="Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+	  {{/form-control}}
+	  {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
+    {{/clipboard-copy-group-copy}}
+  {{/clipboard-copy-group}}
+  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'contenteditable="true" id="content-' clipboard-copy--id '"')}}
+    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+  {{/clipboard-copy-expandable-content}}
+{{/clipboard-copy}}
+<br>
+<br>
+Read-Only
+<br>
+{{#> clipboard-copy clipboard-copy--id="5"}}
+	{{#> clipboard-copy-group}}
+    {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
+    {{/clipboard-copy-group-toggle}}
+    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+	  {{/form-control}}
+	  {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
+    {{/clipboard-copy-group-copy}}
+	{{/clipboard-copy-group}}
+  {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="content-' clipboard-copy--id '"')}}
+    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+  {{/clipboard-copy-expandable-content}}
+{{/clipboard-copy}}
+<br>
+<br>
+{{#> clipboard-copy clipboard-copy--id="6" clipboard-copy--IsExpanded="true"}}
+	{{#> clipboard-copy-group}}
+    {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
+    {{/clipboard-copy-group-toggle}}
+    {{#> form-control controlType="input" form-control--attribute=(concat 'readonly type="text" value="This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
 	  {{/form-control}}
 	  {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-copy}}
   {{/clipboard-copy-group}}
   {{#> clipboard-copy-expandable-content clipboard-copy-expandable-content--attribute=(concat 'id="content-' clipboard-copy--id '"')}}
-    Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
+    This is an editable version of the Copy to Clipboard Component that has an expandable section. Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion.
   {{/clipboard-copy-expandable-content}}
 {{/clipboard-copy}}

--- a/src/patternfly/components/ClipboardCopy/examples/clipboard-copy-expansion-example.hbs
+++ b/src/patternfly/components/ClipboardCopy/examples/clipboard-copy-expansion-example.hbs
@@ -17,7 +17,7 @@
 	{{#> clipboard-copy-group}}
     {{#> clipboard-copy-group-toggle clipboard-copy-group-toggle--attribute=(concat 'id="toggle-' clipboard-copy--id '" aria-labelledby="toggle-' clipboard-copy--id ' text-input-' clipboard-copy--id '" aria-controls="content-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-toggle}}
-    {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" value="Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
+    {{#> form-control controlType="input" form-control--attribute=(concat 'readonly type="text" value="Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting expansion." id="text-input-' clipboard-copy--id '" aria-label="Copyable input"')}}
 	  {{/form-control}}
 	  {{#> clipboard-copy-group-copy clipboard-copy-group-copy--attribute=(concat 'id="copy-button-' clipboard-copy--id '" aria-labelledby="copy-button-' clipboard-copy--id ' text-input-' clipboard-copy--id '"')}}
     {{/clipboard-copy-group-copy}}


### PR DESCRIPTION
close #1764 

@srambach I know you were working on these focus rings. Do you think it looks odd for only one button to have a negative outline-offset. In tabs they aren't consistent so maybe this is fine for now...

<img width="757" alt="Screen Shot 2019-06-05 at 1 27 40 PM" src="https://user-images.githubusercontent.com/20118816/58976544-b77fe580-8795-11e9-95fb-4e7b62f5c88f.png">

@mceledonia the input field when the clipboardcopy component is expanded, is now "Read-Only" which means that to be consistent it takes on the gray background of our "Read-Only" form control. I can override the background-color to be white here like it was before. I dont know if that will have a usability problem as users may think it is editable. Was wondering what you thought?
