### PR TITLE
fix(chip label): updated padding(iss1983)

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -15,7 +15,7 @@
   --pf-c-chip-group__label--PaddingTop: var(--pf-global--spacer--xs);
   --pf-c-chip-group__label--PaddingRight: var(--pf-global--spacer--sm);
   --pf-c-chip-group__label--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-chip-group__label--PaddingLeft: var(--pf-global--spacer--xs);
+  --pf-c-chip-group__label--PaddingLeft: 0;
   --pf-c-chip-group__label--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-chip-group__label--Maxwidth: #{pf-size-prem(120px)};
 


### PR DESCRIPTION
Fixed padding so the padding-left is now 0 to align with the spacer system. closes #1983