### PR TITLE
Charts: Update area chart opacity

### DIFF
--- a/src/patternfly/_chart-globals.scss
+++ b/src/patternfly/_chart-globals.scss
@@ -108,7 +108,7 @@ $pf-chart-global--Fill--Color--white: $pf-color-white;
 // Individual Charts
 
 // Area Chart
-$pf-chart-area--Opacity: .4;
+$pf-chart-area--Opacity: .3;
 $pf-chart-area--stroke--Width: $pf-chart-global--stroke--Width--sm;
 $pf-chart-area--data--Fill: $pf-chart-global--Fill--Color--900;
 


### PR DESCRIPTION
This updates the area chart opacity to 30%, per my discussion with @mceledonia.

Fixes https://github.com/patternfly/patternfly-next/issues/2232