### PR TITLE
fix(aboutmodalbox): add word break to content

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -188,7 +188,7 @@
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 
-  > * {
+  * {
     word-break: break-all;
   }
 

--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -188,6 +188,10 @@
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 
+  > * {
+    word-break: break-all;
+  }
+
   @media screen and (min-width: $pf-global--breakpoint--sm) {
     overflow: visible;
     overscroll-behavior: auto;


### PR DESCRIPTION
fix #1784 

Longs strings of words now break in the content section in the About Modal.

<img width="390" alt="Screen Shot 2019-06-06 at 10 46 49 AM" src="https://user-images.githubusercontent.com/20118816/59043662-a47b1d00-884a-11e9-9f53-0338c15ab31b.png">
