### PR TITLE
fix(zindex): reorder indexes and remove some.

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -2,7 +2,7 @@
   // Component variables
   --pf-c-about-modal-box--BackgroundColor: #{$pf-color-black-1000}; // Modal uses a non-standard background color
   --pf-c-about-modal-box--BoxShadow: 0 0 100px 0 rgba(255, 255, 255, .05);  // This is a special one-off glow for the about modal
-  --pf-c-about-modal-box--ZIndex: var(--pf-global--ZIndex--2xl);
+  --pf-c-about-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
   --pf-c-about-modal-box--Height: 100%;
   --pf-c-about-modal-box--lg--Height: #{pf-size-prem(762px)}; // Height is optimized for the exact height desired
   --pf-c-about-modal-box--lg--MaxHeight: calc(100% - var(--pf-global--spacer--xl)); // MaxHeight ensures that the modal will not go off the screen and instead the content will scroll
@@ -199,7 +199,6 @@
   grid-area: close;
   position: sticky;
   top: 0;
-  z-index: var(--pf-c-about-modal-box__close--ZIndex);
   display: flex;
   align-items: flex-start;
   justify-content: flex-end;

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -6,7 +6,7 @@
   --pf-c-app-launcher__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-app-launcher__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-app-launcher__menu--Top: calc(100% + var(--pf-global--spacer--xs));
-  --pf-c-app-launcher__menu--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-app-launcher__menu--ZIndex: var(--pf-global--ZIndex--sm);
 
   // Expanded
   --pf-c-app-launcher__toggle--PaddingTop: var(--pf-global--spacer--form-element);

