### PR TITLE
Charts: Set mix-blend-mode for better color contrast

### DIFF
--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -2,6 +2,13 @@
 
 /* stylelint-disable */
 
+.pf-c-chart {
+  // Color blending mode
+  svg g[clip-path] {
+    mix-blend-mode: multiply;
+  }
+}
+
 :root {
   // Chart colors
 


### PR DESCRIPTION
In order to help eliminate contrast issues, we want to add the following CSS rule to patternfly-charts.scss.

`.pf-c-chart svg g[clip-path] { mix-blend-mode: multiply }`

Fixes https://github.com/patternfly/patternfly-next/issues/2238