### PR TITLE
fix(table): unset word-break, add modifiers

### DIFF
--- a/src/patternfly/components/Table/docs/code.md
+++ b/src/patternfly/components/Table/docs/code.md
@@ -11,7 +11,7 @@ Applying `role="grid"` to tables enhances accessible interaction while in table 
 Table columns may shift when expanding/collapsing. To address this, set `.pf-m-fit-content`, or assign a width `.pf-m-width-[width]` to the corresponding `<th>` defining the column or `<td>` within the column. Width values are `[10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90]` or `max`.
 
 ## Table header cells
-By default, all table header cells are set to `white-space: nowrap`. If a `<th>`'s content needs to wrap, apply `.pf-m-wrap`.
+By default, all table header cells contents wrap. If a `<th>`'s content needs to not wrap, apply `.pf-m-nowrap`.
 
 ## Implementation support
 - One expandable toggle button, positioned in the first cell of a non-expandable row, preceding an expandable row.
@@ -27,3 +27,10 @@ By default, all table header cells are set to `white-space: nowrap`. If a `<th>`
 | `.pf-m-grid-md`, `.pf-m-grid-lg`, `.pf-m-grid-xl`, `.pf-m-grid-2xl` | `.pf-c-table` | Changes tabular layout to responsive, grid based layout at suffixed breakpoint. |
 | `.pf-m-grid` | `.pf-c-table` | Changes tabular layout to responsive, grid based layout. This approach requires JavaScript to set this class at some prescribed viewport width value. |
 