--- a/src/patternfly/components/Backdrop/backdrop.scss
+++ b/src/patternfly/components/Backdrop/backdrop.scss
@@ -1,5 +1,5 @@
 .pf-c-backdrop {
-  --pf-c-backdrop--ZIndex: var(--pf-global--ZIndex--2xl);
+  --pf-c-backdrop--ZIndex: var(--pf-global--ZIndex--lg);
   --pf-c-backdrop--Color: var(--pf-global--BackgroundColor--dark-transparent-100);
   --pf-c-backdrop--BackdropFilter: blur(10px);
 

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -30,7 +30,7 @@
 
   // Menu
   --pf-c-context-selector__menu--Top: calc(100% + var(--pf-global--spacer--xs));
-  --pf-c-context-selector__menu--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-context-selector__menu--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-context-selector__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-context-selector__menu--BackgroundColor: var(--pf-global--BackgroundColor--light-100);
   --pf-c-context-selector__menu--BorderWidth: var(--pf-global--BorderWidth--sm);

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -128,7 +128,8 @@
     position: absolute;
     top: var(--pf-c-data-list__item--before--Top);
     left: 0;
-    z-index: var(--pf-c-data-list__item--before--ZIndex);
+
+    // z-index: var(--pf-c-data-list__item--before--ZIndex);
     width: var(--pf-c-data-list__item--before--Width);
     height: var(--pf-c-data-list__item--before--Height);
     content: "";

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -128,8 +128,6 @@
     position: absolute;
     top: var(--pf-c-data-list__item--before--Top);
     left: 0;
-
-    // z-index: var(--pf-c-data-list__item--before--ZIndex);
     width: var(--pf-c-data-list__item--before--Width);
     height: var(--pf-c-data-list__item--before--Height);
     content: "";

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -52,7 +52,7 @@
   --pf-c-dropdown__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-dropdown__menu--Top: calc(100% + var(--pf-global--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
-  --pf-c-dropdown__menu--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-dropdown__menu--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-dropdown--m-top__menu--Top: 0;
   --pf-c-dropdown--m-top__menu--Transform: translateY(calc(-100% - var(--pf-global--spacer--xs))); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -70,7 +70,6 @@ $pf-c-form-control__select--ViewBox: "320" !default;
   // This component always needs to be light
   @include pf-t-light;
 
-  position: relative;
   width: 100%;
   padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
   font-size: var(--pf-c-form-control--FontSize);

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -46,7 +46,6 @@
 
     &[aria-invalid="true"] {
       position: relative;
-      z-index: var(--pf-c-input-group--c-form-control--invalid--ZIndex);
 
       &:not(:last-child) {
         margin-right: var(--pf-c-input-group--c-form-control--MarginRight);

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -42,11 +42,7 @@
   /* stylelint-enable */
 
   .pf-c-form-control {
-    position: static;
-
     &[aria-invalid="true"] {
-      position: relative;
-
       &:not(:last-child) {
         margin-right: var(--pf-c-input-group--c-form-control--MarginRight);
       }

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -7,7 +7,7 @@
   --pf-c-modal-box--PaddingLeft: var(--pf-global--spacer--xl);
   --pf-c-modal-box--BorderSize: var(--pf-global--BorderWidth--sm);
   --pf-c-modal-box--BoxShadow: var(--pf-global--BoxShadow--lg);
-  --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--2xl);
+  --pf-c-modal-box--ZIndex: var(--pf-global--ZIndex--xl);
   --pf-c-modal-box--Width: 100%;
   --pf-c-modal-box--MaxWidth: calc(100% - var(--pf-global--spacer--xl)); // Ensure modal has gutters at full width
   --pf-c-modal-box--m-sm--sm--MaxWidth: #{pf-size-prem(560px)}; // MaxWidth is based on optimal line length for reading

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -178,7 +178,7 @@
 
   // Scroll button
   --pf-c-nav__scroll-button--Top: var(--pf-global--spacer--sm);
-  --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--md);
+  --pf-c-nav__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-nav__scroll-button--Width: var(--pf-global--spacer--xl);
   --pf-c-nav__scroll-button--Height: #{pf-size-prem(40px)};
   --pf-c-nav__scroll-button--PaddingRight: var(--pf-global--spacer--sm);

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -41,7 +41,7 @@
   --pf-c-options-menu__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-options-menu__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-options-menu__menu--Top: calc(100% + var(--pf-global--spacer--xs));
-  --pf-c-options-menu__menu--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-options-menu__menu--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-options-menu--m-top__menu--Top: 0;
   --pf-c-options-menu--m-top__menu--Transform: translateY(calc(-100% - var(--pf-global--spacer--xs))); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -74,7 +74,7 @@
   --pf-c-select__menu--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-select__menu--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-select__menu--Top: calc(100% + var(--pf-global--spacer--xs)); // The top of the menu must be pushed down to create space between the toggle and menu
-  --pf-c-select__menu--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-select__menu--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-select__menu--m-top--Transform: translateY(calc(-100% - var(--pf-global--spacer--xs))); // The "dropup" menu must be transformed up and this calculates how much to create space between the toggle and menu
 
   // Menu item

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -316,7 +316,8 @@
       top: 0;
       bottom: 0;
       left: 0;
-      z-index: 10;
+
+      // z-index: 10;
       width: var(--pf-c-table__expandable-row--before--Width);
       content: "";
     }

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -316,8 +316,6 @@
       top: 0;
       bottom: 0;
       left: 0;
-
-      // z-index: 10;
       width: var(--pf-c-table__expandable-row--before--Width);
       content: "";
     }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -220,8 +220,6 @@
       top: var(--pf-c-table__expandable-row--before--Top);
       bottom: var(--pf-c-table__expandable-row--before--Bottom);
       left: 0;
-
-      // z-index: var(--pf-c-table__expandable-row--before--ZIndex);
       width: var(--pf-c-table__expandable-row--before--Width);
       content: "";
 
@@ -335,8 +333,6 @@
       top: calc(var(--pf-c-table--BorderWidth) * -1);
       right: 0;
       left: 0;
-
-      // z-index: 999;
       content: "";
       border-top: var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderColor);
     }

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -220,7 +220,8 @@
       top: var(--pf-c-table__expandable-row--before--Top);
       bottom: var(--pf-c-table__expandable-row--before--Bottom);
       left: 0;
-      z-index: var(--pf-c-table__expandable-row--before--ZIndex);
+
+      // z-index: var(--pf-c-table__expandable-row--before--ZIndex);
       width: var(--pf-c-table__expandable-row--before--Width);
       content: "";
 
@@ -334,7 +335,8 @@
       top: calc(var(--pf-c-table--BorderWidth) * -1);
       right: 0;
       left: 0;
-      z-index: 999;
+
+      // z-index: 999;
       content: "";
       border-top: var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderWidth) solid var(--pf-c-table__compound-expansion-toggle--BorderTop--BorderColor);
     }

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -22,7 +22,7 @@
 
   // Scroll buttons
   --pf-c-tabs__scroll-button--Width: var(--pf-global--spacer--xl);
-  --pf-c-tabs__scroll-button--ZIndex: var(--pf-global--ZIndex--md);
+  --pf-c-tabs__scroll-button--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-tabs__scroll-button--m-secondary--hover--Color: var(--pf-global--active-color--100);
   --pf-c-tabs__scroll-button--m-secondary--hover--Color: var(--pf-global--active-color--100);
   --pf-c-tabs__scroll-button--m-secondary-right--m-start-current--Color: var(--pf-global--active-color--100);
