### PR TITLE
feat(form): add validated form modifier

### DIFF
--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -91,10 +91,10 @@ cssPrefix: pf-c-form
     {{#> form-label form-label--attribute=(concat 'for="' form--id '-simple-form-comment"')}}
       Comment
     {{/form-label}}
-    {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-validated" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form--id '-simple-form-comment" name="' form--id '-simple-form-comment" aria-describedby="' form--id '-simple-form-comment-help"')}}
+    {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form--id '-simple-form-comment" name="' form--id '-simple-form-comment" aria-describedby="' form--id '-simple-form-comment-help"')}}
     {{/form-control}}
-    {{#> form-helper-text form-helper-text--modifier="pf-m-validated" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-comment-help" aria-live="polite"')}}
-      This is helper text for validated input
+    {{#> form-helper-text form-helper-text--modifier="pf-m-success" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-comment-help" aria-live="polite"')}}
+      This is helper text for success input
     {{/form-helper-text}}
   {{/form-group}}
 {{/form}}
@@ -140,7 +140,7 @@ cssPrefix: pf-c-form
 | `.pf-c-form__actions` | `<div>` | Iniates a row of actions. |
 | `.pf-m-action` | `.pf-c-form__group` | Modifies form group margin-top. |
 | `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text. |
-| `.pf-m-validated` | `.pf-c-form__helper-text` | Modifies text color of helper text. |
+| `.pf-m-success` | `.pf-c-form__helper-text` | Modifies text color of helper text. |
 | `.pf-m-inactive` | `.pf-c-form__helper-text`| Modifies display of helper text to none. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -87,6 +87,16 @@ cssPrefix: pf-c-form
       This is helper text for an invalid input
     {{/form-helper-text}}
   {{/form-group}}
+  {{#> form-group}}
+    {{#> form-label form-label--attribute=(concat 'for="' form--id '-simple-form-comment"')}}
+      Comment
+    {{/form-label}}
+    {{#> form-control controlType="input" input="true" form-control--modifier="pf-m-validated" form-control--attribute=(concat 'value="This is a valid comment"' 'type="text" id="' form--id '-simple-form-comment" name="' form--id '-simple-form-comment" aria-describedby="' form--id '-simple-form-comment-help"')}}
+    {{/form-control}}
+    {{#> form-helper-text form-helper-text--modifier="pf-m-validated" form-helper-text--attribute=(concat 'id="' form--id '-simple-form-comment-help" aria-live="polite"')}}
+      This is helper text for validated input
+    {{/form-helper-text}}
+  {{/form-group}}
 {{/form}}
 ```
 
@@ -130,6 +140,7 @@ cssPrefix: pf-c-form
 | `.pf-c-form__actions` | `<div>` | Iniates a row of actions. |
 | `.pf-m-action` | `.pf-c-form__group` | Modifies form group margin-top. |
 | `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text. |
+| `.pf-m-validated` | `.pf-c-form__helper-text` | Modifies text color of helper text. |
 | `.pf-m-inactive` | `.pf-c-form__helper-text`| Modifies display of helper text to none. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |

--- a/src/patternfly/components/Form/examples/Form.md
+++ b/src/patternfly/components/Form/examples/Form.md
@@ -139,8 +139,8 @@ cssPrefix: pf-c-form
 | `.pf-c-form__horizontal-group` | `<div>`| Wraps `.pf-c-form-control` when using `.pf-m-horizontal` on `.pf-c-form` to provide proper spacing for longer labels. |
 | `.pf-c-form__actions` | `<div>` | Iniates a row of actions. |
 | `.pf-m-action` | `.pf-c-form__group` | Modifies form group margin-top. |
-| `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text. |
-| `.pf-m-success` | `.pf-c-form__helper-text` | Modifies text color of helper text. |
+| `.pf-m-error` | `.pf-c-form__helper-text`| Modifies text color of helper text for error state. |
+| `.pf-m-success` | `.pf-c-form__helper-text` | Modifies text color of helper text for success state. |
 | `.pf-m-inactive` | `.pf-c-form__helper-text`| Modifies display of helper text to none. |
 | `.pf-m-border` | `.pf-c-form__section` | Modifies form element border-bottom. |
 | `.pf-m-disabled` | `.pf-c-form__label` | Modifies form label to show disabled state. |

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -46,6 +46,7 @@
 
   // States
   --pf-c-form--m-error--Color: var(--pf-global--danger-color--100);
+  --pf-c-form--m-validated--Color: var(--pf-global--success-color--200);
 
 
   display: grid;
@@ -158,13 +159,14 @@
 
 .pf-c-form__helper-text {
   font-size: var(--pf-c-form__helper-text--FontSize);
-
-  &:not(.pf-m-error) {
-    color: var(--pf-c-form__helper-text--Color);
-  }
+  color: var(--pf-c-form__helper-text--Color);
 
   &.pf-m-error {
-    color: var(--pf-c-form--m-error--Color);
+    --pf-c-form__helper-text--Color: var(--pf-c-form--m-error--Color);
+  }
+
+  &.pf-m-validated {
+    --pf-c-form__helper-text--Color: var(--pf-c-form--m-validated--Color);
   }
 
   &.pf-m-inactive {

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -46,7 +46,7 @@
 
   // States
   --pf-c-form--m-error--Color: var(--pf-global--danger-color--100);
-  --pf-c-form--m-validated--Color: var(--pf-global--success-color--200);
+  --pf-c-form--m-success--Color: var(--pf-global--success-color--200);
 
 
   display: grid;
@@ -165,8 +165,8 @@
     --pf-c-form__helper-text--Color: var(--pf-c-form--m-error--Color);
   }
 
-  &.pf-m-validated {
-    --pf-c-form__helper-text--Color: var(--pf-c-form--m-validated--Color);
+  &.pf-m-success {
+    --pf-c-form__helper-text--Color: var(--pf-c-form--m-success--Color);
   }
 
   &.pf-m-inactive {

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -15,6 +15,9 @@ cssPrefix: pf-c-form-control
 {{#> form-control controlType="input" input="true" form-control--attribute='required type="text" value="Error" id="textInput4" aria-invalid="true" aria-label="Error state input example"'}}
 {{/form-control}}
 <br /><br />
+{{#> form-control controlType="input" input="true" form-control--modifier="pf-m-validated" form-control--attribute='type="text" value="Validated" id="textInput4" aria-label="Validated state input example"'}}
+{{/form-control}}
+<br /><br />
 {{#> form-control controlType="input" input="true" form-control--attribute='disabled type="text" value="Disabled" id="textInput1" aria-label="Disabled input example"'}}
 {{/form-control}}
 ```
@@ -52,6 +55,18 @@ cssPrefix: pf-c-form-control
     <option value="Option 4">The fourth option</option>
   </optgroup>
 {{/form-control}}
+<br /><br />
+{{#> form-control controlType="select" form-control--modifier="pf-m-validated" form-control--attribute='id="selectExample3" name="selectExample3" aria-label="Validated state select group example"'}}
+  <option value="">Valid option</option>
+  <optgroup label="Group 1">
+    <option value="Option 1">Valid option</option>
+    <option value="Option 2">The second option</option>
+  </optgroup>
+  <optgroup label="Group 2">
+    <option value="Option 3">The third option</option>
+    <option value="Option 4">The fourth option</option>
+  </optgroup>
+{{/form-control}}
 ```
 
 ```hbs title=Textarea
@@ -67,6 +82,10 @@ Readonly
 Error
 {{/form-control}}
 <br /><br />
+{{#> form-control controlType="textarea" form-control--modifier="pf-m-validated" form-control--attribute='name="textarea" id="textareavalidated" aria-label="Validated state textarea example"'}}
+Validated
+{{/form-control}}
+<br /><br />
 {{#> form-control controlType="textarea" form-control--attribute='name="textarea" id="textarea3" aria-label="Resize vertical textarea example"' form-control--modifier="pf-m-resize-vertical"}}
 Resizes vertically
 {{/form-control}}
@@ -77,12 +96,13 @@ Resizes horizontally
 ```
 
 ## Documentation
-### Overiew
+### Overview
 Input, textarea, and select are provided in the form controls component for use cases outside of forms. If they are used without label text ensure some sort of label for assistive technologies. (for example: `aria-label`)
 
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [check component](../../Check/examples/). **Required**  |
-| `.pf-m-resize-vertical` | `textarea.pf-m-form-control` | Modifies a `<textarea>` element to resize vertically. |
-| `.pf-m-resize-horizontal` | `textarea.pf-m-form-control` | Modifies a `<textarea>` element to resize horizontally. |
+| `.pf-m-resize-vertical` | `textarea.pf-c-form-control` | Modifies a `<textarea>` element to resize vertically. |
+| `.pf-m-resize-horizontal` | `textarea.pf-c-form-control` | Modifies a `<textarea>` element to resize horizontally. |
+| `.pf-m-validated` | `.pf-c-form-control` | Modifies a form control for the validated state. |

--- a/src/patternfly/components/FormControl/examples/FormControl.md
+++ b/src/patternfly/components/FormControl/examples/FormControl.md
@@ -15,7 +15,7 @@ cssPrefix: pf-c-form-control
 {{#> form-control controlType="input" input="true" form-control--attribute='required type="text" value="Error" id="textInput4" aria-invalid="true" aria-label="Error state input example"'}}
 {{/form-control}}
 <br /><br />
-{{#> form-control controlType="input" input="true" form-control--modifier="pf-m-validated" form-control--attribute='type="text" value="Validated" id="textInput4" aria-label="Validated state input example"'}}
+{{#> form-control controlType="input" input="true" form-control--modifier="pf-m-success" form-control--attribute='type="text" value="Success" id="textInput4" aria-label="Success state input example"'}}
 {{/form-control}}
 <br /><br />
 {{#> form-control controlType="input" input="true" form-control--attribute='disabled type="text" value="Disabled" id="textInput1" aria-label="Disabled input example"'}}
@@ -56,7 +56,7 @@ cssPrefix: pf-c-form-control
   </optgroup>
 {{/form-control}}
 <br /><br />
-{{#> form-control controlType="select" form-control--modifier="pf-m-validated" form-control--attribute='id="selectExample3" name="selectExample3" aria-label="Validated state select group example"'}}
+{{#> form-control controlType="select" form-control--modifier="pf-m-success" form-control--attribute='id="selectExample3" name="selectExample3" aria-label="Success state select group example"'}}
   <option value="">Valid option</option>
   <optgroup label="Group 1">
     <option value="Option 1">Valid option</option>
@@ -82,8 +82,8 @@ Readonly
 Error
 {{/form-control}}
 <br /><br />
-{{#> form-control controlType="textarea" form-control--modifier="pf-m-validated" form-control--attribute='name="textarea" id="textareavalidated" aria-label="Validated state textarea example"'}}
-Validated
+{{#> form-control controlType="textarea" form-control--modifier="pf-m-success" form-control--attribute='name="textarea" id="textareasuccess" aria-label="Success state textarea example"'}}
+Success
 {{/form-control}}
 <br /><br />
 {{#> form-control controlType="textarea" form-control--attribute='name="textarea" id="textarea3" aria-label="Resize vertical textarea example"' form-control--modifier="pf-m-resize-vertical"}}
@@ -105,4 +105,4 @@ Input, textarea, and select are provided in the form controls component for use 
 | `.pf-c-form-control` | `<input>`,`<textarea>`, `<select>` |  Initiates an input, textarea or select. For styling of checkboxes or radios see the [check component](../../Check/examples/). **Required**  |
 | `.pf-m-resize-vertical` | `textarea.pf-c-form-control` | Modifies a `<textarea>` element to resize vertically. |
 | `.pf-m-resize-horizontal` | `textarea.pf-c-form-control` | Modifies a `<textarea>` element to resize horizontally. |
-| `.pf-m-validated` | `.pf-c-form-control` | Modifies a form control for the validated state. |
+| `.pf-m-success` | `.pf-c-form-control` | Modifies a form control for the success state. |

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -7,6 +7,10 @@ $pf-c-form-control--invalid--Coordinates: "M504 256c0 136.997-111.043 248-248 24
 $pf-c-form-control__select--Coordinates: "M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z" !default;
 $pf-c-form-control__select--ViewBox: "320" !default;
 
+// Input - validated
+$pf-c-form-control--validated--Color: $pf-global--success-color--100 !default;
+$pf-c-form-control--validated--Coordinates: "M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z" !default;
+
 .pf-c-form-control {
   // Component
   --pf-c-form-control--FontSize: var(--pf-global--FontSize--md);
@@ -60,6 +64,17 @@ $pf-c-form-control__select--ViewBox: "320" !default;
   --pf-c-form-control--invalid--exclamation--Background: var(--pf-c-form-control--invalid--BackgroundUrl) var(--pf-c-form-control--invalid--BackgroundPosition) / var(--pf-c-form-control--invalid--BackgroundSize) no-repeat;
   --pf-c-form-control--invalid--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--invalid--exclamation--Background);
 
+  // Input m-validated
+  --pf-c-form-control--validated--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-form-control--validated--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--validated--BorderBottomWidth));
+  --pf-c-form-control--validated--BorderBottomColor: var(--pf-global--success-color--100);
+  --pf-c-form-control--validated--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-form-control--validated--BackgroundPosition: calc(100% - var(--pf-c-form-control--PaddingLeft)) var(--pf-c-form-control--PaddingLeft);
+  --pf-c-form-control--validated--BackgroundSize: var(--pf-c-form-control--FontSize) var(--pf-c-form-control--FontSize);
+  --pf-c-form-control--validated--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--validated--Coordinates, $svg-color: $pf-c-form-control--validated--Color)};
+  --pf-c-form-control--validated--check--Background: var(--pf-c-form-control--validated--BackgroundUrl) var(--pf-c-form-control--validated--BackgroundPosition) / var(--pf-c-form-control--validated--BackgroundSize) no-repeat;
+  --pf-c-form-control--validated--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--validated--check--Background);
+
   // Select
   --pf-c-form-control__select--PaddingRight: var(--pf-global--spacer--lg);
   --pf-c-form-control__select--BackgroundUrl: #{pf-bg-svg($pf-c-form-control__select--Coordinates, $pf-c-form-control__select--ViewBox)};
@@ -69,6 +84,8 @@ $pf-c-form-control__select--ViewBox: "320" !default;
   --pf-c-form-control__select--Background: var(--pf-c-form-control__select--arrow--Background);
   --pf-c-form-control__select--invalid--Background: var(--pf-c-form-control--invalid--exclamation--Background), var(--pf-c-form-control__select--arrow--Background);
   --pf-c-form-control__select--invalid--PaddingRight: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--2xl));
+  --pf-c-form-control__select--validated--Background: var(--pf-c-form-control--validated--check--Background), var(--pf-c-form-control__select--arrow--Background);
+  --pf-c-form-control__select--validated--PaddingRight: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--2xl));
 
   // This component always needs to be light
   @include pf-t-light;
@@ -141,6 +158,15 @@ $pf-c-form-control__select--ViewBox: "320" !default;
     border-bottom-width: var(--pf-c-form-control--invalid--BorderBottomWidth);
   }
 
+  &.pf-m-validated {
+    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--validated--PaddingRight);
+    --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--validated--BorderBottomColor);
+
+    padding-bottom: var(--pf-c-form-control--validated--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
+    background: var(--pf-c-form-control--validated--Background);
+    border-bottom-width: var(--pf-c-form-control--validated--BorderBottomWidth);
+  }
+
   @at-root select#{&} {
     --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--PaddingRight);
 
@@ -150,6 +176,12 @@ $pf-c-form-control__select--ViewBox: "320" !default;
       --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--invalid--PaddingRight);
       --pf-c-form-control--invalid--BackgroundPosition: calc(100% - var(--pf-global--spacer--sm) - var(--pf-global--spacer--lg));
       --pf-c-form-control--invalid--Background: var(--pf-c-form-control__select--invalid--Background);
+    }
+
+    &.pf-m-validated {
+      --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--validated--PaddingRight);
+      --pf-c-form-control--validated--BackgroundPosition: calc(100% - var(--pf-global--spacer--sm) - var(--pf-global--spacer--lg));
+      --pf-c-form-control--validated--Background: var(--pf-c-form-control__select--validated--Background);
     }
   }
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -7,9 +7,9 @@ $pf-c-form-control--invalid--Coordinates: "M504 256c0 136.997-111.043 248-248 24
 $pf-c-form-control__select--Coordinates: "M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z" !default;
 $pf-c-form-control__select--ViewBox: "320" !default;
 
-// Input - validated
-$pf-c-form-control--validated--Color: $pf-global--success-color--100 !default;
-$pf-c-form-control--validated--Coordinates: "M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z" !default;
+// Input - success
+$pf-c-form-control--success--Color: $pf-global--success-color--100 !default;
+$pf-c-form-control--success--Coordinates: "M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z" !default;
 
 .pf-c-form-control {
   // Component
@@ -64,16 +64,16 @@ $pf-c-form-control--validated--Coordinates: "M504 256c0 136.967-111.033 248-248 
   --pf-c-form-control--invalid--exclamation--Background: var(--pf-c-form-control--invalid--BackgroundUrl) var(--pf-c-form-control--invalid--BackgroundPosition) / var(--pf-c-form-control--invalid--BackgroundSize) no-repeat;
   --pf-c-form-control--invalid--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--invalid--exclamation--Background);
 
-  // Input m-validated
-  --pf-c-form-control--validated--BorderBottomWidth: var(--pf-global--BorderWidth--md);
-  --pf-c-form-control--validated--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--validated--BorderBottomWidth));
-  --pf-c-form-control--validated--BorderBottomColor: var(--pf-global--success-color--100);
-  --pf-c-form-control--validated--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-form-control--validated--BackgroundPosition: calc(100% - var(--pf-c-form-control--PaddingLeft)) var(--pf-c-form-control--PaddingLeft);
-  --pf-c-form-control--validated--BackgroundSize: var(--pf-c-form-control--FontSize) var(--pf-c-form-control--FontSize);
-  --pf-c-form-control--validated--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--validated--Coordinates, $svg-color: $pf-c-form-control--validated--Color)};
-  --pf-c-form-control--validated--check--Background: var(--pf-c-form-control--validated--BackgroundUrl) var(--pf-c-form-control--validated--BackgroundPosition) / var(--pf-c-form-control--validated--BackgroundSize) no-repeat;
-  --pf-c-form-control--validated--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--validated--check--Background);
+  // Input m-success
+  --pf-c-form-control--success--BorderBottomWidth: var(--pf-global--BorderWidth--md);
+  --pf-c-form-control--success--PaddingBottom: calc(var(--pf-global--spacer--form-element) - var(--pf-c-form-control--success--BorderBottomWidth));
+  --pf-c-form-control--success--BorderBottomColor: var(--pf-global--success-color--100);
+  --pf-c-form-control--success--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-form-control--success--BackgroundPosition: calc(100% - var(--pf-c-form-control--PaddingLeft)) var(--pf-c-form-control--PaddingLeft);
+  --pf-c-form-control--success--BackgroundSize: var(--pf-c-form-control--FontSize) var(--pf-c-form-control--FontSize);
+  --pf-c-form-control--success--BackgroundUrl: #{pf-bg-svg($pf-c-form-control--success--Coordinates, $svg-color: $pf-c-form-control--success--Color)};
+  --pf-c-form-control--success--check--Background: var(--pf-c-form-control--success--BackgroundUrl) var(--pf-c-form-control--success--BackgroundPosition) / var(--pf-c-form-control--success--BackgroundSize) no-repeat;
+  --pf-c-form-control--success--Background: var(--pf-c-form-control--BackgroundColor) var(--pf-c-form-control--success--check--Background);
 
   // Select
   --pf-c-form-control__select--PaddingRight: var(--pf-global--spacer--lg);
@@ -84,8 +84,8 @@ $pf-c-form-control--validated--Coordinates: "M504 256c0 136.967-111.033 248-248 
   --pf-c-form-control__select--Background: var(--pf-c-form-control__select--arrow--Background);
   --pf-c-form-control__select--invalid--Background: var(--pf-c-form-control--invalid--exclamation--Background), var(--pf-c-form-control__select--arrow--Background);
   --pf-c-form-control__select--invalid--PaddingRight: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--2xl));
-  --pf-c-form-control__select--validated--Background: var(--pf-c-form-control--validated--check--Background), var(--pf-c-form-control__select--arrow--Background);
-  --pf-c-form-control__select--validated--PaddingRight: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--2xl));
+  --pf-c-form-control__select--success--Background: var(--pf-c-form-control--success--check--Background), var(--pf-c-form-control__select--arrow--Background);
+  --pf-c-form-control__select--success--PaddingRight: calc(var(--pf-global--spacer--sm) + var(--pf-global--spacer--2xl));
 
   // This component always needs to be light
   @include pf-t-light;
@@ -158,13 +158,13 @@ $pf-c-form-control--validated--Coordinates: "M504 256c0 136.967-111.033 248-248 
     border-bottom-width: var(--pf-c-form-control--invalid--BorderBottomWidth);
   }
 
-  &.pf-m-validated {
-    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--validated--PaddingRight);
-    --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--validated--BorderBottomColor);
+  &.pf-m-success {
+    --pf-c-form-control--PaddingRight: var(--pf-c-form-control--success--PaddingRight);
+    --pf-c-form-control--BorderBottomColor: var(--pf-c-form-control--success--BorderBottomColor);
 
-    padding-bottom: var(--pf-c-form-control--validated--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
-    background: var(--pf-c-form-control--validated--Background);
-    border-bottom-width: var(--pf-c-form-control--validated--BorderBottomWidth);
+    padding-bottom: var(--pf-c-form-control--success--PaddingBottom); // Can't redefine --pf-c-form-control--PaddingBottom b/c the hover padding bottom uses the focus padding var to compute it's padding
+    background: var(--pf-c-form-control--success--Background);
+    border-bottom-width: var(--pf-c-form-control--success--BorderBottomWidth);
   }
 
   @at-root select#{&} {
@@ -178,10 +178,10 @@ $pf-c-form-control--validated--Coordinates: "M504 256c0 136.967-111.033 248-248 
       --pf-c-form-control--invalid--Background: var(--pf-c-form-control__select--invalid--Background);
     }
 
-    &.pf-m-validated {
-      --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--validated--PaddingRight);
-      --pf-c-form-control--validated--BackgroundPosition: calc(100% - var(--pf-global--spacer--sm) - var(--pf-global--spacer--lg));
-      --pf-c-form-control--validated--Background: var(--pf-c-form-control__select--validated--Background);
+    &.pf-m-success {
+      --pf-c-form-control--PaddingRight: var(--pf-c-form-control__select--success--PaddingRight);
+      --pf-c-form-control--success--BackgroundPosition: calc(100% - var(--pf-global--spacer--sm) - var(--pf-global--spacer--lg));
+      --pf-c-form-control--success--Background: var(--pf-c-form-control__select--success--Background);
     }
   }
 


### PR DESCRIPTION
Fixes #2320 

Updates colors used for --pf-global--success-color--100 and --pf-global--success-color--200 for better a11y. See #2320

New Validated input:
![image](https://user-images.githubusercontent.com/11633780/66307398-5b0f0d00-e8d2-11e9-8fa4-884232d4ad39.png)

Updates due to success color changes:

![image](https://user-images.githubusercontent.com/11633780/66307418-69f5bf80-e8d2-11e9-93f7-d0aa63cadd77.png)

![image](https://user-images.githubusercontent.com/11633780/66307427-6feba080-e8d2-11e9-94be-68e226d59509.png)

![image](https://user-images.githubusercontent.com/11633780/66307442-78dc7200-e8d2-11e9-9cfa-68105344e8fa.png)


cc @mceledonia @kybaker @serenamarie125 