### PR TITLE
chore(build): allow consumers to build patternfly.scss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,6 +112,8 @@ function copySource() {
     src(config.sourceFiles).pipe(dest('./dist')),
     src('./src/patternfly/_*.scss').pipe(dest('./dist')),
     src('./src/patternfly/sass-utilities/*').pipe(dest('./dist/sass-utilities')),
+    src('./src/patternfly/components/_all.scss').pipe(dest('./dist/components')),
+    src('./src/patternfly/layouts/_all.scss').pipe(dest('./dist/layouts')),
     // Assets
     src('./static/assets/images/**/*').pipe(dest('./dist/assets/images/')),
     src('./src/patternfly/assets/**/*').pipe(dest('./dist/assets/')),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,8 +112,7 @@ function copySource() {
     src(config.sourceFiles).pipe(dest('./dist')),
     src('./src/patternfly/_*.scss').pipe(dest('./dist')),
     src('./src/patternfly/sass-utilities/*').pipe(dest('./dist/sass-utilities')),
-    src('./src/patternfly/components/_all.scss').pipe(dest('./dist/components')),
-    src('./src/patternfly/layouts/_all.scss').pipe(dest('./dist/layouts')),
+    src('./src/patternfly/**/_all.scss').pipe(dest('./dist')),
     // Assets
     src('./static/assets/images/**/*').pipe(dest('./dist/assets/images/')),
     src('./src/patternfly/assets/**/*').pipe(dest('./dist/assets/')),

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,4 +1,4 @@
-@import "../../patternfly-imports";
+@import "../../patternfly-imports.scss";
 
 .pf-c-skip-to-content {
   --pf-c-skip-to-content--Top: var(--pf-global--spacer--md);

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,4 +1,5 @@
-@import "../../patternfly-imports.scss";
+// Don't remove this magic comment. See gulpfile.js.
+// @import "../../sass-utilities/all";
 
 .pf-c-skip-to-content {
   --pf-c-skip-to-content--Top: var(--pf-global--spacer--md);


### PR DESCRIPTION
See #2405
Closes #2404 

> When importing patternfly.scss as a dependency in a project, a series of errors are thrown for not finding /components/_all.scss and /layouts/_all.scss files.
In fact, when installing PF4 via npm install @patternfly/patternfly --save the two files are not currently copied over.

> The PR also fixes a second error thrown by gulp after manually patching the _all.scss files: the @import "../../patternfly-imports" in components/SkipToContent/skip-to-content.scss doesn't specify an extension and gulp is not sure whether it would need to import patternfly-imports.css or patternfly-imports.scss.