### PR TITLE
fix(options menu): removes pointer events from checkbox icon

### DIFF
--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -258,6 +258,7 @@
   margin-left: auto;
   font-size: var(--pf-c-options-menu__menu-item-icon--FontSize);
   color: var(--pf-c-options-menu__menu-item-icon--Color);
+  pointer-events: none;
 }
 
 .pf-c-options-menu__separator {


### PR DESCRIPTION
Closes #2042 

In reference to https://github.com/patternfly/patternfly-react/issues/2415

Checkbox icon is no longer disappearing in when selecting an item options menu.