### PR TITLE
chore(a11y): use tablet viewport size when auditing

### DIFF
--- a/src/patternfly/components/Toolbar/examples/toolbar-expanded-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-expanded-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-button') aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
   {{/button}}
   {{#> toolbar-filter}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-checked-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-checked-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-button') aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
     {{#> badge badge--modifier="pf-m-read"}}3{{/badge}}
   {{/button}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-filter-expanded-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-dropdown-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-dropdown-button')  aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
   {{/button}}
   {{#> toolbar-filter}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-checked-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-checked-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-button') aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle pf-m-expanded" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle pf-m-expanded" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
     {{#> badge badge--modifier="pf-m-read"}}3{{/badge}}
   {{/button}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-mobile-filter-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-button') aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle pf-m-expanded" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle pf-m-expanded" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
   {{/button}}
   {{#> toolbar-filter toolbar-filter--modifier="pf-m-expanded"}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-pagination-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-pagination-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-button')  aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
   {{/button}}
   {{#> toolbar-filter}}

--- a/src/patternfly/components/Toolbar/examples/toolbar-simple-example.hbs
+++ b/src/patternfly/components/Toolbar/examples/toolbar-simple-example.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-simple-example-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-simple-example-button')  aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
   {{/button}}
   {{#> toolbar-filter}}

--- a/src/patternfly/components/Wizard/wizard-toggle.hbs
+++ b/src/patternfly/components/Wizard/wizard-toggle.hbs
@@ -1,4 +1,4 @@
-<button class="pf-c-wizard__toggle{{#if wizard--IsExpanded}} pf-m-expanded{{/if}}{{#if wizard-toggle--modifier}} {{wizard-toggle--modifier}}{{/if}}"
+<button aria-label="Wizard Header Toggle" class="pf-c-wizard__toggle{{#if wizard--IsExpanded}} pf-m-expanded{{/if}}{{#if wizard-toggle--modifier}} {{wizard-toggle--modifier}}{{/if}}"
   aria-expanded="{{#if wizard--IsExpanded}}true{{else}}false{{/if}}"
   {{#if wizard-toggle--attribute}}
     {{{wizard-toggle--attribute}}}

--- a/src/patternfly/demos/CardView/card-view-demo-toolbar.hbs
+++ b/src/patternfly/demos/CardView/card-view-demo-toolbar.hbs
@@ -3,7 +3,7 @@
     {{> dropdown-toggle-check dropdown-toggle-check--id=(concat toolbar--id '-split-button-dropdown-simple-example-check') aria-label="Select all"}}
     {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id=(concat toolbar--id '-split-button-dropdown-simple-example-button')  aria-label="Select"}}
   {{/dropdown}}
-  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" aria-label="Filter results"}}
+  {{#> button button--modifier="pf-m-plain pf-c-toolbar__filter-toggle" button--attribute='aria-label="Filter results"'}}
     <i class="fas fa-filter" aria-hidden="true"></i>
   {{/button}}
   {{#> toolbar-filter}}

--- a/test-a11y/config.js
+++ b/test-a11y/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  toleranceThreshold: 6,
+  toleranceThreshold: 5,
   host: 'localhost',
   port: '8000',
   protocol: 'http',

--- a/test-a11y/config.js
+++ b/test-a11y/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  toleranceThreshold: 5,
+  toleranceThreshold: 3,
   host: 'localhost',
   port: '8000',
   protocol: 'http',

--- a/test-a11y/index.js
+++ b/test-a11y/index.js
@@ -17,7 +17,7 @@ let chromeOptions = {};
 if (process.env.CI) {
   chromeOptions = { args: ['--headless'] };
 } else {
-  chromeOptions = { args: ['--start-maximized', '--incognito'] };
+  chromeOptions = { args: ['--incognito', '--window-size=768,1024'] };
 }
 
 const chromeCapabilities = selenium.Capabilities.chrome();


### PR DESCRIPTION
This PR updates the window size used for the browser that our a11y audit is run against. I've noticed for a while that we get more errors reported on CI that we do locally, was about to file a bug when I realized using a smaller than "maximized" size causes the audit to produce consistent results across both local and CI. We've been wanting to start testing smaller viewports anyway, as many components change in appearance and behavior at smaller dimensions. So, here we use the size of an iPad in portrait orientation.

Should help close; https://github.com/patternfly/patternfly-next/issues/1602 and https://github.com/patternfly/patternfly-next/issues/1906