### PR TITLE
chore(travis): bump chromedriver version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
   local_dir: public
 
 before_script:
-  - wget https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip -d /home/travis/bin/
   - export CHROME_BIN=chromium-browser
   - npm install -g gulp-cli


### PR DESCRIPTION
This PR updates the version of chromedriver that's pulled down by Travis in order to run the accessibility audit.

Steps toward solving https://github.com/patternfly/patternfly-next/issues/2118