### PR TITLE
fix(select): update class selector, stacking context for typeahead input

### DIFF
--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -211,8 +211,10 @@
 
     padding-top: var(--pf-c-select__toggle-wrapper--m-typeahead--PaddingTop);
 
-    input {
+    .pf-c-form-control {
       @include pf-text-overflow;
+
+      position: relative;
     }
 
     // When the input is the first thing then use a negative left padding so it matches the toggle container


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2074