### PR TITLE
fix(typeahead-select): add form wrapper, udpate css

### DIFF
--- a/src/patternfly/components/Select/docs/select-multi-typeahead.md
+++ b/src/patternfly/components/Select/docs/select-multi-typeahead.md
@@ -13,6 +13,7 @@ The Dropdown Multi Select should be used when the user is selecting multiple ite
 | `.pf-c-select` | `<div>` |  Initiates the select component. |
 | `.pf-c-select__toggle` | `<div>` |  Initiates the select toggle. |
 | `.pf-c-select__toggle-wrapper` | `<div>` |  Initiates the select toggle wrapper so that chips and input field can wrap together. |
+| `.pf-c-select__toggle-typeahead-form` | `<form>` |  Initiates the form for typeahead. |
 | `.pf-c-chip` | `<div>` |  Initiates a chip. (See [chip component](/components/Check/examples/) for more details) |
 | `.pf-c-select__toggle-typeahead` | `input.pf-c-form-control` |  Initiates the input field for typeahead. |
 | `.pf-c-select__toggle-clear` | `button.pf-m-plain` |  Initiates a clear button in the toggle. |

--- a/src/patternfly/components/Select/docs/select-single-typeahead.md
+++ b/src/patternfly/components/Select/docs/select-single-typeahead.md
@@ -13,6 +13,7 @@ The single select typeahead should be used when the user is selecting one option
 | `.pf-c-select` | `<div>` |  Initiates the select component. |
 | `.pf-c-select__toggle` | `<div>` |  Initiates the select toggle. |
 | `.pf-c-select__toggle-wrapper` | `<div>` |  Initiates the select toggle wrapper. |
+| `.pf-c-select__toggle-typeahead-form` | `<form>` |  Initiates the form for typeahead. |
 | `.pf-c-select__toggle-typeahead` | `input.pf-c-form-control` |  Initiates the input field for typeahead. |
 | `.pf-c-select__toggle-clear` | `button.pf-m-plain` |  Initiates a clear button in the toggle. |
 | `.pf-c-select__toggle-button` | `<button>` | Initiates a toggle button. |

