### PR TITLE
fix(aboutmodal): use break-word on content area instead of break-all

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -189,10 +189,7 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
-
-  * {
-    word-break: break-all;
-  }
+  word-break: break-word;
 
   @media screen and (min-width: $pf-global--breakpoint--sm) {
     overflow: visible;


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2034