### PR TITLE
docs(dropdown): increase height of examples that overflow

### DIFF
--- a/src/patternfly/components/Dropdown/examples/index.js
+++ b/src/patternfly/components/Dropdown/examples/index.js
@@ -73,7 +73,7 @@ export default (props) => {
       <Example className="is-expanded-dropdown" heading="Split button" handlebars={DropdownSplitButtonRaw}>
         {dropdownSplitButton}
       </Example>
-      <Example minHeight="25em" heading="Dropdown with groups" handlebars={DropdownGroupsRaw}>
+      <Example className="is-extra-tall-body" heading="Dropdown with groups" handlebars={DropdownGroupsRaw}>
         {dropdownGroups}
       </Example>
       <Example className="is-expanded-dropdown" heading="Dropdown panel" handlebars={DropdownPanelRaw} docs={DropdownPanelDoc}>

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -411,7 +411,7 @@ html {
 .is-expanded-dropdown,
 .is-tall-body {
   .Preview__body {
-    height: 17em;
+    height: 20em;
   }
 }
 
@@ -423,7 +423,7 @@ html {
 
 .is-expanded-top {
   .Preview__body {
-    padding-top: 14em;
+    padding-top: 17em;
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1891