### PR TITLE
fix(chart): adjust chart tooltip colors

### DIFF
--- a/src/patternfly/_chart-globals.scss
+++ b/src/patternfly/_chart-globals.scss
@@ -106,7 +106,7 @@ $pf-chart-area--data--Fill: $pf-chart-global--Fill--Color--900;
 
 // Axis Chart
 $pf-chart-axis--axis--stroke--Width: $pf-chart-global--stroke--Width--xs;
-$pf-chart-axis--axis--stroke--Color: $pf-chart-global--Fill--Color--900;
+$pf-chart-axis--axis--stroke--Color: $pf-chart-global--Fill--Color--300;
 $pf-chart-axis--axis--Fill: "transparent";
 $pf-chart-axis--axis-label--Padding: 100;
 $pf-chart-axis--axis-label--stroke--Color: "transparent";
@@ -232,11 +232,12 @@ $pf-chart-stack--data--stroke--Width: $pf-chart-global--stroke--Width--xs;
 // Tooltip
 $pf-chart-tooltip--corner-radius: 0;
 $pf-chart-tooltip--pointer-length: 10;
+$pf-chart-tooltip--Fill: $pf-chart-global--Fill--Color--200;
 $pf-chart-tooltip--flyoutStyle--corner-radius: 0;
 $pf-chart-tooltip--flyoutStyle--stroke--Width: 0;
 $pf-chart-tooltip--flyoutStyle--PointerEvents: "none";
 $pf-chart-tooltip--flyoutStyle--stroke--Color: $pf-chart-global--Fill--Color--900;
-$pf-chart-tooltip--flyoutStyle--Fill: $pf-chart-global--Fill--Color--200;
+$pf-chart-tooltip--flyoutStyle--Fill: $pf-chart-global--Fill--Color--900;
 $pf-chart-tooltip--pointer--Width: 20;
 $pf-chart-tooltip--Padding: 16;
 $pf-chart-tooltip--PointerEvents: "none";
@@ -245,10 +246,11 @@ $pf-chart-tooltip--PointerEvents: "none";
 $pf-chart-voronoi--data--Fill: "transparent";
 $pf-chart-voronoi--data--stroke--Color: "transparent";
 $pf-chart-voronoi--data--stroke--Width: 0;
+$pf-chart-voronoi--labels--Fill: $pf-chart-global--Fill--Color--200;
 $pf-chart-voronoi--labels--Padding: 8;
 $pf-chart-voronoi--labels--PointerEvents: "none";
 $pf-chart-voronoi--flyout--stroke--Width: $pf-chart-global--stroke--Width--xs;
 $pf-chart-voronoi--flyout--PointerEvents: "none";
 $pf-chart-voronoi--flyout--stroke--Color: $pf-chart-global--Fill--Color--900;
-$pf-chart-voronoi--flyout--stroke--Fill: $pf-chart-global--Fill--Color--200;
+$pf-chart-voronoi--flyout--stroke--Fill: $pf-chart-global--Fill--Color--900;
 $pf-chart-voronoi--flyout--PointerEvents: "none";

--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -234,6 +234,7 @@
   // Tooltip
   --pf-chart-tooltip--corner-radius: #{$pf-chart-tooltip--corner-radius};
   --pf-chart-tooltip--pointer-length: #{$pf-chart-tooltip--pointer-length};
+  --pf-chart-tooltip--Fill: #{$pf-chart-tooltip--Fill};
   --pf-chart-tooltip--flyoutStyle--corner-radius: #{$pf-chart-tooltip--flyoutStyle--corner-radius};
   --pf-chart-tooltip--flyoutStyle--stroke--Width: #{$pf-chart-tooltip--flyoutStyle--stroke--Width};
   --pf-chart-tooltip--flyoutStyle--PointerEvents: #{$pf-chart-tooltip--flyoutStyle--PointerEvents};
@@ -248,6 +249,7 @@
   --pf-chart-voronoi--data--stroke--Color: #{$pf-chart-voronoi--data--stroke--Color};
   --pf-chart-voronoi--data--stroke--Width: #{$pf-chart-voronoi--data--stroke--Width};
   --pf-chart-voronoi--labels--Padding: #{$pf-chart-voronoi--labels--Padding};
+  --pf-chart-voronoi--labels--Fill: #{$pf-chart-voronoi--labels--Fill};
   --pf-chart-voronoi--labels--PointerEvents: #{$pf-chart-voronoi--labels--PointerEvents};
   --pf-chart-voronoi--flyout--stroke--Width: #{$pf-chart-voronoi--flyout--stroke--Width};
   --pf-chart-voronoi--flyout--PointerEvents: #{$pf-chart-voronoi--flyout--PointerEvents};


### PR DESCRIPTION
This adjust 3 chart tooltip color vars and adds two new ones. This will ensure tooltips can be seen over the current background color.

Fixes https://github.com/patternfly/patternfly-next/issues/2037