### PR TITLE
fix(nav): change max-height to 100% for subnav

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -121,7 +121,7 @@
 
   // Subnav links
   --pf-c-nav__subnav--MarginTop: var(--pf-global--spacer--sm);
-  --pf-c-nav__subnav--MaxHeight: #{pf-size-prem(600px)};
+  --pf-c-nav__subnav--MaxHeight: 100%;
 
   // List toggle
   --pf-c-nav__list-toggle--PaddingRight: var(--pf-global--spacer--sm);


### PR DESCRIPTION
closes #1808 

I went with just replacing 600px with 100%, since it seems like no product is currently relying on that large of a value for max-height.

<img width="1205" alt="Screen Shot 2019-07-16 at 2 15 56 PM" src="https://user-images.githubusercontent.com/20118816/61319169-abdfff80-a7d4-11e9-94fd-bccd2f216071.png">

