### PR TITLE
fix(input-group): unnest text class

### DIFF
--- a/src/patternfly/components/InputGroup/docs/code.md
+++ b/src/patternfly/components/InputGroup/docs/code.md
@@ -13,5 +13,5 @@ When using the `.pf-c-input-group` always ensure labels are used outside the inp
 
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-input-group` | `<div>` |  Iniaties the input group. **Required** |
-| `.pf-c-input-group__text` | `<span>` |  Iniaties the input group text. This can be used to show text, radio, icons, or check boxes. |
+| `.pf-c-input-group` | `<div>` |  Initiates the input group. **Required** |
+| `.pf-c-input-group__text` | `<span>` |  Initiates the input group text. This can be used to show text, radio, icons, or check boxes. |

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -86,12 +86,6 @@
   }
 }
 
-/* stylelint-disable */
-label.pf-c-input-group__text {
-  cursor: pointer;
-}
-/* stylelint-enable */
-
 .pf-c-input-group__text {
   display: flex;
   align-items: center;
@@ -103,4 +97,8 @@ label.pf-c-input-group__text {
   background-color: var(--pf-c-input-group__text--BackgroundColor);
   border: var(--pf-c-input-group__text--BorderWidth) solid;
   border-color: var(--pf-c-input-group__text--BorderTopColor) var(--pf-c-input-group__text--BorderRightColor) var(--pf-c-input-group__text--BorderBottomColor) var(--pf-c-input-group__text--BorderLeftColor);
+
+  @at-root label#{&} {
+    cursor: pointer;
+  }
 }

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -36,9 +36,6 @@
     margin-left: -1px;
   }
 
-  label.pf-c-input-group__text {
-    cursor: pointer;
-  }
   /* stylelint-enable */
 
   .pf-c-form-control {
@@ -87,17 +84,23 @@
   textarea {
     min-height: var(--pf-c-input-group__textarea--MinHeight);
   }
+}
 
-  .pf-c-input-group__text {
-    display: flex;
-    align-items: center;
-    padding-right: var(--pf-c-input-group__text--PaddingRight);
-    padding-left: var(--pf-c-input-group__text--PaddingLeft);
-    font-size: var(--pf-c-input-group__text--FontSize);
-    color: var(--pf-c-input-group__text--Color);
-    text-align: center;
-    background-color: var(--pf-c-input-group__text--BackgroundColor);
-    border: var(--pf-c-input-group__text--BorderWidth) solid;
-    border-color: var(--pf-c-input-group__text--BorderTopColor) var(--pf-c-input-group__text--BorderRightColor) var(--pf-c-input-group__text--BorderBottomColor) var(--pf-c-input-group__text--BorderLeftColor);
-  }
+/* stylelint-disable */
+label.pf-c-input-group__text {
+  cursor: pointer;
+}
+/* stylelint-enable */
+
+.pf-c-input-group__text {
+  display: flex;
+  align-items: center;
+  padding-right: var(--pf-c-input-group__text--PaddingRight);
+  padding-left: var(--pf-c-input-group__text--PaddingLeft);
+  font-size: var(--pf-c-input-group__text--FontSize);
+  color: var(--pf-c-input-group__text--Color);
+  text-align: center;
+  background-color: var(--pf-c-input-group__text--BackgroundColor);
+  border: var(--pf-c-input-group__text--BorderWidth) solid;
+  border-color: var(--pf-c-input-group__text--BorderTopColor) var(--pf-c-input-group__text--BorderRightColor) var(--pf-c-input-group__text--BorderBottomColor) var(--pf-c-input-group__text--BorderLeftColor);
 }


### PR DESCRIPTION
fixes #2286

Not sure how to move `label` into `.pf-c-input-group__text` as the order needs to be `label.pf-c-input-group__text`

cc @mcoker 