### PR TITLE
fix(expandable): add type to the button

### DIFF
--- a/src/patternfly/components/Button/button.hbs
+++ b/src/patternfly/components/Button/button.hbs
@@ -1,4 +1,11 @@
 <button class="pf-c-button{{#if button--modifier}} {{button--modifier}}{{/if}}"
+  {{#if button--IsSubmit}} 
+    type="submit"
+  {{else if button--IsReset}}
+    type="reset"
+  {{else}}
+    type="button"
+  {{/if}}
   {{#if button--attribute}}
     {{{button--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -5,6 +5,9 @@ Always add a modifier class to add color to the button.
 ## Button vs link
 Semantic buttons and links are important for usability as well as accessibility. Using an `a` instead of a `button` element to perform user initiated actions should be avoided, unless absolutely necessary.
 
+## Button Types
+The default type for a button is button, which must be set to avoid having a button in a form incorrectly default to type "submit". If a button is used in a submit form, the type should be set to "submit". If a button is used to reset a form, the type should be set to "reset".
+
 ## Accessibility
 
 | Attribute | Applied to | Outcome |

--- a/src/patternfly/components/Button/docs/code.md
+++ b/src/patternfly/components/Button/docs/code.md
@@ -5,9 +5,6 @@ Always add a modifier class to add color to the button.
 ## Button vs link
 Semantic buttons and links are important for usability as well as accessibility. Using an `a` instead of a `button` element to perform user initiated actions should be avoided, unless absolutely necessary.
 
-## Button Types
-The default type for a button is button, which must be set to avoid having a button in a form incorrectly default to type "submit". If a button is used in a submit form, the type should be set to "submit". If a button is used to reset a form, the type should be set to "reset".
-
 ## Accessibility
 
 | Attribute | Applied to | Outcome |

--- a/src/patternfly/components/Button/examples/button-types-example.hbs
+++ b/src/patternfly/components/Button/examples/button-types-example.hbs
@@ -1,24 +1,11 @@
+{{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
+  Submit Button
+{{/button}}
+
+{{#> button button--modifier="pf-m-primary" button--IsReset="true"}}
+  Reset Button
+{{/button}}
+
 {{#> button button--modifier="pf-m-primary"}}
-  Primary
-{{/button}}
-{{#> button button--modifier="pf-m-secondary"}}
-  Secondary
-{{/button}}
-{{#> button button--modifier="pf-m-tertiary"}}
-  Tertiary
-{{/button}}
-{{#> button button--modifier="pf-m-danger"}}
-  Danger
-{{/button}}
-{{#> button button--modifier="pf-m-link"}}
-  {{#> button-icon}}
-      <i class="fas fa-plus-circle" aria-hidden="true"></i>
-  {{/button-icon}}
-  Link button
-{{/button}}
-{{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
-  <i class="fas fa-times" aria-hidden="true"></i>
-{{/button}}
-{{#> button button--modifier="pf-m-inline pf-m-link"}}
-  Inline link button
+  Default Button
 {{/button}}

--- a/src/patternfly/components/Button/examples/button-variations-example.hbs
+++ b/src/patternfly/components/Button/examples/button-variations-example.hbs
@@ -1,0 +1,24 @@
+{{#> button button--modifier="pf-m-primary"}}
+  Primary
+{{/button}}
+{{#> button button--modifier="pf-m-secondary"}}
+  Secondary
+{{/button}}
+{{#> button button--modifier="pf-m-tertiary"}}
+  Tertiary
+{{/button}}
+{{#> button button--modifier="pf-m-danger"}}
+  Danger
+{{/button}}
+{{#> button button--modifier="pf-m-link"}}
+  {{#> button-icon}}
+      <i class="fas fa-plus-circle" aria-hidden="true"></i>
+  {{/button-icon}}
+  Link button
+{{/button}}
+{{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}
+  <i class="fas fa-times" aria-hidden="true"></i>
+{{/button}}
+{{#> button button--modifier="pf-m-inline pf-m-link"}}
+  Inline link button
+{{/button}}

--- a/src/patternfly/components/Button/examples/index.js
+++ b/src/patternfly/components/Button/examples/index.js
@@ -1,30 +1,33 @@
 import React from 'react';
 import Documentation from '@siteComponents/Documentation';
 import Example from '@siteComponents/Example';
-import ButtonTypesTemplateRaw from '!raw!./button-types-example.hbs';
+import ButtonVariationTemplateRaw from '!raw!./button-variations-example.hbs';
 import ButtonStatesTemplateRaw from '!raw!./button-states-example.hbs';
 import ButtonBlockTemplateRaw from '!raw!./button-block-example.hbs';
+import ButtonTypesTemplateRaw from '!raw!./button-types-example.hbs';
 import ButtonLinkExampleRaw from '!raw!./button-link-example.hbs';
-import ButtonTypesTemplate from './button-types-example.hbs';
+import ButtonVariationTemplate from './button-variations-example.hbs';
 import ButtonStatesTemplate from './button-states-example.hbs';
 import ButtonBlockTemplate from './button-block-example.hbs';
+import ButtonTypesTemplate from './button-types-example.hbs';
 import ButtonLinkExample from './button-link-example.hbs';
 import docs from '../docs/code.md';
 
 export const Docs = docs;
 
-export default (props) => {
-  const buttonTypesTemplate = ButtonTypesTemplate();
+export default props => {
+  const buttonVariationTemplate = ButtonVariationTemplate();
   const buttonStatesTemplate = ButtonStatesTemplate();
   const buttonLinkExample = ButtonLinkExample();
   const buttonBlockTemplate = ButtonBlockTemplate();
+  const buttonTypesTemplate = ButtonTypesTemplate();
   const headingText = 'Button';
   const variablesRoot = 'pf-c-button';
 
   return (
     <Documentation data={props} docs={Docs} heading={headingText} variablesRoot={variablesRoot}>
-      <Example heading="Button types" handlebars={ButtonTypesTemplateRaw}>
-        {buttonTypesTemplate}
+      <Example heading="Button variations" handlebars={ButtonVariationTemplateRaw}>
+        {buttonVariationTemplate}
       </Example>
       <Example heading="Button states" handlebars={ButtonStatesTemplateRaw}>
         {buttonStatesTemplate}
@@ -34,6 +37,9 @@ export default (props) => {
       </Example>
       <Example heading="Button (block level)" handlebars={ButtonBlockTemplateRaw}>
         {buttonBlockTemplate}
+      </Example>
+      <Example heading="Button types" handlebars={ButtonTypesTemplateRaw}>
+        {buttonTypesTemplate}
       </Example>
     </Documentation>
   );

--- a/src/patternfly/components/Expandable/expandable-toggle.hbs
+++ b/src/patternfly/components/Expandable/expandable-toggle.hbs
@@ -1,4 +1,4 @@
-<button class="pf-c-expandable__toggle{{#if expandable-toggle--modifier}} {{expandable-toggle--modifier}}{{/if}}"
+<button type="button" class="pf-c-expandable__toggle{{#if expandable-toggle--modifier}} {{expandable-toggle--modifier}}{{/if}}"
   {{#if expandable-toggle--attribute}}
     {{{expandable-toggle--attribute}}}
   {{/if}}

--- a/src/patternfly/components/Form/examples/form-action-group-example.hbs
+++ b/src/patternfly/components/Form/examples/form-action-group-example.hbs
@@ -1,11 +1,11 @@
 {{#> form}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-actions}}
-      {{#> button button--modifier="pf-m-primary"}}
+      {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
         Submit form
       {{/button}}
-      {{#> button button--modifier="pf-m-secondary"}}
-        Cancel
+      {{#> button button--modifier="pf-m-secondary" button--IsReset="true"}}
+        Reset form
       {{/button}}
     {{/form-actions}}
   {{/form-group}}

--- a/src/patternfly/components/Login/examples/login-invalid-example.hbs
+++ b/src/patternfly/components/Login/examples/login-invalid-example.hbs
@@ -39,7 +39,7 @@
             {{/check}}
           {{/form-group}}
           {{#> form-group form-group--modifier="pf-m-action"}}
-            {{#> button button--modifier="pf-m-primary pf-m-block" button--attribute='type="submit"'}}
+            {{#> button button--modifier="pf-m-primary pf-m-block" button--IsSubmit="true"}}
               Log in
             {{/button}}
           {{/form-group}}

--- a/src/patternfly/components/Login/examples/login-simple-example.hbs
+++ b/src/patternfly/components/Login/examples/login-simple-example.hbs
@@ -39,7 +39,7 @@
             {{/check}}
           {{/form-group}}
           {{#> form-group form-group--modifier="pf-m-action"}}
-            {{#> button button--modifier="pf-m-primary pf-m-block" button--attribute='type="submit"'}}
+            {{#> button button--modifier="pf-m-primary pf-m-block" button--IsSubmit="true"}}
               Log in
             {{/button}}
           {{/form-group}}

--- a/src/patternfly/components/Wizard/examples/wizard-compact-nav-example.hbs
+++ b/src/patternfly/components/Wizard/examples/wizard-compact-nav-example.hbs
@@ -71,7 +71,7 @@
         {{/wizard-main}}
       {{/wizard-inner-wrap}}
       {{#> wizard-footer}}
-        {{#> button button--modifier="pf-m-primary" button--attribute='type="submit"'}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
           Next
         {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}

--- a/src/patternfly/components/Wizard/examples/wizard-example.hbs
+++ b/src/patternfly/components/Wizard/examples/wizard-example.hbs
@@ -71,7 +71,7 @@
         {{/wizard-main}}
       {{/wizard-inner-wrap}}
       {{#> wizard-footer}}
-        {{#> button button--modifier="pf-m-primary" button--attribute='type="submit"'}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
           Next
         {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}

--- a/src/patternfly/components/Wizard/examples/wizard-expanded-example.hbs
+++ b/src/patternfly/components/Wizard/examples/wizard-expanded-example.hbs
@@ -71,7 +71,7 @@
         {{/wizard-main}}
       {{/wizard-inner-wrap}}
       {{#> wizard-footer}}
-        {{#> button button--modifier="pf-m-primary" button--attribute='type="submit"'}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
           Next
         {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}

--- a/src/patternfly/components/Wizard/examples/wizard-finished-example.hbs
+++ b/src/patternfly/components/Wizard/examples/wizard-finished-example.hbs
@@ -89,7 +89,7 @@
         {{/wizard-main}}
       {{/wizard-inner-wrap}}
       {{#> wizard-footer}}
-        {{#> button button--modifier="pf-m-primary" button--attribute='type="submit"'}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
           Next
         {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}

--- a/src/patternfly/components/Wizard/examples/wizard-full-width-full-height-example.hbs
+++ b/src/patternfly/components/Wizard/examples/wizard-full-width-full-height-example.hbs
@@ -71,7 +71,7 @@
         {{/wizard-main}}
       {{/wizard-inner-wrap}}
       {{#> wizard-footer}}
-        {{#> button button--modifier="pf-m-primary" button--attribute='type="submit"'}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
           Next
         {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}

--- a/src/patternfly/demos/BasicForms/examples/horizontal-form-demo-example.hbs
+++ b/src/patternfly/demos/BasicForms/examples/horizontal-form-demo-example.hbs
@@ -54,7 +54,7 @@
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> horizontal-form-group }}
       {{#> form-actions}}
-        {{#> button button--modifier="pf-m-primary"}}
+        {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
           Submit form
         {{/button}}
         {{#> button button--modifier="pf-m-secondary"}}

--- a/src/patternfly/demos/BasicForms/examples/simple-form-demo-example.hbs
+++ b/src/patternfly/demos/BasicForms/examples/simple-form-demo-example.hbs
@@ -38,7 +38,7 @@
   {{/form-group}}
   {{#> form-group form-group--modifier="pf-m-action"}}
     {{#> form-actions}}
-      {{#> button button--modifier="pf-m-primary"}}
+      {{#> button button--modifier="pf-m-primary" button--IsSubmit="true"}}
         Submit form
       {{/button}}
       {{#> button button--modifier="pf-m-secondary"}}


### PR DESCRIPTION
close #1980 

I think the problem was that there was no "type" set on the toggle button in the expandable component, so when it was added to a form the type defaulted to submit. 

I think its safe to add the type as button to this component because I couldnt see it being a reset/submit type. 

Maybe we should also evaluate the variations of the button component.