### PR TITLE
fix(Table): fix issue with agressive wrap of words

### DIFF
--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -146,7 +146,7 @@
   background-color: var(--pf-c-table--BackgroundColor);
 
   td {
-    word-break: break-word;
+    overflow-wrap: break-word;
   }
 
   // Standard table row (non-expandable)


### PR DESCRIPTION
This commit replaces the use of word-break: break-word for table columns
to overflow-wrap: break-word instead.

According to MDN, the difference between the two is:

`Note: In contrast to word-break, overflow-wrap will only create a break if an
entire word cannot be placed on its own line without overflowing.`

We obviously do not want to break the words by default — they should
only break when absolutely necessary.

Fixes #2325