### PR TITLE
feat(font): add monospace stack for opt in redhat font

### DIFF
--- a/src/patternfly/_variables.scss
+++ b/src/patternfly/_variables.scss
@@ -152,6 +152,7 @@
   --pf-global--FontFamily--monospace: #{$pf-global--FontFamily--monospace};
   --pf-global--FontFamily--redhatfont--sans-serif: #{$pf-global--FontFamily--redhatfont--sans-serif};
   --pf-global--FontFamily--redhatfont--heading--sans-serif: #{$pf-global--FontFamily--redhatfont--heading--sans-serif};
+  --pf-global--FontFamily--redhatfont--monospace: #{$pf-global--FontFamily--redhatfont--monospace};
 
   // Font size
   --pf-global--FontSize--4xl: #{$pf-global--FontSize--4xl};
@@ -193,6 +194,7 @@
 @include pf-m-redhat-font {
   --pf-global--FontFamily--sans-serif: var(--pf-global--FontFamily--redhatfont--sans-serif);
   --pf-global--FontFamily--heading--sans-serif: var(--pf-global--FontFamily--redhatfont--heading--sans-serif);
+  --pf-global--FontFamily--monospace: var(--pf-global--FontFamily--redhatfont--monospace);
   --pf-global--FontWeight--semi-bold: var(--pf-global--FontWeight--redhatfont--bold);
   --pf-global--FontWeight--bold: var(--pf-global--FontWeight--redhatfont--bold);
   --pf-global--link--FontWeight: var(--pf-global--FontWeight--normal);

--- a/src/patternfly/sass-utilities/scss-variables.scss
+++ b/src/patternfly/sass-utilities/scss-variables.scss
@@ -189,6 +189,7 @@ $pf-global--FontFamily--heading--sans-serif: $pf-global--FontFamily--sans-serif;
 $pf-global--FontFamily--monospace: "overpass-mono", overpass-mono, "SFMono-Regular", menlo, monaco, consolas, "Liberation Mono", "Courier New", monospace !default;
 $pf-global--FontFamily--redhatfont--sans-serif: "RedHatText", "Overpass", overpass, helvetica, arial, sans-serif;
 $pf-global--FontFamily--redhatfont--heading--sans-serif: "RedHatDisplay", "Overpass", overpass, helvetica, arial, sans-serif;
+$pf-global--FontFamily--redhatfont--monospace: "Liberation Mono", consolas, "SFMono-Regular", menlo, monaco, "Courier New", monospace;
 // stylelint-enable value-keyword-case
 
 // Font size


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2268

To test this, you can pull down the branch and update some component to use `font-family: var(--pf-global--FontFamily--monospace);`, then make sure the computed `font-family` is "liberation mono", then remove `.pf-m-redhat-font` from the `<html>` element and make sure the computed `font-family` is "overpass-mono".