### PR TITLE
Add strokeDasharray variable for ChartThreshold

### DIFF
--- a/src/patternfly/_chart-globals.scss
+++ b/src/patternfly/_chart-globals.scss
@@ -252,6 +252,9 @@ $pf-chart-scatter--data--Fill: $pf-chart-global--Fill--Color--900;
 // Scatter Chart
 $pf-chart-stack--data--stroke--Width: $pf-chart-global--stroke--Width--xs;
 
+// Threshold
+$pf-chart-threshold--stroke-dash-array: "6,6";
+
 // Tooltip
 $pf-chart-tooltip--corner-radius: 0;
 $pf-chart-tooltip--pointer-length: 10;

--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -256,6 +256,9 @@
   // Scatter Chart
   --pf-chart-stack--data--stroke--Width: #{$pf-chart-stack--data--stroke--Width};
 
+  // Threshold
+  --pf-chart-threshold--stroke-dash-array: #{$pf-chart-threshold--stroke-dash-array};
+
   // Tooltip
   --pf-chart-tooltip--corner-radius: #{$pf-chart-tooltip--corner-radius};
   --pf-chart-tooltip--pointer-length: #{$pf-chart-tooltip--pointer-length};


### PR DESCRIPTION
Added a variable for the new ChartThreshold React component. Victory's, `strokeDasharray` prop defines the length and spacing between dashes in the lines below.

<img width="580" alt="Screen Shot 2019-09-27 at 9 52 43 AM" src="https://user-images.githubusercontent.com/17481322/65774626-9f4d2100-e10c-11e9-8240-7f85a611673b.png">

Fixes https://github.com/patternfly/patternfly-next/issues/2313