### PR TITLE
fix(table): add example of modifier

### DIFF
--- a/src/patternfly/components/Table/docs/code.md
+++ b/src/patternfly/components/Table/docs/code.md
@@ -27,8 +27,3 @@ By default, all table header cells are set to `white-space: nowrap`. If a `<th>`
 | `.pf-m-grid-md`, `.pf-m-grid-lg`, `.pf-m-grid-xl`, `.pf-m-grid-2xl` | `.pf-c-table` | Changes tabular layout to responsive, grid based layout at suffixed breakpoint. |
 | `.pf-m-grid` | `.pf-c-table` | Changes tabular layout to responsive, grid based layout. This approach requires JavaScript to set this class at some prescribed viewport width value. |
 
-## Extra modifiers
-
-| Class | Applied to | Outcome |
-| -- | -- | -- |
-| `.pf-m-wrap` | `<th>`, `<td>` | Modifies content to wrap. |

--- a/src/patternfly/components/Table/docs/table-headers-wrap.md
+++ b/src/patternfly/components/Table/docs/table-headers-wrap.md
@@ -1,0 +1,9 @@
+### Table expandable notes
+
+**All simple table accessibility and usage requirements apply.**
+
+### Usage
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-m-wrap` | `<th>`, `<td>` | Modifies content to wrap. |

--- a/src/patternfly/components/Table/examples/index.js
+++ b/src/patternfly/components/Table/examples/index.js
@@ -11,6 +11,7 @@ import tableCompactExpandableExampleRaw from '!raw!./table-compact-expandable-ex
 import tableWidthExampleRaw from '!raw!./table-width-example.hbs';
 import tableCompoundExpansionExampleRaw from '!raw!./table-compound-expansion-example.hbs';
 import tableHiddenVisibleExampleRaw from '!raw!./table-hidden-visible-example.hbs';
+import tableHeadersWrapExampleRaw from '!raw!./table-headers-wrap-example.hbs';
 
 import TableSimpleExample from './table-simple-example.hbs';
 import tableSimpleDoc from '../docs/table-simple.md';
@@ -41,11 +42,14 @@ import tableCompoundExpansionDoc from '../docs/table-compound-expansion.md';
 import TableHiddenVisibleExample from './table-hidden-visible-example.hbs';
 import tableHiddenVisibleDoc from '../docs/table-hidden-visible.md';
 
+import TableHeadersWrapExample from './table-headers-wrap-example.hbs';
+import tableHeadersWrapDoc from '../docs/table-headers-wrap.md';
+
 import docs from '../docs/code.md';
 
 export const Docs = docs;
 
-export default (props) => {
+export default props => {
   const tableSimpleExample = TableSimpleExample();
   const tableSortableExample = TableSortableExample();
   const tableExpandableExample = TableExpandableExample();
@@ -56,6 +60,7 @@ export default (props) => {
   const tableWidthExample = TableWidthExample();
   const tableCompoundExpansionExample = TableCompoundExpansionExample();
   const tableHiddenVisibleExample = TableHiddenVisibleExample();
+  const tableHeadersWrapExample = TableHeadersWrapExample();
   const headingText = 'Table';
   const variablesRoot = 'pf-c-table';
 
@@ -110,6 +115,13 @@ export default (props) => {
         docs={tableHiddenVisibleDoc}
       >
         {tableHiddenVisibleExample}
+      </Example>
+      <Example
+        heading="Table with headers that wrap"
+        handlebars={tableHeadersWrapExampleRaw}
+        docs={tableHeadersWrapDoc}
+      >
+        {tableHeadersWrapExample}
       </Example>
     </Documentation>
   );

--- a/src/patternfly/components/Table/examples/table-headers-wrap-example.hbs
+++ b/src/patternfly/components/Table/examples/table-headers-wrap-example.hbs
@@ -1,0 +1,98 @@
+{{#> table table--id="simple-table" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a simple table example"'}}
+  {{#> table-caption}}
+    This is the table caption
+  {{/table-caption}}
+  {{#> table-thead}}
+    {{#> table-tr}}
+      {{#> table-th table-th--modifier="pf-m-wrap"}}
+        This is a really long table header that goes on for a long time.
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-wrap"}}
+        This is a really long table header that goes on for a long time.
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-wrap"}}
+        This is a really long table header that goes on for a long time.
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-wrap"}}
+        This is a really long table header that goes on for a long time.
+      {{/table-th}}
+      {{#> table-th table-th--modifier="pf-m-wrap"}}
+        This is a really long table header that goes on for a long time.
+      {{/table-th}}
+    {{/table-tr}}
+  {{/table-thead}}
+
+  {{#> table-tbody}}
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        Repository 1
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        Repository 2
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        Repository 3
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+
+    {{#> table-tr}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        Repository 4
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        10
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        25
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        5
+      {{/table-td}}
+      {{#> table-td table-td--data-label="This is a really long table header that goes on for a long time."}}
+        2 days ago
+      {{/table-td}}
+    {{/table-tr}}
+  {{/table-tbody}}
+{{/table}}

--- a/src/patternfly/components/Table/examples/table-headers-wrap-example.hbs
+++ b/src/patternfly/components/Table/examples/table-headers-wrap-example.hbs
@@ -1,4 +1,4 @@
-{{#> table table--id="simple-table" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is a simple table example"'}}
+{{#> table table--id="headers-wrap-table" table--grid="true" table--modifier="pf-m-grid-md" table--attribute='aria-label="This is an example of the table that has headers that wrap"'}}
   {{#> table-caption}}
     This is the table caption
   {{/table-caption}}


### PR DESCRIPTION
closes #2048 

@KendraMar I added an example of how to make column headers wrap. We should create a new issue if you would like to be able to set max-widths on the columns.

<img width="1007" alt="Screen Shot 2019-07-16 at 2 44 21 PM" src="https://user-images.githubusercontent.com/20118816/61320984-9ff63c80-a7d8-11e9-9712-b0f233ab1f63.png">
