### PR TITLE
fix(Page): Keep sidebar collapsed between sizes

### DIFF
--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -353,7 +353,7 @@
   // Desktop
   // Collapse nav
   &.pf-m-collapsed {
-    @media screen and (min-width: $pf-global--breakpoint--md) {
+    @media screen {
       max-width: 0;
       overflow: hidden;
     }

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -353,10 +353,8 @@
   // Desktop
   // Collapse nav
   &.pf-m-collapsed {
-    @media screen {
-      max-width: 0;
-      overflow: hidden;
-    }
+    max-width: 0;
+    overflow: hidden;
   }
 
   &.pf-m-dark {


### PR DESCRIPTION
What: This fixes the sidebar appearing and closing when resizing window from md to sm when sidebar is closed.

fixes #2252