### PR TITLE
fix(menus): fix menu group space - dropdown, options menu, app launcher

### DIFF
--- a/src/patternfly/components/AppLauncher/app-launcher-menu-item-text.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-menu-item-text.hbs
@@ -1,6 +1,0 @@
-<span class="pf-c-app-launcher__menu-item-text{{#if app-launcher-menu-item-text--modifier}} {{app-launcher-menu-item-text--modifier}}{{/if}}"
-  {{#if app-launcher-menu-item-text--attribute}}
-	  {{{app-launcher-menu-item-text--attribute}}}
-  {{/if}}>
-  {{{@partial-block}}}
-</span>

--- a/src/patternfly/components/AppLauncher/app-launcher-separator.hbs
+++ b/src/patternfly/components/AppLauncher/app-launcher-separator.hbs
@@ -1,7 +1,10 @@
 <{{#if app-launcher-separator--IsHr}}hr{{else}}li{{/if}} class="pf-c-app-launcher__separator{{#if app-launcher-separator--modifier}} {{app-launcher-separator--modifier}}{{/if}}"
   {{#if app-launcher-separator--attribute}}
 	  {{{app-launcher-separator--attribute}}}
-  {{/if}}>
+  {{/if}}
+  {{#unless app-launcher-separator--IsHr}}
+    role="separator"
+  {{/unless}}>
 {{#unless app-launcher-separator--IsHr}}
 </li>
 {{/unless}}

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -191,7 +191,6 @@
   transform: var(--pf-c-app-launcher__menu-item-external-icon--Transform); // move icon a bit to appear more visually centered
 }
 
-// remove this block at breaking change period
 .pf-c-app-launcher__separator {
   height: var(--pf-c-app-launcher__separator--Height);
   margin-top: var(--pf-c-app-launcher__separator--MarginTop);

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -54,8 +54,10 @@
   --pf-c-app-launcher__separator--MarginBottom: var(--pf-global--spacer--sm);
 
   // Groups
-  --pf-c-app-launcher__group--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-app-launcher__group--first-child--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-app-launcher__group--PaddingTop: 0; // remove at breaking change
+  --pf-c-app-launcher__group--group--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-app-launcher__group--first-child--PaddingTop: 0; // remove at breaking change
+  --pf-c-app-launcher__group-title--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-app-launcher__group-title--PaddingRight: var(--pf-c-app-launcher__menu-item--PaddingRight);
   --pf-c-app-launcher__group-title--PaddingBottom: var(--pf-c-app-launcher__menu-item--PaddingBottom);
   --pf-c-app-launcher__group-title--PaddingLeft: var(--pf-c-app-launcher__menu-item--PaddingLeft);
@@ -196,17 +198,26 @@
   margin-bottom: var(--pf-c-app-launcher__separator--MarginBottom);
   background-color: var(--pf-c-app-launcher__separator--BackgroundColor);
   border: 0; // for use when separator is an <hr>
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .pf-c-app-launcher__group {
-  padding-top: var(--pf-c-app-launcher__group--PaddingTop);
+  padding-top: var(--pf-c-app-launcher__group--PaddingTop); // remove at breaking change
 
   &:first-child {
-    --pf-c-app-launcher__group--PaddingTop: var(--pf-c-app-launcher__group--first-child--PaddingTop);
+    --pf-c-app-launcher__group--PaddingTop: var(--pf-c-app-launcher__group--first-child--PaddingTop); // remove at breaking change
+  }
+
+  & + & {
+    --pf-c-app-launcher__group--PaddingTop: var(--pf-c-app-launcher__group--group--PaddingTop);
   }
 }
 
 .pf-c-app-launcher__group-title {
+  padding-top: var(--pf-c-app-launcher__group-title--PaddingTop);
   padding-right: var(--pf-c-app-launcher__group-title--PaddingRight);
   padding-bottom: var(--pf-c-app-launcher__group-title--PaddingBottom);
   padding-left: var(--pf-c-app-launcher__group-title--PaddingLeft);

--- a/src/patternfly/components/AppLauncher/app-launcher.scss
+++ b/src/patternfly/components/AppLauncher/app-launcher.scss
@@ -199,7 +199,7 @@
   border: 0; // for use when separator is an <hr>
 
   &:last-child {
-    margin-bottom: 0;
+    --pf-c-app-launcher__separator--MarginBottom: 0;
   }
 }
 

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.css
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.css
@@ -14,6 +14,8 @@
   align-items: flex-end;
 }
 
-#ws-core-c-applauncher-with-sections-and-icons {
+#ws-core-c-applauncher-with-sections-and-dividers-between-sections,
+#ws-core-c-applauncher-with-sections-and-dividers-between-items,
+#ws-core-c-applauncher-with-sections-dividers-icons-and-external-links {
   min-height: 424px;
 }

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.md
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.md
@@ -222,7 +222,7 @@ import './AppLauncher.css'
 | `.pf-c-app-launcher__menu-item` | `<a>`, `<button>` | Defines a menu item. |
 | `.pf-c-app-launcher__menu-item-icon` | `<span>` | Defines the wrapper for the menu item icon. |
 | `.pf-c-app-launcher__menu-item-external-icon` | `<i>` | Defines the external link icon that appears on hover/focus. Use with `.pf-m-external`. |
-| `.pf-c-app-launcher__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). |
+| `.pf-c-app-launcher__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). There are no visual differences between the types of elements used as a separator. The different elements allowed are only to support valid markup depending on where you place the separator. |
 | `.pf-m-expanded` | `.pf-c-app-launcher` | Modifies for the expanded state. |
 | `.pf-m-top` | `.pf-c-app-launcher` | Modifies to display the menu above the toggle. |
 | `.pf-m-align-right` | `.pf-c-app-launcher__menu` | Modifies to display the menu aligned to the right edge of the toggle. |

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.md
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.md
@@ -62,7 +62,71 @@ import './AppLauncher.css'
 {{/app-launcher}}
 ```
 
-```hbs title=With-sections-and-icons
+```hbs title=With-sections-and-dividers-between-sections
+{{#> app-launcher app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
+  {{#> app-launcher-menu}}
+    {{#> app-launcher-group}}
+      <ul>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link not in group{{/app-launcher-menu-item}}</li>
+      </ul>
+    {{/app-launcher-group}}
+    {{#> app-launcher-separator app-launcher-separator--IsHr="true"}}{{/app-launcher-separator}}
+    {{#> app-launcher-group}}
+      {{#> app-launcher-group-title}}
+        Group 1
+      {{/app-launcher-group-title}}
+      <ul>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
+      </ul>
+    {{/app-launcher-group}}
+    {{#> app-launcher-separator app-launcher-separator--IsHr="true"}}{{/app-launcher-separator}}
+    {{#> app-launcher-group}}
+      {{#> app-launcher-group-title}}
+        Group 2
+      {{/app-launcher-group-title}}
+      <ul>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
+      </ul>
+    {{/app-launcher-group}}
+  {{/app-launcher-menu}}
+{{/app-launcher}}
+```
+
+```hbs title=With-sections-and-dividers-between-items
+{{#> app-launcher app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
+  {{#> app-launcher-menu}}
+    {{#> app-launcher-group}}
+      <ul>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link not in group{{/app-launcher-menu-item}}</li>
+        {{#> app-launcher-separator}}{{/app-launcher-separator}}
+      </ul>
+    {{/app-launcher-group}}
+    {{#> app-launcher-group}}
+      {{#> app-launcher-group-title}}
+        Group 1
+      {{/app-launcher-group-title}}
+      <ul>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 1 link{{/app-launcher-menu-item}}</li>
+        {{#> app-launcher-separator}}{{/app-launcher-separator}}
+      </ul>
+    {{/app-launcher-group}}
+    {{#> app-launcher-group}}
+      {{#> app-launcher-group-title}}
+        Group 2
+      {{/app-launcher-group-title}}
+      <ul>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
+        <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Group 2 link{{/app-launcher-menu-item}}</li>
+      </ul>
+    {{/app-launcher-group}}
+  {{/app-launcher-menu}}
+{{/app-launcher}}
+```
+
+```hbs title=With-sections,-dividers,-icons,-and-external-links
 {{#> app-launcher app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
@@ -72,9 +136,7 @@ import './AppLauncher.css'
             {{#> app-launcher-menu-item-icon}}
               <img src="/assets/images/pf-logo-small.svg" alt="">
             {{/app-launcher-menu-item-icon}}
-            {{#> app-launcher-menu-item-text}}
-              Link not in group
-            {{/app-launcher-menu-item-text}}
+            Link not in group
           {{/app-launcher-menu-item}}
         </li>
       </ul>
@@ -90,9 +152,7 @@ import './AppLauncher.css'
             {{#> app-launcher-menu-item-icon}}
               <img src="/assets/images/pf-logo-small.svg" alt="">
             {{/app-launcher-menu-item-icon}}
-            {{#> app-launcher-menu-item-text}}
-              Group 1 link
-            {{/app-launcher-menu-item-text}}
+            Group 1 link
             {{> app-launcher-menu-item-external-icon}}
           {{/app-launcher-menu-item}}
         </li>
@@ -101,9 +161,7 @@ import './AppLauncher.css'
             {{#> app-launcher-menu-item-icon}}
               <img src="/assets/images/pf-logo-small.svg" alt="">
             {{/app-launcher-menu-item-icon}}
-            {{#> app-launcher-menu-item-text}}
-              Group 1 link
-            {{/app-launcher-menu-item-text}}
+            Group 1 link
             {{> app-launcher-menu-item-external-icon}}
           {{/app-launcher-menu-item}}
         </li>
@@ -120,9 +178,7 @@ import './AppLauncher.css'
             {{#> app-launcher-menu-item-icon}}
               <img src="/assets/images/pf-logo-small.svg" alt="">
             {{/app-launcher-menu-item-icon}}
-            {{#> app-launcher-menu-item-text}}
-              Group 2 link
-            {{/app-launcher-menu-item-text}}
+            Group 2 link
             {{> app-launcher-menu-item-external-icon}}
           {{/app-launcher-menu-item}}
         </li>
@@ -131,9 +187,7 @@ import './AppLauncher.css'
             {{#> app-launcher-menu-item-icon}}
               <img src="/assets/images/pf-logo-small.svg" alt="">
             {{/app-launcher-menu-item-icon}}
-            {{#> app-launcher-menu-item-text}}
-              Group 2 link
-            {{/app-launcher-menu-item-text}}
+            Group 2 link
             {{> app-launcher-menu-item-external-icon}}
           {{/app-launcher-menu-item}}
         </li>
@@ -167,7 +221,6 @@ import './AppLauncher.css'
 | `.pf-c-app-launcher__group-title` | `<h1>` | Defines a title for a group of items. |
 | `.pf-c-app-launcher__menu-item` | `<a>`, `<button>` | Defines a menu item. |
 | `.pf-c-app-launcher__menu-item-icon` | `<span>` | Defines the wrapper for the menu item icon. |
-| `.pf-c-app-launcher__menu-item-text` | `<span>` | Defines the wrapper for the menu item text. |
 | `.pf-c-app-launcher__menu-item-external-icon` | `<i>` | Defines the external link icon that appears on hover/focus. Use with `.pf-m-external`. |
 | `.pf-c-app-launcher__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). |
 | `.pf-m-expanded` | `.pf-c-app-launcher` | Modifies for the expanded state. |

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.md
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.md
@@ -8,7 +8,7 @@ import './AppLauncher.css'
 
 ## Examples
 ```hbs title=Collapsed
-{{#> app-launcher }}
+{{#> app-launcher id="app-launcher-collapsed"}}
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
@@ -19,7 +19,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=Disabled
-{{#> app-launcher app-launcher--IsDisabled="true"}}
+{{#> app-launcher id="app-launcher-disabled" app-launcher--IsDisabled="true"}}
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
@@ -30,7 +30,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=Expanded
-{{#> app-launcher app-launcher--IsExpanded="true"}}
+{{#> app-launcher id="app-launcher-expanded"  app-launcher--IsExpanded="true"}}
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
@@ -41,7 +41,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=Aligned-right
-{{#> app-launcher app-launcher--IsExpanded="true"}}
+{{#> app-launcher id="app-launcher-aligned-right" app-launcher--IsExpanded="true"}}
   {{#> app-launcher-menu app-launcher-menu--modifier="pf-m-align-right"}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
@@ -52,7 +52,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=Aligned-top
-{{#> app-launcher app-launcher--IsExpanded="true" app-launcher--modifier="pf-m-top"}}
+{{#> app-launcher id="app-launcher-aligned-top" app-launcher--IsExpanded="true" app-launcher--modifier="pf-m-top"}}
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
@@ -63,7 +63,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=With-sections-and-dividers-between-sections
-{{#> app-launcher app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
+{{#> app-launcher id="app-launcher-sections-and-dividers-between-sections" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
       <ul>
@@ -95,7 +95,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=With-sections-and-dividers-between-items
-{{#> app-launcher app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
+{{#> app-launcher id="app-launcher-sections-and-dividers-between-items" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
       <ul>
@@ -127,7 +127,7 @@ import './AppLauncher.css'
 ```
 
 ```hbs title=With-sections,-dividers,-icons,-and-external-links
-{{#> app-launcher app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
+{{#> app-launcher id="app-launcher-sections-dividers-icons-and-external-links" app-launcher--IsExpanded="true" app-launcher--IsGrouped="true"}}
   {{#> app-launcher-menu}}
     {{#> app-launcher-group}}
       <ul>

--- a/src/patternfly/components/AppLauncher/examples/AppLauncher.md
+++ b/src/patternfly/components/AppLauncher/examples/AppLauncher.md
@@ -12,16 +12,18 @@ import './AppLauncher.css'
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
+    {{#> app-launcher-separator}}{{/app-launcher-separator}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-disabled" app-launcher-menu-item--attribute='href="#" aria-disabled="true" tabindex="-1"'}}Disabled link{{/app-launcher-menu-item}}</li>
   {{/app-launcher-menu}}
 {{/app-launcher}}
 ```
 
-```hbs title=Disabled 
+```hbs title=Disabled
 {{#> app-launcher app-launcher--IsDisabled="true"}}
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
+    {{#> app-launcher-separator}}{{/app-launcher-separator}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-disabled" app-launcher-menu-item--attribute='href="#" aria-disabled="true" tabindex="-1"'}}Disabled link{{/app-launcher-menu-item}}</li>
   {{/app-launcher-menu}}
 {{/app-launcher}}
@@ -32,6 +34,7 @@ import './AppLauncher.css'
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
+    {{#> app-launcher-separator}}{{/app-launcher-separator}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-disabled" app-launcher-menu-item--attribute='href="#" aria-disabled="true" tabindex="-1"'}}Disabled link{{/app-launcher-menu-item}}</li>
   {{/app-launcher-menu}}
 {{/app-launcher}}
@@ -42,6 +45,7 @@ import './AppLauncher.css'
   {{#> app-launcher-menu app-launcher-menu--modifier="pf-m-align-right"}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
+    {{#> app-launcher-separator}}{{/app-launcher-separator}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-disabled" app-launcher-menu-item--attribute='href="#" aria-disabled="true" tabindex="-1"'}}Disabled link{{/app-launcher-menu-item}}</li>
   {{/app-launcher-menu}}
 {{/app-launcher}}
@@ -52,6 +56,7 @@ import './AppLauncher.css'
   {{#> app-launcher-menu}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--attribute='href="#"'}}Link{{/app-launcher-menu-item}}</li>
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--type="button"}}Action{{/app-launcher-menu-item}}</li>
+    {{#> app-launcher-separator}}{{/app-launcher-separator}}
     <li>{{#> app-launcher-menu-item app-launcher-menu-item--modifier="pf-m-disabled" app-launcher-menu-item--attribute='href="#" aria-disabled="true" tabindex="-1"'}}Disabled link{{/app-launcher-menu-item}}</li>
   {{/app-launcher-menu}}
 {{/app-launcher}}
@@ -74,7 +79,7 @@ import './AppLauncher.css'
         </li>
       </ul>
     {{/app-launcher-group}}
-    {{#> divider}}{{/divider}}
+    {{#> app-launcher-separator app-launcher-separator--IsHr="true"}}{{/app-launcher-separator}}
     {{#> app-launcher-group}}
       {{#> app-launcher-group-title}}
         Group 1
@@ -102,9 +107,9 @@ import './AppLauncher.css'
             {{> app-launcher-menu-item-external-icon}}
           {{/app-launcher-menu-item}}
         </li>
+        {{#> app-launcher-separator}}{{/app-launcher-separator}}
       </ul>
     {{/app-launcher-group}}
-    {{#> divider}}{{/divider}}
     {{#> app-launcher-group}}
       {{#> app-launcher-group-title}}
         Group 2

--- a/src/patternfly/components/Dropdown/dropdown-menu-groups.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu-groups.hbs
@@ -10,11 +10,17 @@
         <li><button class="pf-c-dropdown__menu-item">Action</button></li>
     </ul>
   </section>
+  {{#if dropdown--HasSeparators}}
+    {{#> dropdown-separator dropdown-separator--IsHr="true"}}{{/dropdown-separator}}
+  {{/if}}
   <section class="pf-c-dropdown__group">
     <h1 class="pf-c-dropdown__group-title">Group 2</h1>
     <ul>
         <li><a class="pf-c-dropdown__menu-item" href="#">Group 2 link</a></li>
         <li><button class="pf-c-dropdown__menu-item">Group 2 action</button></li>
+        {{#if dropdown--HasSeparators}}
+          {{#> dropdown-separator}}{{/dropdown-separator}}
+        {{/if}}
     </ul>
   </section>
   <section class="pf-c-dropdown__group">

--- a/src/patternfly/components/Dropdown/dropdown-menu-groups.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu-groups.hbs
@@ -6,28 +6,34 @@
   {{/if}}>
   <section class="pf-c-dropdown__group">
     <ul>
-        <li><a class="pf-c-dropdown__menu-item" href="#">Link</a></li>
-        <li><button class="pf-c-dropdown__menu-item">Action</button></li>
+      <li><a class="pf-c-dropdown__menu-item" href="#">Link</a></li>
+      <li><button class="pf-c-dropdown__menu-item">Action</button></li>
+      {{#if dropdown--HasSeparatorsItems}}
+        {{#> dropdown-separator}}{{/dropdown-separator}}
+      {{/if}}
     </ul>
   </section>
-  {{#if dropdown--HasSeparators}}
+  {{#if dropdown--HasSeparatorsGroups}}
     {{#> dropdown-separator dropdown-separator--IsHr="true"}}{{/dropdown-separator}}
   {{/if}}
   <section class="pf-c-dropdown__group">
     <h1 class="pf-c-dropdown__group-title">Group 2</h1>
     <ul>
-        <li><a class="pf-c-dropdown__menu-item" href="#">Group 2 link</a></li>
-        <li><button class="pf-c-dropdown__menu-item">Group 2 action</button></li>
-        {{#if dropdown--HasSeparators}}
-          {{#> dropdown-separator}}{{/dropdown-separator}}
-        {{/if}}
+      <li><a class="pf-c-dropdown__menu-item" href="#">Group 2 link</a></li>
+      <li><button class="pf-c-dropdown__menu-item">Group 2 action</button></li>
+      {{#if dropdown--HasSeparatorsItems}}
+        {{#> dropdown-separator}}{{/dropdown-separator}}
+      {{/if}}
     </ul>
   </section>
+  {{#if dropdown--HasSeparatorsGroups}}
+    {{#> dropdown-separator dropdown-separator--IsHr="true"}}{{/dropdown-separator}}
+  {{/if}}
   <section class="pf-c-dropdown__group">
     <h1 class="pf-c-dropdown__group-title">Group 3</h1>
     <ul>
-        <li><a class="pf-c-dropdown__menu-item" href="#">Group 3 link</a></li>
-        <li><button class="pf-c-dropdown__menu-item">Group 3 action</button></li>
+      <li><a class="pf-c-dropdown__menu-item" href="#">Group 3 link</a></li>
+      <li><button class="pf-c-dropdown__menu-item">Group 3 action</button></li>
     </ul>
   </section>
 </div>

--- a/src/patternfly/components/Dropdown/dropdown-menu.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-menu.hbs
@@ -8,6 +8,6 @@
   <li><button class="pf-c-dropdown__menu-item">Action</button></li>
   <li><a class="pf-c-dropdown__menu-item pf-m-disabled" aria-disabled="true" tabindex="-1" href="#">Disabled link</a></li>
   <li><button class="pf-c-dropdown__menu-item" disabled>Disabled action</button></li>
-  {{#> divider divider--type="li"}}{{/divider}}
+  {{#> dropdown-separator}}{{/dropdown-separator}}
   <li><a class="pf-c-dropdown__menu-item" href="#">Separated link</a></li>
 </ul>

--- a/src/patternfly/components/Dropdown/dropdown-separator.hbs
+++ b/src/patternfly/components/Dropdown/dropdown-separator.hbs
@@ -1,0 +1,10 @@
+<{{#if dropdown-separator--IsHr}}hr{{else}}li{{/if}} class="pf-c-dropdown__separator{{#if dropdown-separator--modifier}} {{dropdown-separator--modifier}}{{/if}}"
+  {{#if dropdown-separator--attribute}}
+	  {{{dropdown-separator--attribute}}}
+  {{/if}}
+  {{#unless dropdown-separator--IsHr}}
+    role="separator"
+  {{/unless}}>
+{{#unless dropdown-separator--IsHr}}
+</li>
+{{/unless}}

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -93,8 +93,10 @@
   --pf-c-dropdown__separator--MarginBottom: var(--pf-global--spacer--sm); // remove at breaking change
 
   // Groups
-  --pf-c-dropdown__group--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-dropdown__group--first-child--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-dropdown__group--PaddingTop: 0; // remove at breaking change
+  --pf-c-dropdown__group--group--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-dropdown__group--first-child--PaddingTop: 0; // remove at breaking change
+  --pf-c-dropdown__group-title--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-dropdown__group-title--PaddingRight: var(--pf-c-dropdown__menu-item--PaddingRight);
   --pf-c-dropdown__group-title--PaddingBottom: var(--pf-c-dropdown__menu-item--PaddingBottom);
   --pf-c-dropdown__group-title--PaddingLeft: var(--pf-c-dropdown__menu-item--PaddingLeft);
@@ -362,17 +364,27 @@
   margin-top: var(--pf-c-dropdown__separator--MarginTop);
   margin-bottom: var(--pf-c-dropdown__separator--MarginBottom);
   background-color: var(--pf-c-dropdown__separator--BackgroundColor);
+  border: 0; // for use when separator is an <hr>
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .pf-c-dropdown__group {
-  padding-top: var(--pf-c-dropdown__group--PaddingTop);
+  padding-top: var(--pf-c-dropdown__group--PaddingTop); // remove at breaking change
 
   &:first-child {
-    --pf-c-dropdown__group--PaddingTop: var(--pf-c-dropdown__group--first-child--PaddingTop);
+    --pf-c-dropdown__group--PaddingTop: var(--pf-c-dropdown__group--first-child--PaddingTop); // remove at breaking change
+  }
+
+  & + & {
+    --pf-c-dropdown__group--PaddingTop: var(--pf-c-dropdown__group--group--PaddingTop);
   }
 }
 
 .pf-c-dropdown__group-title {
+  padding-top: var(--pf-c-dropdown__group-title--PaddingTop);
   padding-right: var(--pf-c-dropdown__group-title--PaddingRight);
   padding-bottom: var(--pf-c-dropdown__group-title--PaddingBottom);
   padding-left: var(--pf-c-dropdown__group-title--PaddingLeft);

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -366,7 +366,7 @@
   border: 0; // for use when separator is an <hr>
 
   &:last-child {
-    margin-bottom: 0;
+    --pf-c-dropdown__separator--MarginBottom: 0;
   }
 }
 

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -87,10 +87,10 @@
   --pf-c-dropdown__c-divider--MarginBottom: var(--pf-global--spacer--sm);
 
   // Menu Item Separator
-  --pf-c-dropdown__separator--Height: var(--pf-global--BorderWidth--sm); // remove this var at breaking change
-  --pf-c-dropdown__separator--BackgroundColor: var(--pf-global--BorderColor--100); // remove this var at breaking change
-  --pf-c-dropdown__separator--MarginTop: var(--pf-global--spacer--sm); // remove at breaking change
-  --pf-c-dropdown__separator--MarginBottom: var(--pf-global--spacer--sm); // remove at breaking change
+  --pf-c-dropdown__separator--Height: var(--pf-global--BorderWidth--sm);
+  --pf-c-dropdown__separator--BackgroundColor: var(--pf-global--BorderColor--100);
+  --pf-c-dropdown__separator--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-dropdown__separator--MarginBottom: var(--pf-global--spacer--sm);
 
   // Groups
   --pf-c-dropdown__group--PaddingTop: 0; // remove at breaking change
@@ -358,7 +358,6 @@
   }
 }
 
-// remove this block at breaking change period
 .pf-c-dropdown__separator {
   height: var(--pf-c-dropdown__separator--Height);
   margin-top: var(--pf-c-dropdown__separator--MarginTop);

--- a/src/patternfly/components/Dropdown/examples/Dropdown.css
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.css
@@ -19,7 +19,8 @@
 }
 
 #ws-core-c-dropdown-with-groups,
-#ws-core-c-dropdown-with-groups-and-separators {
+#ws-core-c-dropdown-with-groups-and-separators-between-groups,
+#ws-core-c-dropdown-with-groups-and-separators-between-items {
   min-height: 440px;
 }
 

--- a/src/patternfly/components/Dropdown/examples/Dropdown.css
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.css
@@ -18,7 +18,8 @@
   align-items: flex-end;
 }
 
-#ws-core-c-dropdown-with-groups {
+#ws-core-c-dropdown-with-groups,
+#ws-core-c-dropdown-with-groups-and-separators {
   min-height: 440px;
 }
 

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -8,7 +8,7 @@ import './Dropdown.css'
 
 ## Examples
 ```hbs title=Expanded
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-expanded" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Expanded dropdown
   {{/dropdown-toggle-text}}
@@ -16,7 +16,7 @@ import './Dropdown.css'
 ```
 
 ```hbs title=Collapsed
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-collapsed" dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Collapsed dropdown
   {{/dropdown-toggle-text}}
@@ -24,7 +24,7 @@ import './Dropdown.css'
 ```
 
 ```hbs title=Disabled
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true" dropdown-toggle--IsDisabled="true"}}
+{{#> dropdown id="dropdown-disabled" dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true" dropdown-toggle--IsDisabled="true"}}
   {{#> dropdown-toggle-text}}
     Disabled dropdown
   {{/dropdown-toggle-text}}
@@ -32,18 +32,18 @@ import './Dropdown.css'
 ```
 
 ```hbs title=Kebab
-{{#> dropdown dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions" dropdown-toggle--IsDisabled="true"}}{{/dropdown}}
-{{#> dropdown dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+{{#> dropdown id="dropdown-kebab-disabled" dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions" dropdown-toggle--IsDisabled="true"}}{{/dropdown}}
+{{#> dropdown id="dropdown-kebab" dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+{{#> dropdown id="dropdown-kebab-expanded" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
 ```
 
 ```hbs title=Kebab-align-right
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
+{{#> dropdown id="dropdown-kebab-align-right" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown-menu--modifier="pf-m-align-right" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
 {{/dropdown}}
 ```
 
 ```hbs title=Align-right
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown-menu--modifier="pf-m-align-right"}}
+{{#> dropdown id="dropdown-align-right" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown-menu--modifier="pf-m-align-right"}}
   {{#> dropdown-toggle-text}}
     Right
   {{/dropdown-toggle-text}}
@@ -51,12 +51,12 @@ import './Dropdown.css'
 ```
 
 ```hbs title=Align-top
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-align-top" dropdown--IsActionMenu="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Top
   {{/dropdown-toggle-text}}
 {{/dropdown}}
-{{#> dropdown dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-align-top-expanded" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--modifier="pf-m-top" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Top
   {{/dropdown-toggle-text}}
@@ -64,29 +64,29 @@ import './Dropdown.css'
 ```
 
 ```hbs title=Split-button
-{{#> dropdown dropdown--IsSplitButton="true" dropdown-toggle--IsDisabled="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-disabled-example-button"}}
+{{#> dropdown id="dropdown-split-button-disabled" dropdown--IsSplitButton="true" dropdown-toggle--IsDisabled="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-disabled-example-button"}}
   {{> dropdown-toggle-check dropdown-toggle-check--id="split-button-dropdown-disabled-example-check" aria-label="Select all"}}
   {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id="split-button-dropdown-disabled-example-button" aria-label="Select"}}
 {{/dropdown}}
 
-{{#> dropdown dropdown--IsSplitButton="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-example-button"}}
+{{#> dropdown id="dropdown-split-button" dropdown--IsSplitButton="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-example-button"}}
   {{> dropdown-toggle-check dropdown-toggle-check--id="split-button-dropdown-example-check" aria-label="Select all"}}
   {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id="split-button-dropdown-example-button" aria-label="Select"}}
 {{/dropdown}}
 
-{{#> dropdown dropdown--IsExpanded="true" dropdown--IsSplitButton="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-expanded-example-button"}}
+{{#> dropdown id="dropdown-split-button-expanded" dropdown--IsExpanded="true" dropdown--IsSplitButton="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-expanded-example-button"}}
   {{> dropdown-toggle-check dropdown-toggle-check--id="split-button-dropdown-expanded-example-check" aria-label="Select all"}}
   {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id="split-button-dropdown-expanded-example-button"  aria-label="Select"}}
 {{/dropdown}}
 
-{{#> dropdown dropdown--IsSplitButton="true" dropdown--IsSplitButtonText="10 selected" dropdown--CheckboxIsChecked="true" dropdown--IsBulkSelect="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-with-text-example-button"}}
+{{#> dropdown id="dropdown-split-button-text" dropdown--IsSplitButton="true" dropdown--IsSplitButtonText="10 selected" dropdown--CheckboxIsChecked="true" dropdown--IsBulkSelect="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button" dropdown-menu--toggle-id="split-button-dropdown-with-text-example-button"}}
   {{> dropdown-toggle-check dropdown-toggle-check--id="split-button-dropdown-with-text-example-check" aria-label="Unselect all"}}
   {{> dropdown-toggle-button dropdown--IsToggleButton="true" dropdown-toggle-button--id="split-button-dropdown-with-text-example-button"  aria-label="Select"}}
 {{/dropdown}}
 ```
 
 ```hbs title=With-groups
-{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true"}}
+{{#> dropdown id="dropdown-groups" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true"}}
   {{#> dropdown-toggle-text}}
     Groups
   {{/dropdown-toggle-text}}
@@ -94,7 +94,7 @@ import './Dropdown.css'
 ```
 
 ```hbs title=With-groups-and-separators-between-groups
-{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparatorsGroups="true"}}
+{{#> dropdown id="dropdown-groups-and-separators-between-groups" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparatorsGroups="true"}}
   {{#> dropdown-toggle-text}}
     Groups
   {{/dropdown-toggle-text}}
@@ -102,7 +102,7 @@ import './Dropdown.css'
 ```
 
 ```hbs title=With-groups-and-separators-between-items
-{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparatorsItems="true"}}
+{{#> dropdown id="dropdown-groups-and-separators-between-items" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparatorsItems="true"}}
   {{#> dropdown-toggle-text}}
     Groups
   {{/dropdown-toggle-text}}
@@ -110,7 +110,7 @@ import './Dropdown.css'
 ```
 
 ```hbs title=Panel
-{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-panel" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Expanded dropdown
   {{/dropdown-toggle-text}}
@@ -120,13 +120,13 @@ import './Dropdown.css'
 The dropdown panel is provided for flexibility in allowing various content within a dropdown.
 
 ```hbs title=Primary-toggle
-{{#> dropdown dropdown-toggle--modifier="pf-m-primary" dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-primary-toggle" dropdown-toggle--modifier="pf-m-primary" dropdown--IsActionMenu="true" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Collapsed dropdown
   {{/dropdown-toggle-text}}
 {{/dropdown}}
 &nbsp;
-{{#> dropdown dropdown-toggle--modifier="pf-m-primary" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
+{{#> dropdown id="dropdown-primary-toggle-expanded" dropdown-toggle--modifier="pf-m-primary" dropdown--IsActionMenu="true" dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
     Expanded dropdown
   {{/dropdown-toggle-text}}

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -93,6 +93,14 @@ import './Dropdown.css'
 {{/dropdown}}
 ```
 
+```hbs title=With-groups-and-separators
+{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparators="true"}}
+  {{#> dropdown-toggle-text}}
+    Groups
+  {{/dropdown-toggle-text}}
+{{/dropdown}}
+```
+
 ```hbs title=Panel
 {{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true"}}
   {{#> dropdown-toggle-text}}
@@ -131,7 +139,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `hidden` | `.pf-c-dropdown__menu` | Indicates that the menu is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies. |
 | `aria-labelledby="{toggle button id}"` | `.pf-c-dropdown__menu` | Gives the menu an accessible name by referring to the element that toggles the menu. |
 | `aria-labelledby="{checkbox id} {toggle text id}"` | `.pf-m-split-button .pf-c-dropdown__toggle-check > input[type="checkbox"]` | Gives the checkbox an accessible name by referring to the element by which it is described. |
-| `role="separator"` | `.pf-c-dropdown__separator` | Indicates that the separator is a separator. |
+| `role="separator"` | `li.pf-c-dropdown__separator` | Indicates that the separator is a separator. |
 | `disabled` | `.pf-c-dropdown__toggle`, `.pf-c-dropdown__toggle-button`, `.pf-c-dropdown__toggle-check > input[type="checkbox"]` | Disables the dropdown toggle and removes it from keyboard focus. |
 | `disabled` | `button.pf-c-dropdown__menu-item` | When the menu item uses a button element, indicates that it is unavailable and removes it from keyboard focus. |
 | `aria-disabled="true"` | `a.pf-c-dropdown__menu-item` | When the menu item uses a link element, indicates that it is unavailable. |
@@ -149,7 +157,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-c-dropdown__menu` | `<ul>`, `<div>` | Defines the parent wrapper of the menu items. |
 | `.pf-c-dropdown__menu-item` | `<a>` | Defines a menu item that navigates to another page. |
 | `.pf-c-dropdown__menu-item` | `<button>` | Defines a menu item that performs an action on the current page. |
-| `.pf-c-dropdown__separator` | `<div>` | Defines a separator within the menu. |
+| `.pf-c-dropdown__separator` | `<li>`, `<h4>` | Defines a separator within the menu. |
 | `.pf-c-dropdown__group` | `<section>` | Defines a group of items in a dropdown. **Required when there is more than one group in a dropdown**. |
 | `.pf-c-dropdown__group-title` | `<h1>` | Defines the title for a group of items in the dropdown menu. |
 | `.pf-m-expanded` | `.pf-c-dropdown` | Modifies for the expanded state. |

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -165,7 +165,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-c-dropdown__menu` | `<ul>`, `<div>` | Defines the parent wrapper of the menu items. |
 | `.pf-c-dropdown__menu-item` | `<a>` | Defines a menu item that navigates to another page. |
 | `.pf-c-dropdown__menu-item` | `<button>` | Defines a menu item that performs an action on the current page. |
-| `.pf-c-dropdown__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). |
+| `.pf-c-dropdown__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). There are no visual differences between the types of elements used as a separator. The different elements allowed are only to support valid markup depending on where you place the separator. |
 | `.pf-c-dropdown__group` | `<section>` | Defines a group of items in a dropdown. **Required when there is more than one group in a dropdown**. |
 | `.pf-c-dropdown__group-title` | `<h1>` | Defines the title for a group of items in the dropdown menu. |
 | `.pf-m-expanded` | `.pf-c-dropdown` | Modifies for the expanded state. |

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -157,7 +157,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-c-dropdown__menu` | `<ul>`, `<div>` | Defines the parent wrapper of the menu items. |
 | `.pf-c-dropdown__menu-item` | `<a>` | Defines a menu item that navigates to another page. |
 | `.pf-c-dropdown__menu-item` | `<button>` | Defines a menu item that performs an action on the current page. |
-| `.pf-c-dropdown__separator` | `<li>`, `<h4>` | Defines a separator within the menu. |
+| `.pf-c-dropdown__separator` | `<li>`, `<hr>` | Defines a separator within the menu. |
 | `.pf-c-dropdown__group` | `<section>` | Defines a group of items in a dropdown. **Required when there is more than one group in a dropdown**. |
 | `.pf-c-dropdown__group-title` | `<h1>` | Defines the title for a group of items in the dropdown menu. |
 | `.pf-m-expanded` | `.pf-c-dropdown` | Modifies for the expanded state. |

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -93,8 +93,16 @@ import './Dropdown.css'
 {{/dropdown}}
 ```
 
-```hbs title=With-groups-and-separators
-{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparators="true"}}
+```hbs title=With-groups-and-separators-between-groups
+{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparatorsGroups="true"}}
+  {{#> dropdown-toggle-text}}
+    Groups
+  {{/dropdown-toggle-text}}
+{{/dropdown}}
+```
+
+```hbs title=With-groups-and-separators-between-items
+{{#> dropdown dropdown--IsExpanded="true" dropdown--HasToggleIcon="true" dropdown--IsGroupsMenu="true" dropdown--HasSeparatorsItems="true"}}
   {{#> dropdown-toggle-text}}
     Groups
   {{/dropdown-toggle-text}}
@@ -157,7 +165,7 @@ The dropdown menu can contain either links or buttons, depending on the expected
 | `.pf-c-dropdown__menu` | `<ul>`, `<div>` | Defines the parent wrapper of the menu items. |
 | `.pf-c-dropdown__menu-item` | `<a>` | Defines a menu item that navigates to another page. |
 | `.pf-c-dropdown__menu-item` | `<button>` | Defines a menu item that performs an action on the current page. |
-| `.pf-c-dropdown__separator` | `<li>`, `<hr>` | Defines a separator within the menu. |
+| `.pf-c-dropdown__separator` | `<li>`, `<hr>` | Defines a separator within the menu. Can be used between items (`<li>`) or  between groups (`<hr>`). |
 | `.pf-c-dropdown__group` | `<section>` | Defines a group of items in a dropdown. **Required when there is more than one group in a dropdown**. |
 | `.pf-c-dropdown__group-title` | `<h1>` | Defines the title for a group of items in the dropdown menu. |
 | `.pf-m-expanded` | `.pf-c-dropdown` | Modifies for the expanded state. |

--- a/src/patternfly/components/OptionsMenu/options-menu-multiple.hbs
+++ b/src/patternfly/components/OptionsMenu/options-menu-multiple.hbs
@@ -15,7 +15,7 @@
     {{/options-menu-menu-item}}
   </ul>
 </li>
-{{#> divider divider--type="li"}}{{/divider}}
+{{#> options-menu-separator}}{{/options-menu-separator}}
 <li>
   <ul aria-label="Sort direction">
     {{#> options-menu-menu-item options-menu-menu-item--IsSelected="true"}}

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -72,10 +72,10 @@
   --pf-c-options-menu__c-divider--MarginBottom: var(--pf-global--spacer--sm);
 
   // Menu item separator
-  --pf-c-options-menu__separator--Height: var(--pf-global--BorderWidth--sm); // remove at breaking change
-  --pf-c-options-menu__separator--BackgroundColor: var(--pf-global--BackgroundColor--light-300); // remove at breaking change
-  --pf-c-options-menu__separator--MarginTop: var(--pf-global--spacer--sm); // remove at breaking change
-  --pf-c-options-menu__separator--MarginBottom: var(--pf-global--spacer--sm); // remove at breaking change
+  --pf-c-options-menu__separator--Height: var(--pf-global--BorderWidth--sm);
+  --pf-c-options-menu__separator--BackgroundColor: var(--pf-global--BorderColor--100);
+  --pf-c-options-menu__separator--MarginTop: var(--pf-global--spacer--sm);
+  --pf-c-options-menu__separator--MarginBottom: var(--pf-global--spacer--sm);
 
   position: relative;
   display: inline-block;
@@ -275,7 +275,6 @@
   color: var(--pf-c-options-menu__menu-item-icon--Color);
 }
 
-// remove this block at breaking change period
 .pf-c-options-menu__separator {
   height: var(--pf-c-options-menu__separator--Height);
   margin-top: var(--pf-c-options-menu__separator--MarginTop);

--- a/src/patternfly/components/OverflowMenu/examples/OverflowMenu.md
+++ b/src/patternfly/components/OverflowMenu/examples/OverflowMenu.md
@@ -276,5 +276,6 @@ The action group consists of a primary and secondary action. Any additional acti
 | `.pf-c-overflow-menu__control` | `<div>` | Initiates the overflow menu control. **Required** |
 | `.pf-c-overflow-menu__group` | `<div>` | Initiates an overflow menu group. |
 | `.pf-c-overflow-menu__item` | `<div>` | Initiates an overflow menu item. **Required** |
+| `.pf-c-overflow-menu__separator` | `<li>` | Defines a separator within the menu. |
 | `.pf-m-button-group` | `.pf-c-overflow-menu__group` | Modifies overflow menu group spacing. Spacer value is set to `var(--pf-c-overflow-menu__group--m-button-group--spacer)`. Child spacer value is set to `var(--pf-c-overflow-menu__group--m-button-group--space-items)`. |
 | `.pf-m-icon-button-group` | `.pf-c-overflow-menu__group` | Modifies overflow menu group spacing. Spacer value is set to `var(--pf-c-overflow-menu__group--m-icon-button-group--spacer)`. Child spacer value is set to `var(--pf-c-overflow-menu__group--m-icon-button-group--space-items)`. |


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2102

Updated our examples to show a divider in a list (as an `<li>`), as the last `<li>` in a list as a way to separate groups (how the react examples use it), and also as an `<hr>` between groups per the new spacing @mceledonia and I discussed.