### PR TITLE
fix(form): update label alignment

### DIFF
--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -28,4 +28,5 @@
 | `.pf-m-inactive` | `.pf-c-form__helper-text`| Modifies display of helper text to none. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |
+| `.pf-m-align-top` | `.pf-c-form__label` | Modifies form label to align to the top of its parent. |
 | `.pf-m-inline` | `.pf-c-form__group` | Modifies form group children to be inline (this is primarily for radio buttons and checkboxes). |

--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -28,5 +28,5 @@
 | `.pf-m-inactive` | `.pf-c-form__helper-text`| Modifies display of helper text to none. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |
-| `.pf-m-no-padding` | `.pf-c-form__label` | Removes top padding from the label element for labels adjacent to an element that isn't a form control. |
+| `.pf-m-no-padding-top` | `.pf-c-form__label` | Removes top padding from the label element for labels adjacent to an element that isn't a form control. |
 | `.pf-m-inline` | `.pf-c-form__group` | Modifies form group children to be inline (this is primarily for radio buttons and checkboxes). |

--- a/src/patternfly/components/Form/docs/code.md
+++ b/src/patternfly/components/Form/docs/code.md
@@ -28,5 +28,5 @@
 | `.pf-m-inactive` | `.pf-c-form__helper-text`| Modifies display of helper text to none. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |
