### PR TITLE
fix(applauncher): use icon var for icon height/width

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -31,8 +31,8 @@
 
   // Menu item icon
   --pf-c-app-launcher__menu-item-icon--MarginRight: var(--pf-global--spacer--sm);
-  --pf-c-app-launcher__menu-item-icon--Width: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md));
-  --pf-c-app-launcher__menu-item-icon--Height: calc(var(--pf-global--FontSize--md) * var(--pf-global--LineHeight--md));
+  --pf-c-app-launcher__menu-item-icon--Width: var(--pf-global--icon--FontSize--lg);
+  --pf-c-app-launcher__menu-item-icon--Height: var(--pf-global--icon--FontSize--lg);
 
   // Menu item external icon
   --pf-c-app-launcher__menu-item-external-icon--Color: var(--pf-global--link--Color);

--- a/src/patternfly/components/AppLauncher/examples/index.js
+++ b/src/patternfly/components/AppLauncher/examples/index.js
@@ -23,7 +23,7 @@ export default props => {
       <Example heading="App launcher collapsed" handlebars={AppLauncherCollapsedExampleRaw}>
         {AppLauncherCollapsedExample}
       </Example>
-      <Example heading="App launcher expanded" handlebars={AppLauncherExpandedExampleRaw} minHeight="28em">
+      <Example heading="App launcher expanded" handlebars={AppLauncherExpandedExampleRaw} minHeight="15em">
         {AppLauncherExpandedExample}
       </Example>
       <Example


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1934

also updates workspace example height