--- a/src/patternfly/components/Select/select-toggle-typeahead-form.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead-form.hbs
@@ -1,0 +1,6 @@
+<form novalidate class="pf-c-select__toggle-typeahead-form{{#if select-toggle-typeahead-form--modifier}} {{select-toggle-typeahead-form--modifier}}{{/if}}"
+  {{#if select-toggle-typeahead-form--attribute}}
+    {{{select-toggle-typeahead-form--attribute}}}
+  {{/if}}>
+  {{>@partial-block}}
+</form>

--- a/src/patternfly/components/Select/select-toggle-typeahead.hbs
+++ b/src/patternfly/components/Select/select-toggle-typeahead.hbs
@@ -1,13 +1,15 @@
-{{#if select--ItemIsSelected}}
-	{{#> form-control controlType="input"
-		input="true"
-		form-control--modifier="pf-c-select__toggle-typeahead"
-		form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" value="' select-typeahead--Placeholder '"')}}
-	{{/form-control}}
-{{else}}
-	{{#> form-control controlType="input"
-		input="true"
-		form-control--modifier="pf-c-select__toggle-typeahead"
-		form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
-	{{/form-control}}
-{{/if}}
+{{#> select-toggle-typeahead-form}}
+  {{#if select--ItemIsSelected}}
+    {{#> form-control controlType="input"
+      input="true"
+      form-control--modifier="pf-c-select__toggle-typeahead"
+      form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" value="' select-typeahead--Placeholder '"')}}
+    {{/form-control}}
+  {{else}}
+    {{#> form-control controlType="input"
+      input="true"
+      form-control--modifier="pf-c-select__toggle-typeahead"
+      form-control--attribute=(concat 'type="text" id="' id '-typeahead" aria-label="Type to filter" placeholder="' select-typeahead--Placeholder '"')}}
+    {{/form-control}}
+  {{/if}}
+{{/select-toggle-typeahead-form}}

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -27,8 +27,9 @@
   --pf-c-select__toggle--m-plain--Color: var(--pf-global--Color--100);
   --pf-c-select__toggle--m-plain--hover--Color: var(--pf-global--Color--100);
 
+  // Remove during breaking change
   // When there is a typeahead (input box) adjust the top padding of the wrapper in case it wraps to the second line
-  --pf-c-select__toggle-wrapper--m-typeahead--PaddingTop: var(--pf-global--spacer--xs);
+  --pf-c-select__toggle-wrapper--m-typeahead--PaddingTop: 0;
 
   // Space for the children of the toggle
   --pf-c-select__toggle-wrapper--not-last-child--MarginRight: var(--pf-global--spacer--xs);
@@ -38,7 +39,8 @@
   --pf-c-select__toggle-wrapper--MaxWidth: calc(100% - var(--pf-global--spacer--lg));
 
   // Chip group within a toggle-wrapper needs a margin-bottom in case it wraps
-  --pf-c-select__toggle-wrapper--c-chip-group--MarginBottom: 0;
+  --pf-c-select__toggle-wrapper--c-chip-group--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-select__toggle-wrapper--c-chip-group--MarginBottom: var(--pf-global--spacer--xs);
 
   // The button inside a chip must be adjusted to reduce the padding, which is driving the height of the chip, so it fits within the toggle
   --pf-c-select__toggle-wrapper--c-chip--c-button--PaddingTop: var(--pf-global--spacer--xs);
@@ -50,6 +52,9 @@
   --pf-c-select__toggle-typeahead--BorderTop: none;
   --pf-c-select__toggle-typeahead--BorderRight: none;
   --pf-c-select__toggle-typeahead--BorderLeft: none;
+
+  // Typeahead form
+  --pf-c-select__toggle-typeahead-form--MinWidth: #{pf-size-prem(120px)};
 
   // This is really var(--pf-c-form-control--PaddingBottom) but has to be recalculated instead of reusing another component's variable
   --pf-c-select__toggle-typeahead--active--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-global--BorderWidth--sm));
@@ -230,11 +235,7 @@
       @include pf-text-overflow;
 
       position: relative;
-    }
-
-    // When the input is the first thing then use a negative left padding so it matches the toggle container
-    input:first-child {
-      margin-left: calc(-1 * var(--pf-c-select__toggle--PaddingLeft));
+      height: auto;
     }
   }
 
@@ -273,6 +274,7 @@
 
 .pf-c-select__toggle-wrapper {
   display: flex;
+  flex: 1;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
@@ -294,6 +296,7 @@
     padding-bottom: var(--pf-c-select__toggle-wrapper--c-chip--c-button--PaddingBottom);
   }
 
+  // Remove during breaking change
   // if there is an input in the toggle-wrapper, then give it a negative top margin to match the typeahead top padding
   > .pf-c-form-control {
     margin-top: calc(-1 * var(--pf-c-select__toggle-wrapper--m-typeahead--PaddingTop));
@@ -301,7 +304,14 @@
 
   // a chip group needs a bottom margin to make some space between the chip group and typeahead input box if it wraps
   .pf-c-chip-group {
+    margin-top: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginTop);
     margin-bottom: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginBottom);
+  }
+
+  // When the input or form is the first thing then use a negative left padding so it matches the toggle container
+  > .pf-c-select__toggle-typeahead-form:first-child,
+  > .pf-c-select__toggle-typeahead:first-child {
+    margin-left: calc(-1 * var(--pf-c-select__toggle--PaddingLeft));
   }
 }
 
@@ -332,6 +342,13 @@
     // This is really var(--pf-c-form-control--PaddingBottom) but has to be recalculated instead of reusing another component's variable
     padding-bottom: var(--pf-c-select__toggle-typeahead--active--PaddingBottom);
   }
+}
+
+// Support form with input and input alone
+.pf-c-select__toggle-typeahead-form,
+.pf-c-select__toggle-typeahead {
+  flex: 1;
+  min-width: var(--pf-c-select__toggle-typeahead-form--MinWidth);
 }
 
 .pf-c-select__menu {

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -308,7 +308,9 @@
     margin-bottom: var(--pf-c-select__toggle-wrapper--c-chip-group--MarginBottom);
   }
 
+  // Remove 'form:first-child' during breaking change
   // When the input or form is the first thing then use a negative left padding so it matches the toggle container
+  > form:first-child,
   > .pf-c-select__toggle-typeahead-form:first-child,
   > .pf-c-select__toggle-typeahead:first-child {
     margin-left: calc(-1 * var(--pf-c-select__toggle--PaddingLeft));


### PR DESCRIPTION
closes #2130 

- `.pf-c-form-control` `height` property throws off vertical alignment of typeahead text. Setting to `auto` allows for `input` to scale correctly.
- added `form.pf-c-select__toggle-form` to match [PF-React implementation](https://patternfly-react.surge.sh/patternfly-4/components/select/)
![Screen Shot 2019-09-12 at 8 42 01 AM](https://user-images.githubusercontent.com/5385435/64784940-417bdf00-d539-11e9-8fc8-86afa49c232f.png)
- remove `pf-c-select__toggle.pf-m-typeahead` `padding-top` as this adjusts height of select 
- add `margin-top` to `.pf-c-chip-group` to retain proper spacing
