### PR TITLE
fix(form): add element for form label text, make it bold

### DIFF
--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -8,6 +8,7 @@
 | `id="{helper_text_id}"` | `.pf-c-form__helper-text` | Form fields with related `.pf-c-form__helper-text` require this attribute. Usage `<p class="pf-c-form__helper-text" id="{helper_text_id}">`.  |
 | `aria-describedby="{helper_text_id}"` | `<input>`, `<select>`, `<textarea>` | Form fields with related `.pf-c-form__helper-text` require this attribute. Usage `<input aria-describedby="{helper_text_id}">`.  |
 | `aria-invalid="true" aria-describedby="{helper_text_id}"` | `<input>`, `<select>`, `<textarea>` |  When form validation fails `aria-describedby` is used to communicate the error to the user. These attributes need to be handled with Javascript so that `aria-describedby` only references help text that explains the error, and so that `aria-invalid="true"` is only present when validation fails. For proper styling of errors `aria-invalid="true"` is required. |
+| `aria-hidden="true"` | `.pf-c-form__label-required` |  Hides the required indicator from assistive technologies. |
 
 
 ## Usage
@@ -16,7 +17,9 @@
 | -- | -- | -- |
 | `.pf-c-form` | `<form>` |  Initiates a standard form. **Required** |
 | `.pf-c-form__label` | `<label>` |  Initiates a form label. **Required** |
-| `.pf-c-form__helper-text` | `<p>` |  Initiates a form helper text block. |
+| `.pf-c-form__label-text` | `<span>` |  Initiates a form label text. **Required** |
+| `.pf-c-form__label-required` | `<span>` |  Initiates a form label required indicator. |
+| `.pf-c-form__helper-text` | `<span>` |  Initiates a form helper text block. |
 | `.pf-c-form__group` | `<div>` |  Wraps form fields `<label>` + `<field>` + `.form-helper-text`. |
 | `.pf-c-form__horizontal-group` | `<div>`| Wraps `.pf-c-form-control` when using `.pf-m-horizontal` on `.pf-c-form` to provide proper spacing for longer labels. |
 | `.pf-c-form__actions` | `<div>` | Iniates a row of actions. |

--- a/src/patternfly/components/Form/examples/form-help-text-example.hbs
+++ b/src/patternfly/components/Form/examples/form-help-text-example.hbs
@@ -11,7 +11,7 @@
   {{/form-group}}
   {{#> form-group}}
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-simple-form-address"') required='true'}}
-      address
+      Address
     {{/form-label}}
     {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'required type="text" id="' form--id '-simple-form-address" name="' form--id '-simple-form-address" aria-invalid="true" aria-describedby="' form--id '-simple-form-address-helper"')}}
     {{/form-control}}

--- a/src/patternfly/components/Form/form-label-text.hbs
+++ b/src/patternfly/components/Form/form-label-text.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-form__label-text{{#if form-label-text--modifier}} {{form-label-text--modifier}}{{/if}}"
+  {{#if form-label-text--attribute}}
+    {{{form-label-text--attribute}}}
+  {{/if}}>
+    {{>@partial-block}}
+</span>

--- a/src/patternfly/components/Form/form-label.hbs
+++ b/src/patternfly/components/Form/form-label.hbs
@@ -2,7 +2,9 @@
   {{#if form-label--attribute}}
     {{{form-label--attribute}}}
   {{/if}}>
-  {{>@partial-block}}
+  {{#> form-label-text}}
+    {{>@partial-block}}
+  {{/form-label-text}}
   {{#if required}}
     <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
   {{/if}}

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -10,6 +10,9 @@
   --pf-c-form__label--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-form__label--m-disabled--Color: var(--pf-global--disabled-color--100);
 
+  // Label text
+  --pf-c-form__label-text--FontWeight: var(--pf-global--FontWeight--bold);
+
   // Required labels
   --pf-c-form__label-required--MarginLeft: var(--pf-global--spacer--xs);
   --pf-c-form__label-required--FontSize: var(--pf-global--FontSize--sm);
@@ -132,6 +135,10 @@
   &.pf-m-disabled:hover {
     cursor: not-allowed;
   }
+}
+
+.pf-c-form__label-text {
+  font-weight: var(--pf-c-form__label-text--FontWeight);
 }
 
 .pf-c-form__label-required {


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1943

per @kybaker & @mceledonia only the label text should be bold, not the icons or anything else that a user might add. So added an element to target the label text and make that bold. Should look like 

<img width="446" alt="Screen Shot 2019-06-19 at 10 16 06 AM" src="https://user-images.githubusercontent.com/35148959/59780285-6553bf80-927f-11e9-9b32-a75e84d240e6.png">
