### PR TITLE
feat(docs): add html formatting

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,3 +17,20 @@ exports.onCreateWebpackConfig = ({ actions }) => {
     }
   });
 };
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const typeDefs = `
+    type MdxFrontmatter @infer {
+      title: String!
+      section: String
+      cssPrefix: String
+      hideTOC: Boolean
+      optIn: String
+      experimentalStage: String
+    }
+    type Mdx implements Node @infer {
+      frontmatter: MdxFrontmatter
+    }
+  `;
+  actions.createTypes(typeDefs);
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ function pfIconFont() {
 }
 
 function copyFA() {
-  return src('./node_modules/@fortawesome/fontawesome/styles.css')
+  return src(require.resolve('@fortawesome/fontawesome/styles.css'))
     .pipe(rename('fontawesome.css'))
     .pipe(dest('./dist/assets/icons'));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8651,6 +8651,40 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+      "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000989",
+        "electron-to-chromium": "^1.3.247",
+        "node-releases": "^1.1.29"
+      },
+      "dependencies": {
+        "electron-to-chromium": {
+          "version": "1.3.280",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.280.tgz",
+          "integrity": "sha512-qYWNMjKLEfQAWZF2Sarvo+ahigu0EArnpCFSoUuZJS3W5wIeVfeEvsgmT2mgIrieQkeQ0+xFmykK3nx2ezekPQ==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.35",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+          "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "bser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
@@ -9125,6 +9159,12 @@
       "version": "1.0.30000815",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000815.tgz",
       "integrity": "sha1-DiGPoTPQ0HHIhqoEG0NSWMx0aJE=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000999",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
+      "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -19223,15 +19263,15 @@
           }
         },
         "@babel/core": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.3.tgz",
-          "integrity": "sha512-QfQ5jTBgXLzJuo7Mo8bZK/ePywmgNRgk/UQykiKwEtZPiFIn8ZqE6jB+AnD1hbB1S2xQyL4//it5vuAUOVAMTw==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+          "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
+            "@babel/generator": "^7.6.4",
             "@babel/helpers": "^7.6.2",
-            "@babel/parser": "^7.6.3",
+            "@babel/parser": "^7.6.4",
             "@babel/template": "^7.6.0",
             "@babel/traverse": "^7.6.3",
             "@babel/types": "^7.6.3",
@@ -19241,19 +19281,19 @@
             "lodash": "^4.17.13",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
-            "source-map": "^0.6.1"
+            "source-map": "^0.5.0"
           }
         },
         "@babel/generator": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.3.tgz",
-          "integrity": "sha512-hLhYbAb3pHwxjlijC4AQ7mqZdcoujiNaW7izCT04CIowHK8psN0IN8QjDv0iyFtycF5FowUOTwDloIheI25aMw==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.6.3",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
-            "source-map": "^0.6.1"
+            "source-map": "^0.5.0"
           }
         },
         "@babel/helper-function-name": {
@@ -19308,9 +19348,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.3.tgz",
-          "integrity": "sha512-sUZdXlva1dt2Vw2RqbMkmfoImubO0D0gaCrNngV6Hi0DA4x3o4mlrq0tbfY0dZEUIccH8I6wQ4qgEtwcpOR6Qg==",
+          "version": "7.6.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
           "dev": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -19503,23 +19543,6 @@
             "color-convert": "^1.9.0"
           }
         },
-        "browserslist": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-          "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30000989",
-            "electron-to-chromium": "^1.3.247",
-            "node-releases": "^1.1.29"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000999",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
-          "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -19565,12 +19588,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "electron-to-chromium": {
-          "version": "1.3.279",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.279.tgz",
-          "integrity": "sha512-iiBT/LeUWKnhd7d/n4IZsx/NIacs7gjFgAT1q5/i0POiS+5d0rVnbbyCRMmsBW7vaQJOUhWyh4PsyIVZb/Ax5Q==",
-          "dev": true
         },
         "fs-extra": {
           "version": "8.1.0",
@@ -19628,23 +19645,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "node-releases": {
-          "version": "1.1.35",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
-          "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
         "pretty-bytes": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
@@ -19669,12 +19669,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
@@ -20259,9 +20253,9 @@
       }
     },
     "gatsby-theme-patternfly-org": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-patternfly-org/-/gatsby-theme-patternfly-org-0.0.10.tgz",
-      "integrity": "sha512-POODE/BjB8vtS294NtBB/eBFAlprqPJusqMh7D14p6LMUE0JcQ9cA6KI2CZnTBJoQh1gDR8vBrEtg+i9A9snyw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-patternfly-org/-/gatsby-theme-patternfly-org-0.0.11.tgz",
+      "integrity": "sha512-OOFlL29r/TSHt1kevUSuNrIeewS4Hf6+u+MV1bqEYxkJnd91f0aHE/0lAg+y2pFymJ7wKzkR9dIBEF6p3MzW3A==",
       "dev": true,
       "requires": {
         "@mdx-js/mdx": "^1.1.5",
@@ -20271,6 +20265,7 @@
         "gatsby-plugin-react-helmet": "^3.1.7",
         "gatsby-transformer-json": "^2.2.8",
         "handlebars": "^4.2.0",
+        "html-formatter": "0.1.9",
         "prismjs": "^1.17.1",
         "react-helmet": "^5.2.1",
         "react-live": "^2.2.0"
@@ -22673,6 +22668,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+      "dev": true
+    },
+    "html-formatter": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/html-formatter/-/html-formatter-0.1.9.tgz",
+      "integrity": "sha1-WOiFlxLz1NnnCUAnUXxMRvTDNrg=",
       "dev": true
     },
     "html-tags": {
@@ -27387,9 +27388,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.2.tgz",
-      "integrity": "sha512-q0iKJHcLc9rZg/qtJ/ioG5s6/5357bqvkYCpqXJxpcyfK7L5us8+uJllZosqPWou7l6E1lY2Qqoq5ce+AMbFuQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.3.tgz",
+      "integrity": "sha512-SbgVmGjEUAR/rYdAM0p0TCdKtJILZeYk3JavV2cmNVmIeR0SaKDudLRk58au6gpJqyFM9qz8ufEsS91D7RZyYA==",
       "dev": true
     },
     "nanomatch": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "fs-extra": "^5.0.0",
     "gatsby": "^2.15.14",
     "gatsby-source-filesystem": "^2.1.22",
-    "gatsby-theme-patternfly-org": "^0.0.10",
+    "gatsby-theme-patternfly-org": "^0.0.11",
     "glob": "^7.1.2",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.2.0",


### PR DESCRIPTION
Bump gatsby-plugin-patternfly-org which now will:
- Throw an error if Handlebars can't compile
- Pretty Handlebars HTML after it compiles

Also fix import path and GraphQL schema for `patternfly-next` to work as a submodule in `gatsby-theme-patternfly-org`.