### PR TITLE
feat(card): add compact variation

### DIFF
--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -4,6 +4,7 @@
   --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--sm);
   --pf-c-card--m-hoverable--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
   --pf-c-card--m-compact__body--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-card--m-compact__footer--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-card--m-compact--first-child--PaddingTop: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingRight: var(--pf-global--spacer--md);
   --pf-c-card--m-compact--child--PaddingBottom: var(--pf-global--spacer--md);
@@ -15,7 +16,7 @@
   --pf-c-card--child--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-global--spacer--md);
   --pf-c-card__body--FontSize: var(--pf-global--FontSize--md);
-  --pf-c-card__footer--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-card__footer--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-card__actions--child--MarginLeft: var(--pf-global--spacer--sm);
 
@@ -32,10 +33,12 @@
 
   &.pf-m-compact {
     --pf-c-card__body--FontSize: var(--pf-c-card--m-compact__body--FontSize);
+    --pf-c-card__footer--FontSize: var(--pf-c-card--m-compact__footer--FontSize);
     --pf-c-card--first-child--PaddingTop: var(--pf-c-card--m-compact--first-child--PaddingTop);
     --pf-c-card--child--PaddingRight: var(--pf-c-card--m-compact--child--PaddingRight);
     --pf-c-card--child--PaddingBottom: var(--pf-c-card--m-compact--child--PaddingBottom);
     --pf-c-card--child--PaddingLeft: var(--pf-c-card--m-compact--child--PaddingLeft);
+    --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-c-card--m-compact__header--not-last-child--PaddingBottom);
   }
 }
 

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -3,12 +3,18 @@
   --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-card--BoxShadow: var(--pf-global--BoxShadow--sm);
   --pf-c-card--m-hoverable--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-card--m-compact__body--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-card--m-compact--first-child--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-card--m-compact--child--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-card--m-compact--child--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-card--m-compact--child--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-card--m-compact__header--not-last-child--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-card--first-child--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingBottom: var(--pf-global--spacer--lg);
   --pf-c-card--child--PaddingLeft: var(--pf-global--spacer--lg);
   --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-card__body--FontSize: var(--pf-global--FontSize--sm);
+  --pf-c-card__body--FontSize: var(--pf-global--FontSize--md);
   --pf-c-card__footer--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-card__actions--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-card__actions--child--MarginLeft: var(--pf-global--spacer--sm);
@@ -22,6 +28,14 @@
     &:hover {
       box-shadow: var(--pf-c-card--m-hoverable--hover--BoxShadow);
     }
+  }
+
+  &.pf-m-compact {
+    --pf-c-card__body--FontSize: var(--pf-c-card--m-compact__body--FontSize);
+    --pf-c-card--first-child--PaddingTop: var(--pf-c-card--m-compact--first-child--PaddingTop);
+    --pf-c-card--child--PaddingRight: var(--pf-c-card--m-compact--child--PaddingRight);
+    --pf-c-card--child--PaddingBottom: var(--pf-c-card--m-compact--child--PaddingBottom);
+    --pf-c-card--child--PaddingLeft: var(--pf-c-card--m-compact--child--PaddingLeft);
   }
 }
 

--- a/src/patternfly/components/Card/docs/code.md
+++ b/src/patternfly/components/Card/docs/code.md
@@ -12,6 +12,6 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
 | `.pf-c-card__head` | `<div>` | Creates the head of the card where images or actions can go. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