+## Modifiers
+
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-m-break-word` | `.pf-c-table` | Modifies `.pf-c-table > th` and `.pf-c-table > td` to break long strings of text, such as a URL. |
+| `.pf-m-nowrap` | `.pf-c-table` | Modifies `.pf-c-table > th` and `.pf-c-table > td` to `white-space: pre`, forcing string not to wrap. |
+| `.pf-m-text-overflow` | `.pf-c-table` | Modifies `.pf-c-table > th` and `.pf-c-table > td` to show overflow as ellipsis on long strings of text, such as a URL. |

--- a/src/patternfly/components/Table/docs/table-headers-wrap.md
+++ b/src/patternfly/components/Table/docs/table-headers-wrap.md
@@ -1,9 +1,0 @@
-### Table expandable notes
-
-**All simple table accessibility and usage requirements apply.**
-
-### Usage
-
-| Class | Applied to | Outcome |
-| -- | -- | -- |
-| `.pf-m-wrap` | `<th>`, `<td>` | Modifies content to wrap. |

--- a/src/patternfly/components/Table/examples/index.js
+++ b/src/patternfly/components/Table/examples/index.js
@@ -11,39 +11,28 @@ import tableCompactExpandableExampleRaw from '!raw!./table-compact-expandable-ex
 import tableWidthExampleRaw from '!raw!./table-width-example.hbs';
 import tableCompoundExpansionExampleRaw from '!raw!./table-compound-expansion-example.hbs';
 import tableHiddenVisibleExampleRaw from '!raw!./table-hidden-visible-example.hbs';
-import tableHeadersWrapExampleRaw from '!raw!./table-headers-wrap-example.hbs';
 
 import TableSimpleExample from './table-simple-example.hbs';
-import tableSimpleDoc from '../docs/table-simple.md';
-
 import TableSortableExample from './table-sortable-example.hbs';
-import tableSortableDoc from '../docs/table-sortable.md';
-
 import TableSimpleWithCheckboxesExample from './table-simple-with-checkboxes-example.hbs';
-import tableCheckboxesActionsDoc from '../docs/table-checkboxes-actions.md';
-
 import TableExpandableExample from './table-expandable-example.hbs';
-import tableExpandableDoc from '../docs/table-expandable.md';
-
 import TableCompactExample from './table-compact-example.hbs';
-import tableCompactDoc from '../docs/table-compact.md';
-
 import TableCompactNoBorderRowsExample from './table-compact-no-border-rows-example.hbs';
-import tableCompactNoBorderRowsDoc from '../docs/table-compact-no-border-rows.md';
 import TableCompactExpandableExample from './table-compact-expandable-example.hbs';
-import tableCompactExpandableDoc from '../docs/table-compact-expandable.md';
-
 import TableWidthExample from './table-width-example.hbs';
-import tableWidthDoc from '../docs/table-width.md';
-
 import TableCompoundExpansionExample from './table-compound-expansion-example.hbs';
-import tableCompoundExpansionDoc from '../docs/table-compound-expansion.md';
-
 import TableHiddenVisibleExample from './table-hidden-visible-example.hbs';
-import tableHiddenVisibleDoc from '../docs/table-hidden-visible.md';
 
-import TableHeadersWrapExample from './table-headers-wrap-example.hbs';
-import tableHeadersWrapDoc from '../docs/table-headers-wrap.md';
+import tableSimpleDoc from '../docs/table-simple.md';
+import tableSortableDoc from '../docs/table-sortable.md';
+import tableCheckboxesActionsDoc from '../docs/table-checkboxes-actions.md';
+import tableExpandableDoc from '../docs/table-expandable.md';
+import tableCompactDoc from '../docs/table-compact.md';
+import tableCompactNoBorderRowsDoc from '../docs/table-compact-no-border-rows.md';
+import tableCompactExpandableDoc from '../docs/table-compact-expandable.md';
+import tableWidthDoc from '../docs/table-width.md';
+import tableCompoundExpansionDoc from '../docs/table-compound-expansion.md';
+import tableHiddenVisibleDoc from '../docs/table-hidden-visible.md';
 
 import docs from '../docs/code.md';
 
@@ -60,7 +49,6 @@ export default props => {
   const tableWidthExample = TableWidthExample();
   const tableCompoundExpansionExample = TableCompoundExpansionExample();
   const tableHiddenVisibleExample = TableHiddenVisibleExample();
-  const tableHeadersWrapExample = TableHeadersWrapExample();
   const headingText = 'Table';
   const variablesRoot = 'pf-c-table';
 
@@ -115,13 +103,6 @@ export default props => {
         docs={tableHiddenVisibleDoc}
       >
         {tableHiddenVisibleExample}
-      </Example>
-      <Example
-        heading="Table with headers that wrap"
-        handlebars={tableHeadersWrapExampleRaw}
-        docs={tableHeadersWrapDoc}
-      >
-        {tableHeadersWrapExample}
       </Example>
     </Documentation>
   );

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -136,6 +136,7 @@
 
   // Modifier - sort
   --pf-c-table__sort--sorted--Color: var(--pf-global--active-color--100);
+  --pf-c-table--m-text-overflow--MaxWidth: #{pf-size-prem(50px)};
 
   /* stylelint-enable */
 
@@ -144,10 +145,6 @@
   // Base
   width: 100%;
   background-color: var(--pf-c-table--BackgroundColor);
-
-  td {
-    word-break: break-word;
-  }
 
   // Standard table row (non-expandable)
   // exclude expandable rows
@@ -472,8 +469,9 @@
 
   &.pf-m-no-border-rows:not(.pf-m-expandable) {
     tbody {
-      --pf-c-table--BorderWidth: 0;
       --pf-c-table--BorderColor: transparent;
+
+      border: none;
 
       tr:first-child > * {
         --pf-c-table-cell--PaddingTop: calc(var(--pf-c-table--m-compact-cell--PaddingTop) * 2);
@@ -564,10 +562,31 @@
   white-space: nowrap;
 }
 
-// Modifier - Wrap
+// Modifier - wrap
 .pf-c-table .pf-m-wrap {
   white-space: normal;
 }
+
+// Modifier - nowrap
+.pf-c-table .pf-m-nowrap {
+  white-space: pre;
+}
+
+// Modifier - break word
+.pf-c-table .pf-m-break-word {
+  word-break: break-word;
+  white-space: normal;
+}
+
+/* stylelint-disable selector-no-qualifying-type */
+// Modifier - Wrap
+.pf-c-table td.pf-m-text-overflow,
+.pf-c-table th.pf-m-text-overflow {
+  @include pf-text-overflow;
+
+  max-width: var(--pf-c-table--m-text-overflow--MaxWidth);
+}
+/* stylelint-enable */
 
 // Modifier - Width
 /* stylelint-disable */


### PR DESCRIPTION
fixes #2205 
fixes #2325 

- remove `word-break: break-word;` from `<td>`
- ~~add `.pf-c-table-container` - set `overflow-x: auto:` for when table run out of available space~~
- add `.pf-m-break-word` - sets `word-break: break-word;`
- add `.pf-m-text-overflow` - sets text overflow to ellipsis
- add `.pf-m-nowrap` - sets `white-space: pre`
- removed `--pf-c-table--BorderWidth: 0;` as this causes `overflow-y` to scroll
