### PR TITLE
fix(dropdown): add space-between when width of dropdown grows

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -97,7 +97,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   min-width: var(--pf-c-dropdown__toggle--MinWidth);
   max-width: 100%;
   padding: var(--pf-c-dropdown__toggle--PaddingTop) var(--pf-c-dropdown__toggle--PaddingRight) var(--pf-c-dropdown__toggle--PaddingBottom) var(--pf-c-dropdown__toggle--PaddingLeft);

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -118,7 +118,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   min-width: var(--pf-c-options-menu__toggle--MinWidth);
   max-width: 100%;
   padding-left: var(--pf-c-options-menu__toggle--PaddingLeft);


### PR DESCRIPTION
closes #1847

Replaced `justify-content: center;` with `justify-content: space-between;` 

Also updated the options menu component, looks like the select and context selector already use `justify-content: space-between`

<img width="590" alt="Screen Shot 2019-07-12 at 2 10 22 PM" src="https://user-images.githubusercontent.com/20118816/61149522-568faf80-a4af-11e9-8165-a7eb3b7db935.png">
<img width="833" alt="Screen Shot 2019-07-12 at 2 11 24 PM" src="https://user-images.githubusercontent.com/20118816/61149523-568faf80-a4af-11e9-8ebe-ec7ad5fcfd36.png">