-| `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component, that involves smaller font sizes and spacing. |
+| `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
-| `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover` |
+| `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |

--- a/src/patternfly/components/Card/docs/code.md
+++ b/src/patternfly/components/Card/docs/code.md
@@ -1,6 +1,6 @@
 ## Overview
 
-A card is a generic rectangular container that can be used to build other components.
+A card is a generic rectangular container that can be used to build other components. Use a default card for regular page content and the compact variation for dashboard or small cards.
 
 ## Usage
 
@@ -12,5 +12,6 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
 | `.pf-c-card__head` | `<div>` | Creates the head of the card where images or actions can go. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
+| `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component, that involves smaller font sizes and spacing. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover` |

--- a/src/patternfly/components/Card/examples/card-compact-example.hbs
+++ b/src/patternfly/components/Card/examples/card-compact-example.hbs
@@ -1,0 +1,11 @@
+{{#> card card--modifier="pf-m-compact"}}
+  {{#> card-header}}
+    Header
+  {{/card-header}}
+  {{#> card-body}}
+    Body
+  {{/card-body}}
+  {{#> card-footer}}
+    Footer
+  {{/card-footer}}
+{{/card}}

--- a/src/patternfly/components/Card/examples/index.js
+++ b/src/patternfly/components/Card/examples/index.js
@@ -7,6 +7,7 @@ import CardNoHeaderExampleRaw from '!raw!./card-no-header-example.hbs';
 import CardContentOnlyExampleRaw from '!raw!./card-content-only-example.hbs';
 import CardMultipleBodyExampleRaw from '!raw!./card-multiple-body-example.hbs';
 import CardFillExampleRaw from '!raw!./card-no-fill-example.hbs';
+import CardCompactExampleRaw from '!raw!./card-compact-example.hbs';
 import CardHoverExampleRaw from '!raw!./card-hover-example.hbs';
 import CardImgActionRaw from '!raw!./card-img-action.hbs';
 import docs from '../docs/code.md';
@@ -16,18 +17,20 @@ import CardNoHeaderExample from './card-no-header-example.hbs';
 import CardContentOnlyExample from './card-content-only-example.hbs';
 import CardMultipleBodyExample from './card-multiple-body-example.hbs';
 import CardFillExample from './card-no-fill-example.hbs';
+import CardCompactExample from './card-compact-example.hbs';
 import CardHoverExample from './card-hover-example.hbs';
 import CardImgActionExample from './card-img-action.hbs';
 
 export const Docs = docs;
 
-export default (props) => {
+export default props => {
   const cardBasicExample = CardBasicExample();
   const cardNoFooterExample = CardNoFooterExample();
   const cardNoHeaderExample = CardNoHeaderExample();
   const cardContentOnlyExample = CardContentOnlyExample();
   const cardMultipleBodyExample = CardMultipleBodyExample();
   const cardFillExample = CardFillExample();
+  const cardCompactExample = CardCompactExample();
   const cardHoverExample = CardHoverExample();
   const cardImgActionExample = CardImgActionExample();
   const headingText = 'Card';
@@ -60,6 +63,9 @@ export default (props) => {
         className="is-height-flex-column-grow"
       >
         {cardFillExample}
+      </Example>
+      <Example heading="Card compact example" handlebars={CardCompactExampleRaw}>
+        {cardCompactExample}
       </Example>
       <Example heading="Card hover example" handlebars={CardHoverExampleRaw}>
         {cardHoverExample}

--- a/src/patternfly/demos/CardView/card-view-demo-template-gallery.hbs
+++ b/src/patternfly/demos/CardView/card-view-demo-template-gallery.hbs
@@ -1,5 +1,5 @@
 {{#> gallery gallery--modifier="pf-m-gutter"}}
-    {{#> card card--id="card-1" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-1" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/pf-logo-small.svg" alt="Logo">
         {{#> card-actions}}
@@ -18,7 +18,7 @@
           PatternFly is a community project that promotes design commonality and improves user experience.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-2" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-2" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/activemq-core_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -37,7 +37,7 @@
         The ActiveMQ component allows messages to be sent to a JMS Queue or Topic; or messages to be consumed from a JMS Queue or Topic using Apache ActiveMQ.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-3" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-3" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/camel-spark_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -56,7 +56,7 @@
         This documentation page covers the Apache Spark component for the Apache Camel.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-4" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-4" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/camel-avro_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -75,7 +75,7 @@
         This component provides a dataformat for avro, which allows serialization and deserialization of messages using Apache Avro’s binary dataformat. Moreover, it provides support for Apache Avro’s rpc, by providing producers and consumers endpoint for using avro over netty or http.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-5" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-5" card--modifier="pf-m-hoverable pf-m-compact"}}
     {{#> card-head}}
       <img src="/assets/images/FuseConnector_Icons_AzureServices.png" width="60px" alt="Logo">
       {{#> card-actions}}
@@ -94,7 +94,7 @@
       The Camel Components for Windows Azure Services provide connectivity to Azure services from Camel.
     {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-6" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-6" card--modifier="pf-m-hoverable pf-m-compact"}}
     {{#> card-head}}
         <img src="/assets/images/camel-saxon_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -113,7 +113,7 @@
       For providing flexible endpoints to sign and verify exchanges using the Signature Service of the Java Cryptographic Extension.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-7" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-7" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/camel-dropbox_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -132,7 +132,7 @@
         The dropbox: component allows you to treat Dropbox remote folders as a producer or consumer of messages.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-8" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-8" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/camel-infinispan_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -151,7 +151,7 @@
         Read or write to a fully-supported distributed cache and data grid for faster integration services.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-9" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-9" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/FuseConnector_Icons_REST.png" width="60px" alt="Logo">
         {{#> card-actions}}
@@ -171,7 +171,7 @@
         From Camel 2.18 onwards the rest component can also be used as a client (producer) to call REST services.
       {{/card-body}}
     {{/card}}
-    {{#> card card--id="card-10" card--modifier="pf-m-hoverable"}}
+    {{#> card card--id="card-10" card--modifier="pf-m-hoverable pf-m-compact"}}
       {{#> card-head}}
         <img src="/assets/images/camel-swagger-java_200x150.png" width="60px" alt="Logo">
         {{#> card-actions}}


### PR DESCRIPTION
closes #1946 

@mceledonia  @gdoyle1 should the font-size in the header still be 16px for the compact card?
<img width="470" alt="Screen Shot 2019-06-25 at 4 10 19 PM" src="https://user-images.githubusercontent.com/20118816/60130168-b888af00-9764-11e9-9e5a-3764a39d8dc3.png">

Here is how the card view demo looks using the compact card:
<img width="936" alt="Screen Shot 2019-06-25 at 4 16 39 PM" src="https://user-images.githubusercontent.com/20118816/60130213-d0603300-9764-11e9-9172-2e35d910e6fa.png">


