### PR TITLE
refactor(flex-layout): wrap flex items, update css

### DIFF
--- a/src/patternfly/layouts/Flex/docs/code.md
+++ b/src/patternfly/layouts/Flex/docs/code.md
@@ -45,5 +45,5 @@
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > *` |  Modifies a nested flex layout or a flex item spacing. |
+| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > .pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |
 | `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/code.md
+++ b/src/patternfly/layouts/Flex/docs/code.md
@@ -46,4 +46,4 @@
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > .pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |
-| `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |
+| `.pf-m-item-space-items-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/code.md
+++ b/src/patternfly/layouts/Flex/docs/code.md
@@ -37,7 +37,7 @@
 | `.pf-m-align-content-stretch{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to stretch. |
 | `.pf-m-align-content-space-between{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to space-between. |
 | `.pf-m-align-content-space-around{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to space-around. |
-| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Resets the flex layout element margin-left property to 0. |
+| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets the flex layout element margin-left property to 0. |
 | `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Modifies the flex layout element margin-left property to auto. |
 
 

--- a/src/patternfly/layouts/Flex/docs/code.md
+++ b/src/patternfly/layouts/Flex/docs/code.md
@@ -12,10 +12,9 @@
 | `.pf-m-flex-1{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 1 0 0. |
 | `.pf-m-flex-2{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 2 0 0. |
 | `.pf-m-flex-3{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 3 0 0. |
+| `.pf-m-flex-4{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 4 0 0. |
 | `.pf-m-flex-default{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets a nested flex layout or flex item flex shorthand property to 0 1 auto. |
 | `.pf-m-flex-none{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to none. |
-
-
 | `.pf-m-column-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-direction property to column-reverse. |
 | `.pf-m-row-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-direction property to row-reverse. |
 | `.pf-m-wrap{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-wrap property to wrap. |

--- a/src/patternfly/layouts/Flex/docs/code.md
+++ b/src/patternfly/layouts/Flex/docs/code.md
@@ -38,7 +38,7 @@
 | `.pf-m-align-content-space-between{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to space-between. |
 | `.pf-m-align-content-space-around{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to space-around. |
 | `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets the flex layout element margin-left property to 0. |
-| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Modifies the flex layout element margin-left property to auto. |
+| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies the flex layout element margin-left property to auto. |
 
 
 ## Spacer system

--- a/src/patternfly/layouts/Flex/docs/code.md
+++ b/src/patternfly/layouts/Flex/docs/code.md
@@ -1,30 +1,50 @@
-## Modifiers
+## Usage
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-flex{-on-[breakpoint]}` | `.pf-l-flex` | Initializes or resets display property to flex. |
-| `.pf-m-inline-flex{-on-[breakpoint]}` | `.pf-l-flex` | Modifies display property to inline-flex. |
-| `.pf-m-column-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies flex-direction property to column-reverse. |
-| `.pf-m-row-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies flex-direction property to row-reverse. |
-| `.pf-m-wrap{-on-[breakpoint]}` | `.pf-l-flex` | Modifies flex-wrap property to wrap. |
-| `.pf-m-wrap-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies flex-wrap property to wrap-reverse. |
-| `.pf-m-nowrap{-on-[breakpoint]}` | `.pf-l-flex` | Modifies flex-wrap property to nowrap. |
-| `.pf-m-justify-content-flex-start{-on-[breakpoint]}` | `.pf-l-flex` | Modifies justify-content property to flex-start. |
-| `.pf-m-justify-content-flex-end{-on-[breakpoint]}` | `.pf-l-flex` | Modifies justify-content property to flex-end. |
-| `.pf-m-justify-content-center{-on-[breakpoint]}` | `.pf-l-flex` | Modifies justify-content property to center. |
-| `.pf-m-justify-content-space-between{-on-[breakpoint]}` | `.pf-l-flex` | Modifies justify-content property to space-between. |
-| `.pf-m-justify-content-space-around{-on-[breakpoint]}` | `.pf-l-flex` | Modifies justify-content property to space-around. |
-| `.pf-m-justify-content-space-evenly{-on-[breakpoint]}` | `.pf-l-flex` | Modifies justify-content property to space-evenly. |
-| `.pf-m-align-items-flex-start{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-items property to flex-start. |
-| `.pf-m-align-items-flex-end{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-items property to flex-end. |
-| `.pf-m-align-items-center{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-items property to center. |
-| `.pf-m-align-items-stretch{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-items property to stretch. |
-| `.pf-m-align-items-baseline{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-items property to baseline. |
-| `.pf-m-align-content-flex-start{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-content property to flex-start. |
-| `.pf-m-align-content-flex-end{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-content property to flex-end. |
-| `.pf-m-align-content-center{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-content property to center. |
-| `.pf-m-align-content-stretch{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-content property to stretch. |
-| `.pf-m-align-content-space-between{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-content property to space-between. |
-| `.pf-m-align-content-space-around{-on-[breakpoint]}` | `.pf-l-flex` | Modifies align-content property to space-around. |
-| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Resets margin-left property to 0. |
-| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Modifies margin-left property to auto. |
+| `.pf-l-flex` | `*` | Initiates the flex layout. **Required** |
+| `.pf-l-flex__item` | `.pf-l-flex > *` | Initiates a flex item. **Required** |
+| `.pf-m-flex{-on-[breakpoint]}` | `.pf-l-flex` | Initializes or resets the flex layout display property to flex. |
+| `.pf-m-inline-flex{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout display property to inline-flex. |
+| `.pf-m-grow{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex-grow property to 1. |
+| `.pf-m-shrink{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex-shrink property to 1. |
+| `.pf-m-full-width{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex item to full width of parent. |
+| `.pf-m-flex-1{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 1 0 0. |
+| `.pf-m-flex-2{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 2 0 0. |
+| `.pf-m-flex-3{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 3 0 0. |
+| `.pf-m-flex-default{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets a nested flex layout or flex item flex shorthand property to 0 1 auto. |
+| `.pf-m-flex-none{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to none. |
+
+
+| `.pf-m-column-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-direction property to column-reverse. |
+| `.pf-m-row-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-direction property to row-reverse. |
+| `.pf-m-wrap{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-wrap property to wrap. |
+| `.pf-m-wrap-reverse{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-wrap property to wrap-reverse. |
+| `.pf-m-nowrap{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout flex-wrap property to nowrap. |
+| `.pf-m-justify-content-flex-start{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout justify-content property to flex-start. |
+| `.pf-m-justify-content-flex-end{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout justify-content property to flex-end. |
+| `.pf-m-justify-content-center{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout justify-content property to center. |
+| `.pf-m-justify-content-space-between{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout justify-content property to space-between. |
+| `.pf-m-justify-content-space-around{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout justify-content property to space-around. |
+| `.pf-m-justify-content-space-evenly{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout justify-content property to space-evenly. |
+| `.pf-m-align-items-flex-start{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-items property to flex-start. |
+| `.pf-m-align-items-flex-end{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-items property to flex-end. |
+| `.pf-m-align-items-center{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-items property to center. |
+| `.pf-m-align-items-stretch{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-items property to stretch. |
+| `.pf-m-align-items-baseline{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-items property to baseline. |
+| `.pf-m-align-content-flex-start{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to flex-start. |
+| `.pf-m-align-content-flex-end{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to flex-end. |
+| `.pf-m-align-content-center{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to center. |
+| `.pf-m-align-content-stretch{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to stretch. |
+| `.pf-m-align-content-space-between{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to space-between. |
+| `.pf-m-align-content-space-around{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout align-content property to space-around. |
+| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Resets the flex layout element margin-left property to 0. |
+| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > *` | Modifies the flex layout element margin-left property to auto. |
+
+
+## Spacer system
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > *` |  Modifies a nested flex layout or a flex item spacing. |
+| `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/flex-alignment.md
+++ b/src/patternfly/layouts/Flex/docs/flex-alignment.md
@@ -1,11 +1,11 @@
-# Usage
+## Usage
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies margin-left property to auto. |
-| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex > *` | Resets margin-left property 0. |
-| `.pf-m-align-self-flex-start{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies align-self property to flex-start. |
-| `.pf-m-align-self-flex-end{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies align-self property to flex-end. |
-| `.pf-m-align-self-flex-center{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies align-self property to center. |
-| `.pf-m-align-self-flex-baseline{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies align-self property to baseline. |
-| `.pf-m-align-self-flex-stretch{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies align-self property to stretch. |
+| `.pf-m-align-right{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies margin-left property to auto. |
+| `.pf-m-align-left{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets margin-left property 0. |
+| `.pf-m-align-self-flex-start{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies align-self property to flex-start. |
+| `.pf-m-align-self-flex-end{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies align-self property to flex-end. |
+| `.pf-m-align-self-flex-center{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies align-self property to center. |
+| `.pf-m-align-self-flex-baseline{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies align-self property to baseline. |
+| `.pf-m-align-self-flex-stretch{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies align-self property to stretch. |

--- a/src/patternfly/layouts/Flex/docs/flex-basic.md
+++ b/src/patternfly/layouts/Flex/docs/flex-basic.md
@@ -2,5 +2,5 @@
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-l-flex` | `*` |  Initiates flex layout. **Required** |
-| `.pf-l-flex__item` | `.pf-l-flex > *` |  Identifies a flex item. **Optional** |
+| `.pf-l-flex` | `*` | Initiates the flex layout. **Required** |
+| `.pf-l-flex__item` | `.pf-l-flex > *` | Initiates a flex item. **Required** |

--- a/src/patternfly/layouts/Flex/docs/flex-intro.md
+++ b/src/patternfly/layouts/Flex/docs/flex-intro.md
@@ -4,7 +4,7 @@ The flex layout is based on the CSS Flex properties where the layout determines 
 ### Default spacing for:
 - Flex items (not last child): `margin-right: 16px`.
 - Nested `.pf-l-flex` containers (not last child): `margin-right: 16px`.
-- `.pf-m-column` direct descendants (not first child): `margin-bottom: 16px`.
+- `.pf-m-column` direct descendants (not last child): `margin-bottom: 16px`.
 - `.pf-m-column` nested `.pf-l-flex` containers (not last child): `margin-bottom: 16px`.
 
 <br>
@@ -14,7 +14,7 @@ The flex layout is based on the CSS Flex properties where the layout determines 
 - `.pf-m-space-items-{xs,sm,md,lg,xl,2xl,3xl}` can be applied to `.pf-l-flex` only and changes the spacing of direct children only. Responsive spacers can be used by appending `{-on-[breakpoint]}` to `.pf-m-space-items-{size}`. Example: `.pf-m-space-items-lg-on-xl`.
 
 <br>
-### Available breakpoints are: `-on-sm, -on-md, -on-lg, -on-xl`.
+### Available breakpoints are: `-on-sm, -on-md, -on-lg, -on-xl, -on-2xl`.
 
 <br>
 ### Use `.pf-l-flex` when:
@@ -24,8 +24,8 @@ The flex layout is based on the CSS Flex properties where the layout determines 
 <br>
 ### `.pf-l-flex` is different than a utility class in that:
 - It contains multiple css declarations and does not use the !important tag.
-- Does not require wrapping elements in columns or rows.
-- Break dependency upon adding utility classes to each child.
+- It does not require wrapping elements in columns or rows.
+- It breaks the dependency upon adding utility classes to each child.
 - It can be applied to container elements or components.
 
 <br>

--- a/src/patternfly/layouts/Flex/docs/flex-intro.md
+++ b/src/patternfly/layouts/Flex/docs/flex-intro.md
@@ -1,32 +1,42 @@
-The flex layout is based on the CSS Flex properties where the layout determines how a flex item will grow or shrink to fit the space available in its container. The system relies on a default spacer value that is applied to flex items.
+The flex layout is based on the CSS Flex properties where the layout determines how a flex item will grow or shrink to fit the space available in its container. The system relies on a default spacer value `--pf-l-flex--spacer--base`, whose value is `--pf-global--spacer--md` or `16px` that is applied to flex items. By default, `flex-wrap` is set to `wrap` and `align-items` is set to `baseline`.
 
 <br>
+
 ### Default spacing for:
+
 - Flex items (not last child): `margin-right: 16px`.
 - Nested `.pf-l-flex` containers (not last child): `margin-right: 16px`.
 - `.pf-m-column` direct descendants (not last child): `margin-bottom: 16px`.
 - `.pf-m-column` nested `.pf-l-flex` containers (not last child): `margin-bottom: 16px`.
 
 <br>
+
 ### Features:
+
 - `.pf-l-flex` is infinitely nestable and can be used to group items within.
 - `.pf-m-spacer-{xs,sm,md,lg,xl,2xl,3xl}` can be applied to parent or direct children and changes the spacer value for only the element to which it is applied. Responsive spacers can be used by appending `{-on-[breakpoint]}` to `.pf-m-spacer-{size}`. Example: `.pf-m-spacer-lg-on-xl`.
 - `.pf-m-space-items-{xs,sm,md,lg,xl,2xl,3xl}` can be applied to `.pf-l-flex` only and changes the spacing of direct children only. Responsive spacers can be used by appending `{-on-[breakpoint]}` to `.pf-m-space-items-{size}`. Example: `.pf-m-space-items-lg-on-xl`.
 
 <br>
+
 ### Available breakpoints are: `-on-sm, -on-md, -on-lg, -on-xl, -on-2xl`.
 
 <br>
+
 ### Use `.pf-l-flex` when:
+
 - Content dictates layout and elements wrap when necessary.
 - A rigid grid is not necessary/wanted.
 
 <br>
+
 ### `.pf-l-flex` is different than a utility class in that:
+
 - It contains multiple css declarations and does not use the !important tag.
 - It does not require wrapping elements in columns or rows.
 - It breaks the dependency upon adding utility classes to each child.
 - It can be applied to container elements or components.
 
 <br>
-# The CSS approach, by keeping specificity low on base class properties and resetting css variable values at higher specificities, allows any spacer property to be overwritten with a single selector (specificity of 10 or greater).
+
+### The CSS approach, by keeping specificity low on base class properties and resetting css variable values at higher specificities, allows any spacer property to be overwritten with a single selector (specificity of 10 or greater).

--- a/src/patternfly/layouts/Flex/docs/flex-justification.md
+++ b/src/patternfly/layouts/Flex/docs/flex-justification.md
@@ -1,4 +1,4 @@
-# Usage
+## Usage
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |

--- a/src/patternfly/layouts/Flex/docs/flex-layout-responsive.md
+++ b/src/patternfly/layouts/Flex/docs/flex-layout-responsive.md
@@ -1,4 +1,5 @@
 ## Usage
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-column{-on-[breakpoint]}` | `.pf-l-flex`  |  Modifies flex-direction property to column. |

--- a/src/patternfly/layouts/Flex/docs/flex-layout.md
+++ b/src/patternfly/layouts/Flex/docs/flex-layout.md
@@ -2,12 +2,12 @@
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-inline-flex{-on-[breakpoint]}` | `.pf-l-flex` | Modifies display property to inline-flex. |
-| `.pf-m-grow{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex-grow property to 1. |
-| `.pf-m-shrink{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex-shrink property to 1. |
-| `.pf-m-full-width{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex item to full width of parent. |
-| `.pf-m-flex-1{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex shorthand property to 1 0 0. |
-| `.pf-m-flex-2{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex shorthand property to 2 0 0. |
-| `.pf-m-flex-3{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex shorthand property to 3 0 0. |
-| `.pf-m-flex-default{-on-[breakpoint]}` | `.pf-l-flex > *` | Resets flex shorthand property to 0 1 auto. |
-| `.pf-m-flex-none{-on-[breakpoint]}` | `.pf-l-flex > *` | Modifies flex shorthand property to none. |
+| `.pf-m-inline-flex{-on-[breakpoint]}` | `.pf-l-flex` | Modifies the flex layout display property to inline-flex. |
+| `.pf-m-grow{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex-grow property to 1. |
+| `.pf-m-shrink{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex-shrink property to 1. |
+| `.pf-m-full-width{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex item to full width of parent. |
+| `.pf-m-flex-1{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 1 0 0. |
+| `.pf-m-flex-2{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 2 0 0. |
+| `.pf-m-flex-3{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 3 0 0. |
+| `.pf-m-flex-default{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets a nested flex layout or flex item flex shorthand property to 0 1 auto. |
+| `.pf-m-flex-none{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to none. |

--- a/src/patternfly/layouts/Flex/docs/flex-layout.md
+++ b/src/patternfly/layouts/Flex/docs/flex-layout.md
@@ -9,5 +9,6 @@
 | `.pf-m-flex-1{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 1 0 0. |
 | `.pf-m-flex-2{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 2 0 0. |
 | `.pf-m-flex-3{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 3 0 0. |
+| `.pf-m-flex-4{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to 4 0 0. |
 | `.pf-m-flex-default{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Resets a nested flex layout or flex item flex shorthand property to 0 1 auto. |
 | `.pf-m-flex-none{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` | Modifies a nested flex layout or flex item flex shorthand property to none. |

--- a/src/patternfly/layouts/Flex/docs/flex-spacing.md
+++ b/src/patternfly/layouts/Flex/docs/flex-spacing.md
@@ -3,4 +3,4 @@
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > .pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |
-| `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |
+| `.pf-m-space-items-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/flex-spacing.md
+++ b/src/patternfly/layouts/Flex/docs/flex-spacing.md
@@ -2,5 +2,5 @@
 # Applying `.pf-m-space-items-{size}` to `.pf-l-flex` will override css variable values for direct descendants, excluding last child. This spacing can be overridden for direct descendant with `.pf-m-spacer-{size}`.
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > .pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |
+| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |
 | `.pf-m-space-items-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/flex-spacing.md
+++ b/src/patternfly/layouts/Flex/docs/flex-spacing.md
@@ -2,5 +2,5 @@
 # Applying `.pf-m-space-items-{size}` to `.pf-l-flex` will override css variable values for direct descendants, excluding last child. This spacing can be overridden for direct descendant with `.pf-m-spacer-{size}`.
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > *` |  Modifies spacer value. |
-| `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies all direct descendant spacer values. |
+| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > *` |  Modifies a nested flex layout or a flex item spacing. |
+| `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/flex-spacing.md
+++ b/src/patternfly/layouts/Flex/docs/flex-spacing.md
@@ -2,5 +2,5 @@
 # Applying `.pf-m-space-items-{size}` to `.pf-l-flex` will override css variable values for direct descendants, excluding last child. This spacing can be overridden for direct descendant with `.pf-m-spacer-{size}`.
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > *` |  Modifies a nested flex layout or a flex item spacing. |
+| `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex`, `.pf-l-flex > .pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |
 | `.pf-m-item-spacing-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex` |  Modifies the flex layout direct descendant spacing. |

--- a/src/patternfly/layouts/Flex/docs/flex-spacing.md
+++ b/src/patternfly/layouts/Flex/docs/flex-spacing.md
@@ -1,5 +1,7 @@
-# Applying `.pf-m-spacer-{size}` to direct descendants of `.pf-l-flex` will override css variable value.
-# Applying `.pf-m-space-items-{size}` to `.pf-l-flex` will override css variable values for direct descendants, excluding last child. This spacing can be overridden for direct descendant with `.pf-m-spacer-{size}`.
+**Applying `.pf-m-spacer-{size}` to direct descendants of `.pf-l-flex` will override css variable value.**
+
+**Applying `.pf-m-space-items-{size}` to `.pf-l-flex` will override css variable values for direct descendants, excluding last child. This spacing can be overridden for direct descendant with `.pf-m-spacer-{size}`.**
+
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-m-spacer-{none, xs, sm, md, lg, xl, 2xl}{-on-[breakpoint]}` | `.pf-l-flex > .pf-l-flex`, `.pf-l-flex__item` |  Modifies a nested flex layout or a flex item spacing. |

--- a/src/patternfly/layouts/Flex/examples/flex-alignment-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-alignment-example.hbs
@@ -71,30 +71,6 @@
       Flex item
     {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex-item}}
-    Flex item
-  {{/l-flex-item}}
-  {{#> l-flex-item}}
-    Flex item
-  {{/l-flex-item}}
-{{/l-flex}}
-
-{{#> example-title}}Using <code>.pf-m-flex-1</code> to align adjacent content.{{/example-title}}
-{{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1"}}
-    {{#> l-flex-item}}
-      Flex item
-    {{/l-flex-item}}
-    {{#> l-flex-item}}
-      Flex item
-    {{/l-flex-item}}
-    {{#> l-flex-item}}
-      Flex item
-    {{/l-flex-item}}
-    {{#> l-flex-item}}
-      Flex item
-    {{/l-flex-item}}
-  {{/l-flex}}
   {{#> l-flex newcontext}}
     {{#> l-flex-item}}
       Flex item

--- a/src/patternfly/layouts/Flex/examples/flex-alignment-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-alignment-example.hbs
@@ -1,109 +1,198 @@
 {{#> example-title}}Aligning right with <code>.pf-m-align-right</code>. This solution will always align element right by setting margin-left: auto, including when wrapped.{{/example-title}}
 {{#> l-flex l-flex--modifier="example-border"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="pf-m-align-right example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-align-right"}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Align right on single item.{{/example-title}}
 {{#> l-flex l-flex--modifier="example-border"}}
-  {{#> example-text example-text--modifier="pf-m-align-right example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-align-right"}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Align right on multiple groups.{{/example-title}}
-{{#> l-flex l-flex--modifier="example-border"}}
+{{#> l-flex}}
   {{#> l-flex newcontext}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
   {{#> l-flex newcontext l-flex--modifier="pf-m-align-right"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
   {{#> l-flex newcontext l-flex--modifier="pf-m-align-right"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Using <code>.pf-m-flex-1</code> to align adjacent content.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Using <code>.pf-m-flex-1</code> to align adjacent content.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Aligning nested columns with <code>.pf-m-align-self-flex-end</code>.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-flex-end example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-flex-end"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Aligning nested columns with <code>.pf-m-align-self-center</code>.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-center example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-center"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Aligning nested columns with <code>.pf-m-align-self-baseline</code>.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-baseline example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-baseline"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Aligning nested columns with <code>.pf-m-align-self-stretch</code>.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-stretch example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column pf-m-align-self-stretch"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/examples/flex-basic-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-basic-example.hbs
@@ -2,25 +2,42 @@
   Basic flex - <code>.pf-l-flex</code>.
 </h2>
 {{#> l-flex}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 <h2 class="example-title">
   Flex nesting - <code>.pf-l-flex > .pf-l-flex</code>.
 </h2>
 {{#> l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
@@ -28,13 +45,25 @@
   Nested flex and items.
 </h2>
 {{#> l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/examples/flex-justification-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-justification-example.hbs
@@ -1,21 +1,41 @@
 {{#> example-title}}Justify content with <code>.pf-m-justify-content-flex-end</code>.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-justify-content-flex-end example-border"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Justify content with <code>.pf-m-justify-content-space-between</code>.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-justify-content-space-between example-border"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Justify content with <code>.pf-m-justify-content-flex-start</code>.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-justify-content-flex-start example-border"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/examples/flex-layout-column-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-layout-column-example.hbs
@@ -1,82 +1,63 @@
 {{#> example-title}}Flex column layout. When <code>.pf-m-column</code> is applied to <code>.pf-l-flex</code>, spacing will be applied to margin-bottom for direct descendants.{{/example-title}}
-{{#> l-flex l-flex--modifier="pf-m-column example-border" l-flex--attribute='data-label=".pf-m-column"'}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+{{#> l-flex l-flex--modifier="pf-m-column"}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Stacking <code>.pf-l-flex</code> elements.{{/example-title}}
-{{#> l-flex l-flex--modifier="pf-m-column example-border" l-flex--attribute='data-label=".pf-m-column"'}}
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+{{#> l-flex l-flex--modifier="pf-m-column"}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Nesting <code>.pf-l-flex</code> elements and setting to <code>.pf-m-column</code>.{{/example-title}}
-{{#> l-flex l-flex--modifier="example-border"}}
-  {{#> l-flex l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-{{/l-flex}}
-
-{{#> example-title}}Adjusting width with <code>.pf-m-grow</code>. In this example, the second item is set to <code>.pf-m-grow</code> and will occupy the remaining available space.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-grow example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-{{/l-flex}}
-
-{{#> example-title}}Adjusting width with <code>.pf-m-flex-1</code>. In this example, all direct descendants are set to <code>.pf-m-flex-1</code>. They will share available space equally.{{/example-title}}
-{{#> l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-{{/l-flex}}
-
-{{#> example-title}}Specifying column widths with <code>.pf-m-flex-{1,2,3}</code>.{{/example-title}}
-{{#> l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-2 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-3 example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/examples/flex-layout-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-layout-example.hbs
@@ -26,7 +26,7 @@
 
 {{#> example-title}}Adjusting width with <code>.pf-m-grow</code>. In this example, the first group is set to <code>.pf-m-grow</code> and will occupy the remaining available space.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex}}
+  {{#> l-flex l-flex--modifier="pf-m-grow"}}
     {{#> l-flex-item}}
       Flex item
     {{/l-flex-item}}

--- a/src/patternfly/layouts/Flex/examples/flex-layout-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-layout-example.hbs
@@ -1,61 +1,109 @@
 {{#> example-title}}Default layout <code>.pf-l-flex</code>.{{/example-title}}
 {{#> l-flex l-flex--modifier="example-border"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Inline flex <code>.pf-m-inline-flex</code>.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-inline-flex example-border"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 {{#> example-title}}Adjusting width with <code>.pf-m-grow</code>. In this example, the first group is set to <code>.pf-m-grow</code> and will occupy the remaining available space.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-grow example-border" l-flex--attribute='data-label=".pf-m-grow"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Adjusting width with <code>.pf-m-flex-1</code>. In this example, all groups are set to <code>.pf-m-flex-1</code>. They will share available space equally.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border" l-flex--attribute='data-label=".pf-m-flex-1"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-flex-1"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border" l-flex--attribute='data-label=".pf-m-flex-1"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-flex-1"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border" l-flex--attribute='data-label=".pf-m-flex-1"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-flex-1"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Specifying column widths with <code>.pf-m-flex-{1,2,3}</code>.{{/example-title}}
 {{#> l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-1 example-border" l-flex--attribute='data-label=".pf-m-flex-1"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-flex-1"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-2 example-border" l-flex--attribute='data-label=".pf-m-flex-2"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-flex-2"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
-  {{#> l-flex l-flex--modifier="pf-m-flex-3 example-border" l-flex--attribute='data-label=".pf-m-flex-3"'}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex l-flex--modifier="pf-m-flex-3"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/examples/flex-layout-responsive-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-layout-responsive-example.hbs
@@ -1,4 +1,4 @@
-{{#> example-title}}Switching between flex-direction column and row at breakpoints (-on-lg).{{/example-title}}
+{{#> example-title}}Switching between flex-direction column and row at breakpoints (<code>-on-lg</code>).{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-lg"}}
   {{#> l-flex newcontext}}
     {{#> l-flex-item}}
@@ -25,7 +25,7 @@
   {{/l-flex}}
 {{/l-flex}}
 
-{{#> example-title}}Switching between flex-direction column and row at breakpoints (-on-lg). If content is likely to wrap, modifiers will need to be used to control width. The example below wraps because the flex item expands in response to long paragraph text.{{/example-title}}
+{{#> example-title}}Switching between flex-direction column and row at breakpoints (<code>-on-lg</code>). If content is likely to wrap, modifiers will need to be used to control width. The example below wraps because the flex item expands in response to long paragraph text.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-lg"}}
   {{#> l-flex newcontext}}
     {{#> l-flex-item}}
@@ -46,9 +46,9 @@
   {{/l-flex}}
 {{/l-flex}}
 
-{{#> example-title}}Switching between flex-direction column and row at breakpoints (-on-lg). To control the width of the flex item, set <code>.pf-m-flex-1</code> on the flex group containing the long paragraph text.{{/example-title}}
+{{#> example-title}}Switching between flex-direction column and row at breakpoints (<code>-on-lg</code>). To control the width of the flex item, set <code>.pf-m-flex-1</code> on the flex group containing the long paragraph text.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-lg"}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1 pf-m-align-items-flex-start"}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1"}}
     {{#> l-flex-item}}
       Flex item
     {{/l-flex-item}}

--- a/src/patternfly/layouts/Flex/examples/flex-layout-responsive-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-layout-responsive-example.hbs
@@ -1,44 +1,68 @@
 {{#> example-title}}Switching between flex-direction column and row at breakpoints (-on-lg).{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-lg"}}
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Switching between flex-direction column and row at breakpoints (-on-lg). If content is likely to wrap, modifiers will need to be used to control width. The example below wraps because the flex item expands in response to long paragraph text.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-lg"}}
-  {{#> l-flex newcontext l-flex--modifier="example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}
+  {{#> l-flex newcontext}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
       <b>Because this text is long enough to wrap, this item's width will force the adjacent item to wrap.</b> Lorem ipsum dolor sit amet consectetur adipisicing elit. Est animi modi temporibus, alias qui obcaecati ullam dolor nam, nulla magni iste rem praesentium numquam provident amet ut nesciunt harum accusamus.
-    {{/example-text}}
+    {{/l-flex-item}}
   {{/l-flex}}
 
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}
 
 {{#> example-title}}Switching between flex-direction column and row at breakpoints (-on-lg). To control the width of the flex item, set <code>.pf-m-flex-1</code> on the flex group containing the long paragraph text.{{/example-title}}
 {{#> l-flex l-flex--modifier="pf-m-column pf-m-row-on-lg"}}
-  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1 pf-m-align-items-flex-start example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="pf-m-flex-1 example-border"}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-flex-1 pf-m-align-items-flex-start"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item l-flex-item--modifier="pf-m-flex-1"}}
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Est animi modi temporibus, alias qui obcaecati ullam dolor nam, nulla magni iste rem praesentium numquam provident amet ut nesciunt harum accusamus.
-    {{/example-text}}
+    {{/l-flex-item}}
   {{/l-flex}}
 
-  {{#> l-flex newcontext l-flex--modifier="pf-m-column example-border"}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-    {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex newcontext l-flex--modifier="pf-m-column"}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
+    {{#> l-flex-item}}
+      Flex item
+    {{/l-flex-item}}
   {{/l-flex}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/examples/flex-spacing-example.hbs
+++ b/src/patternfly/layouts/Flex/examples/flex-spacing-example.hbs
@@ -1,32 +1,69 @@
 {{#> example-title}}Individually spaced items - <code>.pf-m-spacer-{xs,sm,md,lg,xl,2xl,3xl}</code>.{{/example-title}}
 {{#> l-flex}}
-  {{#> example-text example-text--modifier="example-border pf-m-spacer-xs"}}Item - xs{{/example-text}}
-    {{#> example-text example-text--modifier="example-border pf-m-spacer-sm"}}Item - sm{{/example-text}}
-    {{#> example-text example-text--modifier="example-border pf-m-spacer-md"}}Item - md{{/example-text}}
-    {{#> example-text example-text--modifier="example-border pf-m-spacer-lg"}}Item - lg{{/example-text}}
-    {{#> example-text example-text--modifier="example-border pf-m-spacer-xl"}}Item - xl{{/example-text}}
-    {{#> example-text example-text--modifier="example-border pf-m-spacer-2xl"}}Item - 2xl{{/example-text}}
-    {{#> example-text example-text--modifier="example-border pf-m-spacer-3xl"}}Item - 3xl{{/example-text}}
-  {{/l-flex}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-none"}}
+    Item - none
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-xs"}}
+    Item - xs
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-sm"}}
+    Item - sm
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-md"}}
+    Item - md
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-lg"}}
+    Item - lg
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-xl"}}
+    Item - xl
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-2xl"}}
+    Item - 2xl
+  {{/l-flex-item}}
+  {{#> l-flex-item l-flex-item--modifier="pf-m-spacer-3xl"}}
+    Item - 3xl
+  {{/l-flex-item}}
+{{/l-flex}}
 
 <h2 class="example-title">
   Flex with modified spacing - <code>.pf-m-space-items-xl</code>.
 </h2>
 {{#> l-flex l-flex--modifier="pf-m-space-items-xl"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}
 
 <h2 class="example-title">
   Flex with modified spacing - <code>.pf-m-space-items-none</code>.
 </h2>
 {{#> l-flex l-flex--modifier="pf-m-space-items-none"}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
-  {{#> example-text example-text--modifier="example-border"}}Flex item{{/example-text}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
+  {{#> l-flex-item}}
+    Flex item
+  {{/l-flex-item}}
 {{/l-flex}}

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -1,110 +1,7 @@
-// Spacer values
-$pf-flex-spacer-map: (
-  "none": 0,
-  "xs": "var(--pf-l-flex--spacer--xs)",
-  "sm": "var(--pf-l-flex--spacer--sm)",
-  "md": "var(--pf-l-flex--spacer--md)",
-  "lg": "var(--pf-l-flex--spacer--lg)",
-  "xl": "var(--pf-l-flex--spacer--xl)",
-  "2xl": "var(--pf-l-flex--spacer--2xl)",
-  "3xl": "var(--pf-l-flex--spacer--3xl)"
-);
-
-@mixin pf-l-flex--space-items-builder {
-  @each $prop, $value in $pf-flex-spacer-map {
-    &.pf-m-space-items-#{$prop} > * {
-      --pf-l-flex--spacer: #{$value};
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--sm) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      &.pf-m-space-items-#{$prop}-on-sm > * {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      &.pf-m-space-items-#{$prop}-on-md > * {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      &.pf-m-space-items-#{$prop}-on-lg > * {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--xl) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      &.pf-m-space-items-#{$prop}-on-xl > * {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--2xl) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      &.pf-m-space-items-#{$prop}-on-2xl > * {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-}
-
-@mixin pf-l-flex--spacer-builder {
-  @each $prop, $value in $pf-flex-spacer-map {
-    .pf-m-spacer-#{$prop} {
-      --pf-l-flex--spacer: #{$value};
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--sm) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      .pf-m-spacer-#{$prop}-on-sm {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--md) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      .pf-m-spacer-#{$prop}-on-md {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--lg) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      .pf-m-spacer-#{$prop}-on-lg {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--xl) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      .pf-m-spacer-#{$prop}-on-xl {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-
-  @media screen and (min-width: $pf-global--breakpoint--2xl) {
-    @each $prop, $value in $pf-flex-spacer-map {
-      .pf-m-spacer-#{$prop}-on-2xl {
-        --pf-l-flex--spacer: #{$value};
-      }
-    }
-  }
-}
+// Always keep list of spacers and breakpoints up-to-date
+$pf-l-flex--breakpoint-map: build-breakpoint-map();
+$pf-l-flex--spacer-map: build-spacer-map();
+$pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--spacer-map);
 
 .pf-l-flex {
   --pf-l-flex--Display: flex;
@@ -118,274 +15,276 @@ $pf-flex-spacer-map: (
   --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
   --pf-l-flex--flex--spacer: var(--pf-global--spacer--lg);
 
-  // Flex spacer values
-  --pf-l-flex--spacer--none: 0;
-  --pf-l-flex--spacer--xs: var(--pf-global--spacer--xs);
-  --pf-l-flex--spacer--sm: var(--pf-global--spacer--sm);
-  --pf-l-flex--spacer--md: var(--pf-global--spacer--md);
-  --pf-l-flex--spacer--lg: var(--pf-global--spacer--lg);
-  --pf-l-flex--spacer--xl: var(--pf-global--spacer--xl);
-  --pf-l-flex--spacer--2xl: var(--pf-global--spacer--2xl);
-  --pf-l-flex--spacer--3xl: var(--pf-global--spacer--3xl);
+  // Emit spacer css variables that map to requested spacer values
+  @include pf-emit-properties($pf-l-flex--variable-map);
 
   display: var(--pf-l-flex--Display);
   flex-wrap: var(--pf-l-flex--FlexWrap);
   align-items: var(--pf-l-flex--AlignItems);
+}
 
-  // Establish default item spacing
-  > * {
-    margin-right: var(--pf-l-flex--spacer);
+/* stylelint-disable no-duplicate-selectors, max-nesting-depth */
 
-    &:last-child:not([class*="pf-m-spacer"]) {
-      --pf-l-flex--spacer: 0;
-    }
+// Flex
+.pf-l-flex {
+  --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
+
+  &:last-child {
+    --pf-l-flex--spacer: 0;
   }
+}
 
-  // Reset item spacing in nested flex layouts
-  & & {
-    --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
+// Item
+.pf-l-flex > *,
+.pf-l-flex__item {
+  // reset spacer
+  --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
 
-    > * {
-      --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
-    }
-
-    > :last-child:not([class*="pf-m-spacer"]),
-    &:last-child:not([class*="pf-m-spacer"]) {
-      --pf-l-flex--spacer: 0;
-    }
+  &:last-child {
+    --pf-l-flex--spacer: 0;
   }
+}
 
-  @include pf-l-flex--space-items-builder;
-  @include pf-l-flex--spacer-builder;
+// Use global selector to
+.pf-l-flex > *,
+.pf-l-flex__item {
+  margin-right: var(--pf-l-flex--spacer);
+}
 
-  // Breakpoints with responsive modifiers
-  $breakpoint-list: (
-    (null),
-    ($pf-global--breakpoint--sm, "-on-sm"),
-    ($pf-global--breakpoint--md,"-on-md"),
-    ($pf-global--breakpoint--lg, "-on-lg"),
-    ($pf-global--breakpoint--xl, "-on-xl"),
-    ($pf-global--breakpoint--2xl, "-on-2xl")
-  );
+.pf-l-flex {
+  @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
-  // List of modifiers
-  @mixin flex-modifiers($mod: null) {
-    // display
-    &.pf-m-flex#{$mod} {
-      display: var(--pf-l-flex--Display);
-    }
+    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
+        &.pf-m-space-items-#{$spacer}#{$breakpoint-name} {
+          > * {
+            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
+          }
 
-    &.pf-m-inline-flex#{$mod} {
-      --pf-l-flex--Display: inline-flex;
-    }
-
-    // flex-direction
-    &.pf-m-column#{$mod} {
-      flex-direction: column;
-      align-items: normal;
-
-      > * {
-        margin: 0 0 var(--pf-l-flex--spacer) 0;
+          > :last-child {
+            --pf-l-flex--spacer: 0;
+          }
+        }
       }
-    }
 
-    // flex-direction
-    &.pf-m-column-reverse#{$mod} {
-      flex-direction: column-reverse;
-      align-items: normal;
+      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
+        .pf-m-spacer-#{$spacer}#{$breakpoint-name} {
+          --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
 
-      > * {
-        margin: var(--pf-l-flex--spacer) 0 0 0;
+          &:last-child {
+            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
+          }
+        }
       }
-    }
 
-    &.pf-m-row#{$mod} {
-      flex-direction: row;
-      align-items: var(--pf-l-flex--m-row--AlignItems);
-
-      // unset styling set for .pf-m-column
-      > * {
-        margin: 0 var(--pf-l-flex--spacer) 0 0;
+      // display
+      &.pf-m-flex#{$breakpoint-name},
+      .pf-m-flex#{$breakpoint-name} {
+        display: var(--pf-l-flex--Display);
       }
-    }
 
-    &.pf-m-row-reverse#{$mod} {
-      flex-direction: row-reverse;
-      align-items: var(--pf-l-flex--m-row-reverse--AlignItems);
-
-      // unset styling set for .pf-m-column
-      > * {
-        margin: 0 0 0 var(--pf-l-flex--spacer);
+      &.pf-m-inline-flex#{$breakpoint-name},
+      .pf-m-inline-flex#{$breakpoint-name} {
+        --pf-l-flex--Display: inline-flex;
       }
-    }
 
-    // flex-wrap
-    &.pf-m-wrap#{$mod} {
-      flex-wrap: wrap;
-    }
+      // flex-direction
+      &.pf-m-column#{$breakpoint-name} {
+        flex-direction: column;
+        align-items: normal;
 
-    &.pf-m-wrap-reverse#{$mod} {
-      flex-wrap: wrap-reverse;
-    }
+        > * {
+          margin: 0 0 var(--pf-l-flex--spacer) 0;
+        }
+      }
 
-    &.pf-m-nowrap#{$mod} {
-      flex-wrap: nowrap;
-    }
+      // flex-direction
+      &.pf-m-column-reverse#{$breakpoint-name} {
+        flex-direction: column-reverse;
+        align-items: normal;
 
-    // justify-content
-    &.pf-m-justify-content-flex-start#{$mod} {
-      justify-content: flex-start;
-    }
+        > * {
+          margin: var(--pf-l-flex--spacer) 0 0 0;
+        }
+      }
 
-    &.pf-m-justify-content-flex-end#{$mod} {
-      justify-content: flex-end;
-    }
+      &.pf-m-row#{$breakpoint-name} {
+        flex-direction: row;
+        align-items: var(--pf-l-flex--m-row--AlignItems);
 
-    &.pf-m-justify-content-center#{$mod} {
-      justify-content: center;
-    }
+        // unset styling set for .pf-m-column
+        > * {
+          margin: 0 var(--pf-l-flex--spacer) 0 0;
+        }
+      }
 
-    &.pf-m-justify-content-space-between#{$mod} {
-      justify-content: space-between;
-    }
+      &.pf-m-row-reverse#{$breakpoint-name} {
+        flex-direction: row-reverse;
+        align-items: var(--pf-l-flex--m-row-reverse--AlignItems);
 
-    &.pf-m-justify-content-space-around#{$mod} {
-      justify-content: space-around;
-    }
+        // unset styling set for .pf-m-column
+        > * {
+          margin: 0 0 0 var(--pf-l-flex--spacer);
+        }
+      }
 
-    &.pf-m-justify-content-space-evenly#{$mod} {
-      justify-content: space-evenly;
-    }
+      // flex-wrap
+      &.pf-m-wrap#{$breakpoint-name} {
+        flex-wrap: wrap;
+      }
 
-    // align-items
-    &.pf-m-align-items-flex-start#{$mod} {
-      align-items: flex-start;
-    }
+      &.pf-m-wrap-reverse#{$breakpoint-name} {
+        flex-wrap: wrap-reverse;
+      }
 
-    &.pf-m-align-items-flex-end#{$mod} {
-      align-items: flex-end;
-    }
+      &.pf-m-nowrap#{$breakpoint-name} {
+        flex-wrap: nowrap;
+      }
 
-    &.pf-m-align-items-center#{$mod} {
-      align-items: center;
-    }
+      // justify-content
+      &.pf-m-justify-content-flex-start#{$breakpoint-name} {
+        justify-content: flex-start;
+      }
 
-    &.pf-m-align-items-stretch#{$mod} {
-      align-items: stretch;
-    }
+      &.pf-m-justify-content-flex-end#{$breakpoint-name} {
+        justify-content: flex-end;
+      }
 
-    &.pf-m-align-items-baseline#{$mod} {
-      align-items: baseline;
-    }
+      &.pf-m-justify-content-center#{$breakpoint-name} {
+        justify-content: center;
+      }
 
-    // align-content
-    &.pf-m-align-content-flex-start#{$mod} {
-      align-content: flex-start;
-    }
+      &.pf-m-justify-content-space-between#{$breakpoint-name} {
+        justify-content: space-between;
+      }
 
-    &.pf-m-align-content-flex-end#{$mod} {
-      align-content: flex-end;
-    }
+      &.pf-m-justify-content-space-around#{$breakpoint-name} {
+        justify-content: space-around;
+      }
 
-    &.pf-m-align-content-center#{$mod} {
-      align-content: center;
-    }
+      &.pf-m-justify-content-space-evenly#{$breakpoint-name} {
+        justify-content: space-evenly;
+      }
 
-    &.pf-m-align-content-stretch#{$mod} {
-      align-content: stretch;
-    }
+      // align-items
+      &.pf-m-align-items-flex-start#{$breakpoint-name} {
+        align-items: flex-start;
+      }
 
-    &.pf-m-align-content-space-between#{$mod} {
-      align-content: space-between;
+      &.pf-m-align-items-flex-end#{$breakpoint-name} {
+        align-items: flex-end;
+      }
 
-      > * {
-        margin-right: 0;
+      &.pf-m-align-items-center#{$breakpoint-name} {
+        align-items: center;
+      }
+
+      &.pf-m-align-items-stretch#{$breakpoint-name} {
+        align-items: stretch;
+      }
+
+      &.pf-m-align-items-baseline#{$breakpoint-name} {
+        align-items: baseline;
+      }
+
+      // align-content
+      &.pf-m-align-content-flex-start#{$breakpoint-name} {
+        align-content: flex-start;
+      }
+
+      &.pf-m-align-content-flex-end#{$breakpoint-name} {
+        align-content: flex-end;
+      }
+
+      &.pf-m-align-content-center#{$breakpoint-name} {
+        align-content: center;
+      }
+
+      &.pf-m-align-content-stretch#{$breakpoint-name} {
+        align-content: stretch;
+      }
+
+      &.pf-m-align-content-space-between#{$breakpoint-name} {
+        align-content: space-between;
+
+        > * {
+          margin-right: 0;
+          margin-left: 0;
+        }
+      }
+
+      &.pf-m-align-content-space-around#{$breakpoint-name} {
+        align-content: space-around;
+      }
+
+      // alignment
+      &.pf-m-align-right#{$breakpoint-name},
+      .pf-m-align-right#{$breakpoint-name} {
+        margin-left: auto;
+      }
+
+      &.pf-m-align-left#{$breakpoint-name},
+      .pf-m-align-left#{$breakpoint-name} {
+        margin-right: var(--pf-l-flex--spacer);
         margin-left: 0;
       }
-    }
 
-    &.pf-m-align-content-space-around#{$mod} {
-      align-content: space-around;
-    }
-
-    // alignment
-    &.pf-m-align-right#{$mod},
-    .pf-m-align-right#{$mod} {
-      margin-left: auto;
-    }
-
-    &.pf-m-align-left#{$mod},
-    .pf-m-align-left#{$mod} {
-      margin-right: var(--pf-l-flex--spacer);
-      margin-left: 0;
-    }
-
-    // item properties
-    .pf-m-grow#{$mod} {
-      flex-grow: 1;
-    }
-
-    .pf-m-shrink#{$mod} {
-      flex-shrink: 1;
-    }
-
-    .pf-m-full-width#{$mod} {
-      width: 100%;
-      margin-right: 0;
-    }
-
-    .pf-m-flex-1#{$mod} {
-      flex: 1 0 0;
-    }
-
-    .pf-m-flex-2#{$mod} {
-      flex: 2 0 0;
-    }
-
-    .pf-m-flex-3#{$mod} {
-      flex: 3 0 0;
-    }
-
-    .pf-m-flex-default {
-      flex: 0 1 auto;
-    }
-
-    &.pf-m-flex-none#{$mod} {
-      flex: none;
-    }
-
-    // align-self
-    .pf-m-align-self-flex-start#{$mod} {
-      align-self: flex-start;
-    }
-
-    .pf-m-align-self-flex-end#{$mod} {
-      align-self: flex-end;
-    }
-
-    .pf-m-align-self-center#{$mod} {
-      align-self: center;
-    }
-
-    .pf-m-align-self-baseline#{$mod} {
-      align-self: baseline;
-    }
-
-    .pf-m-align-self-stretch#{$mod} {
-      align-self: stretch;
-    }
-  }
-
-  /* stylelint-disable */
-  // Build the base + responsive modifier selectors
-  @each $bp, $mod in $breakpoint-list {
-    @if $bp {
-      @media screen and (min-width: #{$bp}) {
-        @include flex-modifiers($mod);
+      // item properties
+      .pf-m-grow#{$breakpoint-name} {
+        flex-grow: 1;
       }
-    } @else {
-      @include flex-modifiers($mod);
+
+      .pf-m-shrink#{$breakpoint-name} {
+        flex-shrink: 1;
+      }
+
+      .pf-m-full-width#{$breakpoint-name} {
+        width: 100%;
+        margin-right: 0;
+      }
+
+      .pf-m-flex-1#{$breakpoint-name} {
+        flex: 1 0 0;
+      }
+
+      .pf-m-flex-2#{$breakpoint-name} {
+        flex: 2 0 0;
+      }
+
+      .pf-m-flex-3#{$breakpoint-name} {
+        flex: 3 0 0;
+      }
+
+      .pf-m-flex-default#{$breakpoint-name} {
+        flex: 0 1 auto;
+      }
+
+      .pf-m-flex-none#{$breakpoint-name} {
+        flex: none;
+      }
+
+      // align-self
+      .pf-m-align-self-flex-start#{$breakpoint-name} {
+        align-self: flex-start;
+      }
+
+      .pf-m-align-self-flex-end#{$breakpoint-name} {
+        align-self: flex-end;
+      }
+
+      .pf-m-align-self-center#{$breakpoint-name} {
+        align-self: center;
+      }
+
+      .pf-m-align-self-baseline#{$breakpoint-name} {
+        align-self: baseline;
+      }
+
+      .pf-m-align-self-stretch#{$breakpoint-name} {
+        align-self: stretch;
+      }
     }
   }
-  /* stylelint-enable */
 }
+/* stylelint-enable */

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -176,11 +176,6 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
 
       &.pf-m-align-content-space-between#{$breakpoint-name} {
         align-content: space-between;
-
-        > * {
-          margin-right: 0;
-          margin-left: 0;
-        }
       }
 
       &.pf-m-align-content-space-around#{$breakpoint-name} {
@@ -193,7 +188,6 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
       }
 
       > .pf-m-align-left#{$breakpoint-name} {
-        margin-right: var(--pf-l-flex--spacer);
         margin-left: 0;
       }
 

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -13,7 +13,6 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   // Default values: these get reset based on modifier usage
   --pf-l-flex--spacer-base: var(--pf-global--spacer--md);
   --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
-  --pf-l-flex--flex--spacer: var(--pf-global--spacer--lg);
 
   // Emit spacer css variables that map to requested spacer values
   @include pf-emit-properties($pf-l-flex--variable-map);
@@ -21,34 +20,24 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
   display: var(--pf-l-flex--Display);
   flex-wrap: var(--pf-l-flex--FlexWrap);
   align-items: var(--pf-l-flex--AlignItems);
+
+  &:last-child {
+    --pf-l-flex--spacer: 0;
+  }
 }
 
 /* stylelint-disable no-duplicate-selectors, max-nesting-depth */
 
-// Flex
-.pf-l-flex {
-  --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
-
-  &:last-child {
-    --pf-l-flex--spacer: 0;
-  }
-}
-
 // Item
-.pf-l-flex > *,
-.pf-l-flex__item {
+.pf-l-flex > * {
   // reset spacer
   --pf-l-flex--spacer: var(--pf-l-flex--spacer-base);
 
+  margin-right: var(--pf-l-flex--spacer);
+
   &:last-child {
     --pf-l-flex--spacer: 0;
   }
-}
-
-// Use global selector to
-.pf-l-flex > *,
-.pf-l-flex__item {
-  margin-right: var(--pf-l-flex--spacer);
 }
 
 .pf-l-flex {
@@ -57,14 +46,12 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
 
     @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
       // display
-      &.pf-m-flex#{$breakpoint-name},
-      .pf-m-flex#{$breakpoint-name} {
+      &.pf-m-flex#{$breakpoint-name} {
         display: var(--pf-l-flex--Display);
       }
 
       // inline flex
-      &.pf-m-inline-flex#{$breakpoint-name},
-      .pf-m-inline-flex#{$breakpoint-name} {
+      &.pf-m-inline-flex#{$breakpoint-name} {
         --pf-l-flex--Display: inline-flex;
       }
 
@@ -201,73 +188,71 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
       }
 
       // alignment
-      &.pf-m-align-right#{$breakpoint-name},
-      .pf-m-align-right#{$breakpoint-name} {
+      > .pf-m-align-right#{$breakpoint-name} {
         margin-left: auto;
       }
 
-      &.pf-m-align-left#{$breakpoint-name},
-      .pf-m-align-left#{$breakpoint-name} {
+      > .pf-m-align-left#{$breakpoint-name} {
         margin-right: var(--pf-l-flex--spacer);
         margin-left: 0;
       }
 
       // item properties
-      .pf-m-grow#{$breakpoint-name} {
+      > .pf-m-grow#{$breakpoint-name} {
         flex-grow: 1;
       }
 
-      .pf-m-shrink#{$breakpoint-name} {
+      > .pf-m-shrink#{$breakpoint-name} {
         flex-shrink: 1;
       }
 
-      .pf-m-full-width#{$breakpoint-name} {
+      > .pf-m-full-width#{$breakpoint-name} {
         width: 100%;
         margin-right: 0;
       }
 
-      .pf-m-flex-1#{$breakpoint-name} {
+      > .pf-m-flex-1#{$breakpoint-name} {
         flex: 1 0 0;
       }
 
-      .pf-m-flex-2#{$breakpoint-name} {
+      > .pf-m-flex-2#{$breakpoint-name} {
         flex: 2 0 0;
       }
 
-      .pf-m-flex-3#{$breakpoint-name} {
+      > .pf-m-flex-3#{$breakpoint-name} {
         flex: 3 0 0;
       }
 
-      .pf-m-flex-4#{$breakpoint-name} {
+      > .pf-m-flex-4#{$breakpoint-name} {
         flex: 4 0 0;
       }
 
-      .pf-m-flex-default#{$breakpoint-name} {
+      > .pf-m-flex-default#{$breakpoint-name} {
         flex: 0 1 auto;
       }
 
-      .pf-m-flex-none#{$breakpoint-name} {
+      > .pf-m-flex-none#{$breakpoint-name} {
         flex: none;
       }
 
       // align-self
-      .pf-m-align-self-flex-start#{$breakpoint-name} {
+      > .pf-m-align-self-flex-start#{$breakpoint-name} {
         align-self: flex-start;
       }
 
-      .pf-m-align-self-flex-end#{$breakpoint-name} {
+      > .pf-m-align-self-flex-end#{$breakpoint-name} {
         align-self: flex-end;
       }
 
-      .pf-m-align-self-center#{$breakpoint-name} {
+      > .pf-m-align-self-center#{$breakpoint-name} {
         align-self: center;
       }
 
-      .pf-m-align-self-baseline#{$breakpoint-name} {
+      > .pf-m-align-self-baseline#{$breakpoint-name} {
         align-self: baseline;
       }
 
-      .pf-m-align-self-stretch#{$breakpoint-name} {
+      > .pf-m-align-self-stretch#{$breakpoint-name} {
         align-self: stretch;
       }
     }

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -56,34 +56,13 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
     $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
 
     @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
-      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
-        &.pf-m-space-items-#{$spacer}#{$breakpoint-name} {
-          > * {
-            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
-          }
-
-          > :last-child {
-            --pf-l-flex--spacer: 0;
-          }
-        }
-      }
-
-      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
-        .pf-m-spacer-#{$spacer}#{$breakpoint-name} {
-          --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
-
-          &:last-child {
-            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
-          }
-        }
-      }
-
       // display
       &.pf-m-flex#{$breakpoint-name},
       .pf-m-flex#{$breakpoint-name} {
         display: var(--pf-l-flex--Display);
       }
 
+      // inline flex
       &.pf-m-inline-flex#{$breakpoint-name},
       .pf-m-inline-flex#{$breakpoint-name} {
         --pf-l-flex--Display: inline-flex;
@@ -99,7 +78,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
         }
       }
 
-      // flex-direction
+      // flex-direction column-reverse
       &.pf-m-column-reverse#{$breakpoint-name} {
         flex-direction: column-reverse;
         align-items: normal;
@@ -109,6 +88,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
         }
       }
 
+      // flex-direction row
       &.pf-m-row#{$breakpoint-name} {
         flex-direction: row;
         align-items: var(--pf-l-flex--m-row--AlignItems);
@@ -119,6 +99,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
         }
       }
 
+      // flex-direction row-reverse
       &.pf-m-row-reverse#{$breakpoint-name} {
         flex-direction: row-reverse;
         align-items: var(--pf-l-flex--m-row-reverse--AlignItems);
@@ -134,6 +115,7 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
         flex-wrap: wrap;
       }
 
+      // flex-wrap reverse
       &.pf-m-wrap-reverse#{$breakpoint-name} {
         flex-wrap: wrap-reverse;
       }
@@ -256,6 +238,10 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
         flex: 3 0 0;
       }
 
+      .pf-m-flex-4#{$breakpoint-name} {
+        flex: 4 0 0;
+      }
+
       .pf-m-flex-default#{$breakpoint-name} {
         flex: 0 1 auto;
       }
@@ -283,6 +269,42 @@ $pf-l-flex--variable-map: build-variable-map("pf-l-flex--spacer", $pf-l-flex--sp
 
       .pf-m-align-self-stretch#{$breakpoint-name} {
         align-self: stretch;
+      }
+    }
+  }
+
+  // .pf-m-space-items-{size}{-on-breakpoint}
+  @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
+        &.pf-m-space-items-#{$spacer}#{$breakpoint-name} {
+          > * {
+            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
+          }
+
+          > :last-child {
+            --pf-l-flex--spacer: 0;
+          }
+        }
+      }
+    }
+  }
+
+  // .pf-m-spacer-{size}{-on-breakpoint}
+  @each $breakpoint, $breakpoint-value in $pf-l-flex--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint, $pf-l-flex--breakpoint-map) {
+      @each $spacer, $spacer-value in $pf-l-flex--spacer-map {
+        .pf-m-spacer-#{$spacer}#{$breakpoint-name} {
+          --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
+
+          &:last-child {
+            --pf-l-flex--spacer: var(#{map-get($pf-l-flex--variable-map, $spacer-value)});
+          }
+        }
       }
     }
   }

--- a/src/patternfly/layouts/Flex/l-flex-item.hbs
+++ b/src/patternfly/layouts/Flex/l-flex-item.hbs
@@ -1,7 +1,7 @@
 <{{#if l-flex-item--type}}{{l-flex-item--type}}{{else}}div{{/if}} class="pf-l-flex__item{{#if l-flex-item--modifier}} {{l-flex-item--modifier}}{{/if}}"
   {{#if l-flex-item--id}}
     id="{{{l-flex-item--id}}}"
-  {{/if}}>
+  {{/if}}
   {{#if l-flex-item--attribute}}
     {{{l-flex-item--attribute}}}
   {{/if}}

--- a/src/patternfly/layouts/Flex/l-flex-item.hbs
+++ b/src/patternfly/layouts/Flex/l-flex-item.hbs
@@ -1,9 +1,9 @@
 <{{#if l-flex-item--type}}{{l-flex-item--type}}{{else}}div{{/if}} class="pf-l-flex__item{{#if l-flex-item--modifier}} {{l-flex-item--modifier}}{{/if}}"
-  {{#if l-flex-item--attribute}}
-    {{{l-flex-item--attribute}}}
-  {{/if}}
   {{#if l-flex-item--id}}
     id="{{{l-flex-item--id}}}"
   {{/if}}>
+  {{#if l-flex-item--attribute}}
+    {{{l-flex-item--attribute}}}
+  {{/if}}
   {{> @partial-block}}
 </{{#if l-flex-item--type}}{{l-flex-item--type}}{{else}}div{{/if}}>

--- a/src/patternfly/layouts/Flex/l-flex-item.hbs
+++ b/src/patternfly/layouts/Flex/l-flex-item.hbs
@@ -4,6 +4,6 @@
   {{/if}}
   {{#if l-flex-item--attribute}}
     {{{l-flex-item--attribute}}}
-  {{/if}}
+  {{/if}}>
   {{> @partial-block}}
 </{{#if l-flex-item--type}}{{l-flex-item--type}}{{else}}div{{/if}}>

--- a/src/patternfly/sass-utilities/functions.scss
+++ b/src/patternfly/sass-utilities/functions.scss
@@ -33,13 +33,24 @@
 @function build-breakpoint-map($map-items...) {
   $map: ();
 
-  @each $breakpoint in $map-items {
-    @if $breakpoint == "base" {
-      $map: map-merge($map, ($breakpoint: null));
-    }
+  @if length($map-items) == 0 {
+    $map: ("base": null);
+    $map: map-merge($map, $pf-global--breakpoint-name-map);
+  }
 
-    @else {
-      $map: map-merge($map, ($breakpoint: map-get($pf-global--breakpoint-name-map, #{$breakpoint})));
+  @else {
+    @each $breakpoint in $map-items {
+      @if not map-has-key($pf-global--breakpoint-name-map, $breakpoint) and $breakpoint != "base" {
+        $map: map-merge($map, ("invalid breakpoint #{$breakpoint}": null));
+      }
+
+      @else if $breakpoint == "base" {
+        $map: map-merge($map, ($breakpoint: null));
+      }
+
+      @else {
+        $map: map-merge($map, ($breakpoint: map-get($pf-global--breakpoint-name-map, #{$breakpoint})));
+      }
     }
   }
 
@@ -51,8 +62,18 @@
 @function build-spacer-map($map-items...) {
   $map: ();
 
+  @if length($map-items) == 0 {
+    $map: ("none": 0);
+    $map: map-merge($map, $pf-global--spacer-map);
+    $map: map-remove($map, "auto", "0");
+  }
+
   @each $spacer in $map-items {
-    @if $spacer == "none" {
+    @if not map-has-key($pf-global--spacer-map, $spacer) and $spacer != "none" {
+      $map: map-merge($map, ("invalid spacer #{$spacer}": null));
+    }
+
+    @else if $spacer == "none" {
       $map: map-merge($map, ($spacer: 0));
     }
 
@@ -62,4 +83,16 @@
   }
 
   @return $map;
+}
+
+// Build variable map
+// Based on custom map
+@function build-variable-map($namespace, $map: ()) {
+  $new-map: ();
+
+  @each $size, $value in $map {
+    $new-map: map-merge($new-map, (map-get($map, $size): --#{$namespace}--#{$size}));
+  }
+
+  @return $new-map;
 }

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -174,7 +174,7 @@
 
 // Apply media query if value is passed
 @mixin pf-apply-breakpoint($breakpoint, $breakpoint-map: $pf-global--breakpoint-name-map) {
-  @if ($breakpoint == "null" or $breakpoint == "base") {
+  @if ($breakpoint == "null" or $breakpoint == "base" or $breakpoint == "") {
     @content;
   }
 
@@ -184,5 +184,11 @@
     @media (min-width: $breakpoint) {
       @content;
     }
+  }
+}
+
+@mixin pf-emit-properties($map) {
+  @each $prop, $value in $map {
+    #{$value}: #{$prop};
   }
 }

--- a/src/site/workspace.scss
+++ b/src/site/workspace.scss
@@ -335,6 +335,8 @@ html {
   .pf-l-stack > *,
   .pf-l-toolbar__group,
   .pf-l-toolbar__item,
+  .pf-l-flex .pf-l-flex,
+  .pf-l-flex__item,
   [class*="pf-u-"],
   [class*="pf-u-"] > *:not(svg),
   .pf-c-data-toolbar,
@@ -524,35 +526,10 @@ html {
   --example--Color: #888;
   --example--BorderColor: rgba(0, 0, 0, .1);
 
-  padding: 40px;
-
   .example-border {
     background: none;
     border: 2px dashed #393f44;
     box-shadow: none;
-  }
-
-  .pf-l-grid .pf-l-grid__item {
-    padding: .5rem;
-  }
-
-  .pf-l-flex,
-  .pf-l-flex__item {
-    position: relative;
-  }
-
-  [data-label]::after {
-    position: absolute;
-    top: -24px;
-    left: 0;
-    z-index: 2;
-    padding: 0 4px;
-    white-space: nowrap;
-    background: #fff;
-  }
-
-  [data-label]::after {
-    content: attr(data-label);
   }
 
   .example-text,


### PR DESCRIPTION
fixes #1984 

- wrap all `.pf-l-flex` items in `.pf-l-flex__item`
- update css - fixes responsive spacer bug