-| `.pf-m-align-top` | `.pf-c-form__label` | Modifies form label to align to the top of its parent. |
+| `.pf-m-no-padding` | `.pf-c-form__label` | Removes top padding from the label element for labels adjacent to an element that isn't a form control. |
 | `.pf-m-inline` | `.pf-c-form__group` | Modifies form group children to be inline (this is primarily for radio buttons and checkboxes). |

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -1,4 +1,4 @@
-{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-center"}}
+{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-1"}}
   {{#> form-group}}
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"') required="true"}}
       Name
@@ -15,7 +15,7 @@
 
 <br>
 
-{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
+{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-2"}}
   {{#> form-group}}
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"')}}
       Information

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -1,4 +1,4 @@
-{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels"}}
+{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-center"}}
   {{#> form-group}}
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"') required="true"}}
       Name
@@ -7,12 +7,15 @@
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id '-horizontal-form-name" name="' form--id '-horizontal-form-name" required')}}
       {{/form-control}}
     {{/horizontal-form-group}}
+    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-name-helper" aria-live="polite"')}}
+      This is helper text for an invalid input
+    {{/form-helper-text}}
   {{/form-group}}
 {{/form}}
 
 <br>
 
-{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels"}}
+{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
   {{#> form-group}}
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"') form-label--modifier="pf-m-align-top"}}
       Info (.pf-m-align-top)
@@ -21,6 +24,9 @@
       {{#> form-control controlType="textarea" form-control--attribute=(concat 'type="text" id="' form--id '-horizontal-form-name-2" name="' form--id '-horizontal-form-name-2" aria-label="textarea example"')}}
       {{/form-control}}
     {{/horizontal-form-group}}
+    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-info-helper" aria-live="polite"')}}
+      This is helper text for an invalid input
+    {{/form-helper-text}}
   {{/form-group}}
 {{/form}}
 

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -34,7 +34,7 @@
 
 {{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
   {{#> form-group}}
-    {{#> form-label form-label--modifier="pf-m-no-padding" form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"')}}
+    {{#> form-label form-label--modifier="pf-m-no-padding-top" form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"')}}
       No padding label
     {{/form-label}}
     {{#> horizontal-form-group}}

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -29,16 +29,16 @@
 {{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
   {{#> form-group}}
     {{#> form-label form-label--modifier="pf-m-no-padding-top" form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"')}}
-      No padding label
+      Label (no top padding)
     {{/form-label}}
     {{#> horizontal-form-group}}
     {{#> check}}
       {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox1" name="alt-form-checkbox1"'}}{{/check-input}}
-      {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email{{/check-label}}
+      {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Option 1{{/check-label}}
     {{/check}}
       {{#> check}}
         {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox2" name="alt-form-checkbox2"'}}{{/check-input}}
-        {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Remember my password for 30 days{{/check-label}}
+        {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Option 2{{/check-label}}
       {{/check}}
     {{/horizontal-form-group}}
   {{/form-group}}

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -9,3 +9,18 @@
     {{/horizontal-form-group}}
   {{/form-group}}
 {{/form}}
+
+<br>
+
+{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels"}}
+  {{#> form-group}}
+    {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"') form-label--modifier="pf-m-align-top"}}
+      Info (.pf-m-align-top)
+    {{/form-label}}
+    {{#> horizontal-form-group}}
+      {{#> form-control controlType="textarea" form-control--attribute=(concat 'type="text" id="' form--id '-horizontal-form-name-2" name="' form--id '-horizontal-form-name-2" aria-label="textarea example"')}}
+      {{/form-control}}
+    {{/horizontal-form-group}}
+  {{/form-group}}
+{{/form}}
+

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -34,8 +34,8 @@
 
 {{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
   {{#> form-group}}
-    {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"' form-label--modifier="pf-m-align-top")}}
-      Information
+    {{#> form-label form-label--modifier="pf-m-no-padding" form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"')}}
+      No padding label
     {{/form-label}}
     {{#> horizontal-form-group}}
     {{#> check}}
@@ -43,16 +43,11 @@
       {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email{{/check-label}}
     {{/check}}
     {{/horizontal-form-group}}
-  {{/form-group}}
-  {{#> form-group}}
     {{#> horizontal-form-group}}
       {{#> check}}
         {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox2" name="alt-form-checkbox2"'}}{{/check-input}}
         {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Remember my password for 30 days{{/check-label}}
       {{/check}}
     {{/horizontal-form-group}}
-    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-info-helper" aria-live="polite"')}}
-      This is helper text for an invalid input
-    {{/form-helper-text}}
   {{/form-group}}
 {{/form}}

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -17,8 +17,8 @@
 
 {{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
   {{#> form-group}}
-    {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"') form-label--modifier="pf-m-align-top"}}
-      Info (.pf-m-align-top)
+    {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"')}}
+      Information
     {{/form-label}}
     {{#> horizontal-form-group}}
       {{#> form-control controlType="textarea" form-control--attribute=(concat 'type="text" id="' form--id '-horizontal-form-name-2" name="' form--id '-horizontal-form-name-2" aria-label="textarea example"')}}
@@ -30,3 +30,29 @@
   {{/form-group}}
 {{/form}}
 
+<br>
+
+{{#> form form--modifier="pf-m-horizontal" form--id="horizontal-align-labels-top"}}
+  {{#> form-group}}
+    {{#> form-label form-label--attribute=(concat 'for="' form--id '-horizontal-form-name"' form-label--modifier="pf-m-align-top")}}
+      Information
+    {{/form-label}}
+    {{#> horizontal-form-group}}
+    {{#> check}}
+      {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox1" name="alt-form-checkbox1"'}}{{/check-input}}
+      {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email{{/check-label}}
+    {{/check}}
+    {{/horizontal-form-group}}
+  {{/form-group}}
+  {{#> form-group}}
+    {{#> horizontal-form-group}}
+      {{#> check}}
+        {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox2" name="alt-form-checkbox2"'}}{{/check-input}}
+        {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Remember my password for 30 days{{/check-label}}
+      {{/check}}
+    {{/horizontal-form-group}}
+    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-info-helper" aria-live="polite"')}}
+      This is helper text for an invalid input
+    {{/form-helper-text}}
+  {{/form-group}}
+{{/form}}

--- a/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
+++ b/src/patternfly/components/Form/examples/form-horizontal-align-labels-example.hbs
@@ -7,9 +7,6 @@
       {{#> form-control controlType="input" input="true" form-control--attribute=(concat 'type="text" id="' form--id '-horizontal-form-name" name="' form--id '-horizontal-form-name" required')}}
       {{/form-control}}
     {{/horizontal-form-group}}
-    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-name-helper" aria-live="polite"')}}
-      This is helper text for an invalid input
-    {{/form-helper-text}}
   {{/form-group}}
 {{/form}}
 
@@ -24,9 +21,6 @@
       {{#> form-control controlType="textarea" form-control--attribute=(concat 'type="text" id="' form--id '-horizontal-form-name-2" name="' form--id '-horizontal-form-name-2" aria-label="textarea example"')}}
       {{/form-control}}
     {{/horizontal-form-group}}
-    {{#> form-helper-text form-helper-text--modifier="pf-m-error" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-info-helper" aria-live="polite"')}}
-      This is helper text for an invalid input
-    {{/form-helper-text}}
   {{/form-group}}
 {{/form}}
 
@@ -42,8 +36,6 @@
       {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox1" name="alt-form-checkbox1"'}}{{/check-input}}
       {{#> check-label check-label--attribute='for="alt-form-checkbox1"'}}Follow up via email{{/check-label}}
     {{/check}}
-    {{/horizontal-form-group}}
-    {{#> horizontal-form-group}}
       {{#> check}}
         {{#> check-input check-input--attribute='type="checkbox" id="alt-form-checkbox2" name="alt-form-checkbox2"'}}{{/check-input}}
         {{#> check-label check-label--attribute='for="alt-form-checkbox2"'}}Remember my password for 30 days{{/check-label}}

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -73,11 +73,11 @@
       .pf-c-form__group .pf-c-form__label {
         display: flex;
         align-items: center;
-        padding-top: 0; // remove this after breaking change period
         padding-bottom: 0;
 
         &.pf-m-align-top {
           align-items: flex-start;
+          padding-top: var(--pf-c-form__label--PaddingTop);
         }
       }
       /* stylelint-enable */

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -1,7 +1,7 @@
 .pf-c-form {
   --pf-c-form--GridGap: var(--pf-global--gutter);
 
-  // Label
+  // Labels
   --pf-c-form__label--Color: var(--pf-global--Color--100);
   --pf-c-form__label--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-form__label--FontSize: var(--pf-global--FontSize--sm);

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -69,10 +69,18 @@
         grid-template-columns: var(--pf-c-form--m-horizontal--md__group--GridTemplateColumns);
       }
 
+      /* stylelint-disable */
       .pf-c-form__group .pf-c-form__label {
-        padding-top: var(--pf-c-form__label--PaddingTop);
+        display: flex;
+        align-items: center;
         padding-bottom: 0;
+        // padding-top: var(--pf-c-form__label--PaddingTop);
+
+        .pf-m-align-top {
+          align-items: flex-start;
+        }
       }
+      /* stylelint-enable */
 
       .pf-c-form-control,
       .pf-c-form__horizontal-group,

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -24,7 +24,7 @@
   --pf-c-form__group--m-action--MarginTop: var(--pf-global--spacer--xl);
 
   // actions
-  // --pf-c-form__actions--child--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-form__actions--child--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-form__actions--child--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-form__actions--child--MarginBottom: var(--pf-global--spacer--sm);
   --pf-c-form__actions--child--MarginLeft: var(--pf-global--spacer--sm);
@@ -74,9 +74,8 @@
         display: flex;
         align-items: center;
         padding-bottom: 0;
-        // padding-top: var(--pf-c-form__label--PaddingTop);
 
-        .pf-m-align-top {
+        &.pf-m-align-top {
           align-items: flex-start;
         }
       }
@@ -152,7 +151,6 @@
 .pf-c-form__label-required {
   margin-left: var(--pf-c-form__label-required--MarginLeft);
   font-size: var(--pf-c-form__label-required--FontSize);
-  line-height: 0;
   color: var(--pf-c-form__label-required--Color);
 }
 

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -71,13 +71,12 @@
 
       /* stylelint-disable */
       .pf-c-form__group .pf-c-form__label {
-        display: flex;
-        align-items: center;
+        padding-top: var(--pf-c-form__label--PaddingTop);
         padding-bottom: 0;
 
         &.pf-m-align-top {
           align-items: flex-start;
-          padding-top: var(--pf-c-form__label--PaddingTop);
+          padding-top: 0;
         }
       }
       /* stylelint-enable */

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -74,8 +74,7 @@
         padding-top: var(--pf-c-form__label--PaddingTop);
         padding-bottom: 0;
 
-        &.pf-m-align-top {
-          align-items: flex-start;
+        &.pf-m-no-padding {
           padding-top: 0;
         }
       }

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -1,7 +1,7 @@
 .pf-c-form {
   --pf-c-form--GridGap: var(--pf-global--gutter);
 
-  // Labels
+  // Label
   --pf-c-form__label--Color: var(--pf-global--Color--100);
   --pf-c-form__label--FontWeight: var(--pf-global--FontWeight--normal);
   --pf-c-form__label--FontSize: var(--pf-global--FontSize--sm);
@@ -73,6 +73,7 @@
       .pf-c-form__group .pf-c-form__label {
         display: flex;
         align-items: center;
+        padding-top: 0; // remove this after breaking change period
         padding-bottom: 0;
 
         &.pf-m-align-top {

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -74,8 +74,8 @@
         padding-top: var(--pf-c-form__label--PaddingTop);
         padding-bottom: 0;
 
-        &.pf-m-no-padding {
-          padding-top: 0;
+        &.pf-m-no-padding-top {
+          --pf-c-form__label--PaddingTop: 0;
         }
       }
       /* stylelint-enable */

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -24,7 +24,7 @@
   --pf-c-form__group--m-action--MarginTop: var(--pf-global--spacer--xl);
 
   // actions
-  --pf-c-form__actions--child--MarginTop: var(--pf-global--spacer--sm);
+  // --pf-c-form__actions--child--MarginTop: var(--pf-global--spacer--sm);
   --pf-c-form__actions--child--MarginRight: var(--pf-global--spacer--sm);
   --pf-c-form__actions--child--MarginBottom: var(--pf-global--spacer--sm);
   --pf-c-form__actions--child--MarginLeft: var(--pf-global--spacer--sm);

--- a/src/patternfly/demos/BasicForms/examples/horizontal-form-demo-example.hbs
+++ b/src/patternfly/demos/BasicForms/examples/horizontal-form-demo-example.hbs
@@ -1,6 +1,6 @@
 {{#> form form--modifier="pf-m-horizontal"}}
   {{#> form-group}}
-    {{#> form-label form-label--modifier="pf-m-align-top" form-label--attribute='for="horizontal-form-name"' required="true"}}Name{{/form-label}}
+    {{#> form-label form-label--attribute='for="horizontal-form-name"' required="true"}}Name{{/form-label}}
     {{#> horizontal-form-group}}
       {{#> form-control controlType="input" input="true" form-control--attribute='required type="text" id="horizontal-form-name" name="horizontal-form-name" aria-describedby="horizontal-form-name-helper2"'}}
       {{/form-control}}
@@ -29,7 +29,7 @@
     {{/horizontal-form-group}}
   {{/form-group}}
   {{#> form-group}}
-    {{#> form-label form-label--modifier="pf-m-align-top" form-label--attribute='for="horizontal-form-exp"'}}Your experience{{/form-label}}
+    {{#> form-label form-label--attribute='for="horizontal-form-exp"'}}Your experience{{/form-label}}
     {{#> horizontal-form-group}}
       {{#> form-control controlType="textarea" form-control--attribute='name="horizontal-form-exp" id="horizontal-form-exp"'}}
       {{/form-control}}

--- a/src/patternfly/demos/BasicForms/examples/horizontal-form-demo-example.hbs
+++ b/src/patternfly/demos/BasicForms/examples/horizontal-form-demo-example.hbs
@@ -1,6 +1,6 @@
 {{#> form form--modifier="pf-m-horizontal"}}
   {{#> form-group}}
-    {{#> form-label form-label--attribute='for="horizontal-form-name"' required="true"}}Name{{/form-label}}
+    {{#> form-label form-label--modifier="pf-m-align-top" form-label--attribute='for="horizontal-form-name"' required="true"}}Name{{/form-label}}
     {{#> horizontal-form-group}}
       {{#> form-control controlType="input" input="true" form-control--attribute='required type="text" id="horizontal-form-name" name="horizontal-form-name" aria-describedby="horizontal-form-name-helper2"'}}
       {{/form-control}}
@@ -29,7 +29,7 @@
     {{/horizontal-form-group}}
   {{/form-group}}
   {{#> form-group}}
-    {{#> form-label form-label--attribute='for="horizontal-form-exp"'}}Your experience{{/form-label}}
+    {{#> form-label form-label--modifier="pf-m-align-top" form-label--attribute='for="horizontal-form-exp"'}}Your experience{{/form-label}}
     {{#> horizontal-form-group}}
       {{#> form-control controlType="textarea" form-control--attribute='name="horizontal-form-exp" id="horizontal-form-exp"'}}
       {{/form-control}}


### PR DESCRIPTION
closes #2167 

Spoke with @kybaker about how we should handle form labels. We came to the conclusion that: - 
- for form labels adjacent to a form control with one line, the label should be vertically aligned in the center.
- for form labels adjacent to a form control with two lines, the label should be aligned to the top.

This should allow for these labels to more flexible, especially with font-sizes changing. The downside is that the user will have to add a modifier to change the label to align to the top.

Here is the example in the horizontal form demo: 
<img width="717" alt="Screen Shot 2019-08-28 at 10 05 46 AM" src="https://user-images.githubusercontent.com/20118816/63863597-7d7d4480-c97c-11e9-9447-9fdc92f41df6.png">

Bootstrap does something similar:
<img width="763" alt="Screen Shot 2019-08-28 at 9 56 51 AM" src="https://user-images.githubusercontent.com/20118816/63863639-8d952400-c97c-11e9-9164-cfd54e69c6ae.png">