@@ -137,7 +137,6 @@
 
   // Tab item current state
   &.pf-m-current .pf-c-tabs__button {
-    z-index: var(--pf-c-tabs__item--m-current--ZIndex);
     color: var(--pf-c-tabs__item--m-current--Color);
 
     &::before {

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -16,6 +16,7 @@
 
   // Header
   --pf-c-wizard__header--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
+  --pf-c-wizard__header--ZIndex: var(--pf-global--ZIndex--md);
   --pf-c-wizard__header--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-wizard__header--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-wizard__header--PaddingBottom: var(--pf-global--spacer--lg);
@@ -214,6 +215,7 @@
   @include pf-t-dark;
 
   position: relative;
+  z-index: var(--pf-c-wizard__header--ZIndex);
   padding: var(--pf-c-wizard__header--PaddingTop) var(--pf-c-wizard__header--PaddingRight) var(--pf-c-wizard__header--PaddingBottom) var(--pf-c-wizard__header--PaddingLeft);
   background-color: var(--pf-c-wizard__header--BackgroundColor);
 

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -70,7 +70,7 @@
 
   // Toggle
   --pf-c-wizard__toggle--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-wizard__toggle--ZIndex: var(--pf-global--ZIndex--sm);
+  --pf-c-wizard__toggle--ZIndex: var(--pf-global--ZIndex--md);
   --pf-c-wizard__toggle--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
   --pf-c-wizard__toggle--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-wizard__toggle--PaddingRight: var(--pf-global--spacer--md);
@@ -97,7 +97,7 @@
   --pf-c-wizard__toggle-icon--MarginTop: #{pf-size-prem(6px)};
 
   // Nav
-  --pf-c-wizard__nav--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-wizard__nav--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-wizard__nav--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-wizard__nav--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
   --pf-c-wizard__nav--lg--BoxShadow: var(--pf-global--BoxShadow--lg-right);
@@ -130,6 +130,9 @@
   // Outer wrap
   --pf-c-wizard__outer-wrap--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-wizard__outer-wrap--lg--PaddingLeft: var(--pf-c-wizard__nav--lg--Width);
+
+  // Main
+  --pf-c-wizard__main--ZIndex: var(--pf-global--ZIndex--xs);
 
   // Body
   --pf-c-wizard__main-body--PaddingTop: var(--pf-global--spacer--md);
@@ -452,6 +455,7 @@
 }
 
 .pf-c-wizard__main {
+  z-index: var(--pf-c-wizard__main--ZIndex);
   flex: 1 1 auto;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
Close #1668 

I've been testing the Z-Index Orders of our components at these code pens:
https://codepen.io/christiemolloyy/pen/PvvNqK
https://codepen.io/christiemolloyy/pen/eaazJz
https://codepen.io/christiemolloyy/pen/GaaLYZ
https://codepen.io/christiemolloyy/pen/yWWWGW


I was looking at a system for how we should assign Z-Indexes across the system: 

100 (xs): Reserved for order within elements in a component. Example: The buttons in the nav/tabs should sit above the other elements in the component.
200 (sm): Reserved for Menus that need to sit above components that are in the same order level. They need to sit above 100 order elements like scroll buttons.
300 (md): Reserved for the Page Header (the highest order within the page component)
400 (lg): Reserved for the Backdrop. It sits above all elements in the Page Component
500 (xl): Reserved for elements that "pop-up" above a backdrop. Example: the About Modal/Modal Box.
600 (2xl): Reserved for components with the highest order above every element. Example: Alert Toast Group and Skip to Content.

**These are the components with Z-Indexes:**
About Modal: was 600, now 500
Alert Group Toast: 600
App Launcher Menu: was 100,  now 200
Backdrop: was 600, now 400
BackgroundImage: -1
Context Selector Menu: was 100, now 200
Data List Item:before background-color: was 500 (REMOVED) **i dont think we need a z-index for this?**
Dropdown Menu: was 100, now 200
Input Group Form Control Invalid: was 100 (REMOVED) ** does anyone know why this was here?**
Modal Box: was 600, change to 500
Nav Scroll Buttons: was 300, now 100
Options Menu Menu: was 100, now 200
Page Header: 300
Page Sidebar: 200
Page Main: 100
Select Menu Menu: was 100, now 200
Skip to Content: 600
Table tbody::before (grid): 10 (REMOVE)
Table tbody::before: 200 (REMOVE)
Tabs Scroll Button: was 300, now 100
Wizard Toggle: 200
Wizard Side Nav: 100
