### PR TITLE
Add size variables for scatter chart

### DIFF
--- a/src/patternfly/_chart-globals.scss
+++ b/src/patternfly/_chart-globals.scss
@@ -248,6 +248,8 @@ $pf-chart-scatter--data--stroke--Color: "transparent";
 $pf-chart-scatter--data--stroke--Width: 0;
 $pf-chart-scatter--data--Opacity: 1;
 $pf-chart-scatter--data--Fill: $pf-chart-global--Fill--Color--900;
+$pf-chart-scatter--active--size: 5;
+$pf-chart-scatter--size: 3;
 
 // Scatter Chart
 $pf-chart-stack--data--stroke--Width: $pf-chart-global--stroke--Width--xs;

--- a/src/patternfly/patternfly-charts.scss
+++ b/src/patternfly/patternfly-charts.scss
@@ -252,6 +252,8 @@
   --pf-chart-scatter--data--stroke--Width: #{$pf-chart-scatter--data--stroke--Width};
   --pf-chart-scatter--data--Opacity: #{$pf-chart-scatter--data--Opacity};
   --pf-chart-scatter--data--Fill: #{$pf-chart-scatter--data--Fill};
+  --pf-chart-scatter--active--size: #{$pf-chart-scatter--active--size};
+  --pf-chart-scatter--size: #{$pf-chart-scatter--size};
 
   // Scatter Chart
   --pf-chart-stack--data--stroke--Width: #{$pf-chart-stack--data--stroke--Width};


### PR DESCRIPTION
Adds size variables to support interactive data points with the `ChartScatter` component in react-charts.

Fixes https://github.com/patternfly/patternfly-next/issues/2339