### PR TITLE
Adjust chart axis label padding

### DIFF
--- a/src/patternfly/_chart-globals.scss
+++ b/src/patternfly/_chart-globals.scss
@@ -116,7 +116,7 @@ $pf-chart-area--data--Fill: $pf-chart-global--Fill--Color--900;
 $pf-chart-axis--axis--stroke--Width: $pf-chart-global--stroke--Width--xs;
 $pf-chart-axis--axis--stroke--Color: $pf-chart-global--Fill--Color--300;
 $pf-chart-axis--axis--Fill: "transparent";
-$pf-chart-axis--axis-label--Padding: 100;
+$pf-chart-axis--axis-label--Padding: 40;
 $pf-chart-axis--axis-label--stroke--Color: "transparent";
 $pf-chart-axis--grid--Fill: "none";
 $pf-chart-axis--grid--stroke--Color: $pf-chart-global--Fill--Color--300;


### PR DESCRIPTION
The `--pf-chart-axis--axis-label--Padding` variable is currently set as 100. This pushes the axis label way out of bounds for charts. The value should be 40.

Fixes https://github.com/patternfly/patternfly-next/issues/2180