### PR TITLE
chore(a11y): ensure SkipToContent sends focus to page content

### DIFF
--- a/src/patternfly/components/Page/docs/code.md
+++ b/src/patternfly/components/Page/docs/code.md
@@ -8,6 +8,8 @@ This component provides the basic chrome for a page, including sidebar, header, 
 | -- | -- | -- |
 | `role="banner"` | `.pf-c-page__header` | Identifies the element that serves as the banner region. **Required** |
 | `role="main"` | `.pf-c-page__main` | Identifies the element that serves as the main region. **Required** |
+| `tabindex="-1"` | `.pf-c-page__main` | Allows the main region to receive programmatic focus. **Required** |
+| `id="[id]"` | `.pf-c-page__main` | Provides a hook for sending focus to new content. **Required** |
 | `aria-expanded="true/false"` | `.pf-c-page__header-brand-toggle > .pf-c-button` | Indicates that the expandable content is visible and the current state of the contents. **Required** |
 | `aria-controls="[id of nav]"` | `.pf-c-page__header-brand-toggle > .pf-c-button` | Identifies the element controlled by the toggle. **Required**
 

--- a/src/patternfly/components/Page/page-main.hbs
+++ b/src/patternfly/components/Page/page-main.hbs
@@ -1,4 +1,4 @@
-<main role="main" class="pf-c-page__main{{#if page-main--modifier}} {{page-main--modifier}}{{/if}}"
+<main role="main" class="pf-c-page__main{{#if page-main--modifier}} {{page-main--modifier}}{{/if}}" tabindex="-1"
   {{#if page-main--attribute}}
     {{{page-main--attribute}}}
   {{/if}}>

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -369,6 +369,10 @@
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+
+  &:target {
+    outline: 0;
+  }
 }
 
 .pf-c-page__main-nav {

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -370,7 +370,7 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 
-  &:target {
+  &:focus {
     outline: 0;
   }
 }

--- a/src/patternfly/components/SkipToContent/docs/code.md
+++ b/src/patternfly/components/SkipToContent/docs/code.md
@@ -2,7 +2,7 @@
 
 Skip to content allows screen reader and keyboard users to bypass navigation rather than tabbing through it.
 
-When using `.pf-c-skip-to-content` you must provide an `href` attribute who's value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this see the [page demo](../../../demos/Page/examples), and note the use of `tabindex="-1" which allows the element to receive focus programmatically.
+When using `.pf-c-skip-to-content` you must provide an `href` attribute whose value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this see the [page demo](../../../demos/Page/examples), and note the use of `tabindex="-1"` which allows the element to receive focus programmatically.
 
 ## Accessibility
 

--- a/src/patternfly/components/SkipToContent/docs/code.md
+++ b/src/patternfly/components/SkipToContent/docs/code.md
@@ -2,7 +2,13 @@
 
 Skip to content allows screen reader and keyboard users to bypass navigation rather than tabbing through it.
 
-When using `.pf-c-skip-to-content` you must also provide an anchor with the matching id that is applied to the `href` attribute of `.pf-c-skip-to-content`. You will typically place this just before the main content of the page. Ex: `<a id="main-content"></a>` For a demo of this see the [page demo](../../../demos/Page/examples).
+When using `.pf-c-skip-to-content` you must provide an `href` attribute who's value corresponds to the `id` attribute of the primary content container for your application. In most cases this is the `<main>` element. For a demo of this see the [page demo](../../../demos/Page/examples), and note the use of `tabindex="-1" which allows the element to receive focus programmatically.
+
+## Accessibility
+
+| Attribute | Applied to | Outcome |
+| -- | -- | -- |
+| `href="[id of main container]"` | `.pf-c-skip-to-content` | Sends focus to the primary content container. **Required** |
 
 ## Usage
 

--- a/src/patternfly/components/SkipToContent/examples/skip-to-content-example.hbs
+++ b/src/patternfly/components/SkipToContent/examples/skip-to-content-example.hbs
@@ -1,4 +1,3 @@
 {{#> skip-to-content skip-to-content--attribute='href="#main-content"'}}
   Skip to content
 {{/skip-to-content}}
-

--- a/src/patternfly/demos/CardView/examples/card-view-demo-example.hbs
+++ b/src/patternfly/demos/CardView/examples/card-view-demo-example.hbs
@@ -50,8 +50,7 @@
       {{/nav-list}}
     {{/nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
-      <a id="main-content-{{page--id}}"></a>
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{#> content}}
         <h1>Projects</h1>

--- a/src/patternfly/demos/DataList/examples/data-list-actionable-demo.hbs
+++ b/src/patternfly/demos/DataList/examples/data-list-actionable-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> data-list-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> data-list-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/DataList/examples/data-list-expandable-demo.hbs
+++ b/src/patternfly/demos/DataList/examples/data-list-expandable-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> data-list-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> data-list-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/DataList/examples/data-list-simple-demo.hbs
+++ b/src/patternfly/demos/DataList/examples/data-list-simple-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> data-list-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> data-list-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/DataList/examples/data-list-simple-without-pagination-demo.hbs
+++ b/src/patternfly/demos/DataList/examples/data-list-simple-without-pagination-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> data-list-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> data-list-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> data-list-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Page/examples/page-component-expandable-nav-example.hbs
+++ b/src/patternfly/demos/Page/examples/page-component-expandable-nav-example.hbs
@@ -101,10 +101,9 @@
       {{/nav-list}}
     {{/nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-template-breadcrumb}}
     {{/page-template-breadcrumb}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-template-gallery}}

--- a/src/patternfly/demos/Page/examples/page-component-grouped-nav-example.hbs
+++ b/src/patternfly/demos/Page/examples/page-component-grouped-nav-example.hbs
@@ -79,8 +79,7 @@
       {{/nav-section}}
     {{/nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
-    <a id="main-content-{{page--id}}"></a>
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}

--- a/src/patternfly/demos/Page/examples/page-component-horizontal-nav-example.hbs
+++ b/src/patternfly/demos/Page/examples/page-component-horizontal-nav-example.hbs
@@ -46,10 +46,9 @@
     {{#> page-template-header-tools-elements}}
     {{/page-template-header-tools-elements}}
   {{/page-header}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-template-breadcrumb}}
     {{/page-template-breadcrumb}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-template-gallery}}

--- a/src/patternfly/demos/Page/examples/page-component-tertiary-nav-example.hbs
+++ b/src/patternfly/demos/Page/examples/page-component-tertiary-nav-example.hbs
@@ -101,7 +101,7 @@
       {{/nav-list}}
     {{/nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav}}
       {{#> nav nav--modifier="pf-m-start pf-m-end" nav--attribute='aria-label="Local"'}}
         {{#> nav-scroll-button nav-scroll-button--IsLeft="true"}}
@@ -139,7 +139,6 @@
     {{/page-main-nav}}
     {{#> page-template-breadcrumb}}
     {{/page-template-breadcrumb}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-template-gallery}}

--- a/src/patternfly/demos/Page/page-demo-default.hbs
+++ b/src/patternfly/demos/Page/page-demo-default.hbs
@@ -50,10 +50,9 @@
       {{/nav-list}}
     {{/nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-template-breadcrumb}}
     {{/page-template-breadcrumb}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-template-title}}
     {{/page-template-title}}
     {{#> page-template-gallery}}

--- a/src/patternfly/demos/Table/examples/table-compact-demo.hbs
+++ b/src/patternfly/demos/Table/examples/table-compact-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> table-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Table/examples/table-compound-expansion-demo.hbs
+++ b/src/patternfly/demos/Table/examples/table-compound-expansion-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> table-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Table/examples/table-expandable-demo.hbs
+++ b/src/patternfly/demos/Table/examples/table-expandable-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> table-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Table/examples/table-simple-demo.hbs
+++ b/src/patternfly/demos/Table/examples/table-simple-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> table-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}

--- a/src/patternfly/demos/Table/examples/table-sortable-demo.hbs
+++ b/src/patternfly/demos/Table/examples/table-sortable-demo.hbs
@@ -8,11 +8,10 @@
   {{#> page-sidebar}}
     {{> table-page-nav}}
   {{/page-sidebar}}
-  {{#> page-main}}
+  {{#> page-main page-main--attribute=(concat 'id="main-content-' page--id '"')}}
     {{#> page-main-nav page-main-nav--modifier="pf-m-light"}}
       {{> table-main-section-nav}}
     {{/page-main-nav}}
-    <a id="main-content-{{page--id}}"></a>
     {{#> page-main-section page-main-section--modifier="pf-m-light"}}
       {{> table-main-section-content}}
     {{/page-main-section}}


### PR DESCRIPTION
This PR swaps the target element for SkipToContent from being an anchor to being the primary page container. It requires that we supply the `<main>` element with `tabindex="-1" so this region can receive focus programmatically. It's related to https://github.com/patternfly/patternfly-react/pull/2519

I did notice that unless a heading is an immediate child of the main container, we still don't get the headings read aloud for free when using a screen reader, however, I believe this is still a step in the right direction. The technique is described in one of the training courses over at dequeuniversity.com.

Should we do something about the new focus ring that appears as a result of focusing on the main content region?

add doc for new attribute requirements in Page, SkipToContent
update corresponding demos/exmaples
skip to content sends focus to content container