### PR TITLE
fix(nav): change breakpoint to fix bug

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -240,7 +240,7 @@
     min-width: 0;
 
     .pf-c-nav__scroll-button {
-      @media screen and (max-width: 991px) {
+      @media screen and (max-width: #{$pf-global--breakpoint--lg - 1}) {
         top: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--Top);
         background-color: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor);
       }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -240,7 +240,7 @@
     min-width: 0;
 
     .pf-c-nav__scroll-button {
-      @media screen and (max-width: $pf-global--breakpoint--lg) {
+      @media screen and (max-width: 991px) {
         top: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--Top);
         background-color: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor);
       }


### PR DESCRIPTION
fix #1917 

When I remove 1px from the breakpoint it fixes the issue of `top: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--Top);` and `background-color: var(--pf-c-page__header-nav--c-nav__scroll-button--lg--BackgroundColor);` being assigned too early and causing a bug.

This also fixes the nav background-color changing to transparent before it is used for the background color of the scroll buttons.

I think its happening because the grid in the header nav changes at a minimum breakpoint of lg, and these assignments are happening at a maximum breakpoint of lg, although I can't fully pinpoint the issue. @mcoker wondering if you have any insight into this?