### PR TITLE
fix(grid): adds support for aligning/justifying

### DIFF
--- a/src/patternfly/layouts/Grid/examples/Grid.css
+++ b/src/patternfly/layouts/Grid/examples/Grid.css
@@ -7,7 +7,3 @@
 .ws-core-l-grid .pf-l-grid[class*="pf-m-align-"], div[id*="ws-core-l-grid-align-self-"] .pf-l-grid{
   min-height: 260px; /* gives the grid a height to show the alignment */
 }
-
-.ws-core-l-grid div[class*="pf-m-justify-content-"]:not(.pf-m-justify-content-stretch) {
-  grid-template-columns: repeat(3, max-content); /*shows placement of items*/ 
-}

--- a/src/patternfly/layouts/Grid/examples/Grid.css
+++ b/src/patternfly/layouts/Grid/examples/Grid.css
@@ -1,4 +1,13 @@
-.ws-core-l-grid .pf-l-grid__item {
+/* stylelint-disable */
+.ws-core-l-grid .pf-l-grid, .ws-core-l-grid .pf-l-grid__item {
   padding: .5rem !important;
   border: 2px dashed #393f44;
+}
+
+.ws-core-l-grid .pf-l-grid[class*="pf-m-align-"], div[id*="ws-core-l-grid-align-self-"] .pf-l-grid{
+  min-height: 260px; /* gives the grid a height to show the alignment */
+}
+
+.ws-core-l-grid div[class*="pf-m-justify-content-"]:not(.pf-m-justify-content-stretch) {
+  grid-template-columns: repeat(3, max-content); /*shows placement of items*/ 
 }

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -510,230 +510,8 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-#### Justify content
-#### For all `justify-content` grids, `grid-template-columns` is set to `initial` to allow customization over the column count.
-```hbs title=Justify-content-start
-{{#> grid grid--modifier="pf-m-justify-content-start pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Justify-content-center
-{{#> grid grid--modifier="pf-m-justify-content-center pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Justify-content-end
-{{#> grid grid--modifier="pf-m-justify-content-end pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Justify-content-stretch
-{{#> grid grid--modifier="pf-m-justify-content-stretch pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Justify-content-space-around
-{{#> grid grid--modifier="pf-m-justify-content-space-around pf-m-grid-auto-flow-column pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Justify-content-space-between
-{{#> grid grid--modifier="pf-m-justify-content-space-between pf-m-grid-auto-flow-column pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Justify-content-space-evenly
-{{#> grid grid--modifier="pf-m-justify-content-space-evenly pf-m-grid-auto-flow-column pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Grid-auto-flow-column
-{{#> grid grid--modifier="pf-m-grid-auto-flow-column pf-m-justify-content-start pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=Grid-auto-flow-row
-{{#> grid grid--modifier="pf-m-grid-auto-flow-row pf-m-justify-content-start pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
-```hbs title=grid-auto-flow-dense
-{{#> grid grid--modifier="pf-m-grid-auto-flow-dense pf-m-justify-content-start pf-m-gutter"}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 1
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
-    item 2
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-2-col"}}
-    item 3
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 4
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
-    item 5
-  {{/grid-item}}
-  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
-    item 6
-  {{/grid-item}}
-{{/grid}}
-```
 #### Align content
-```hbs title=align-content-start
+```hbs title=Align-content-start
 {{#> grid grid--modifier="pf-m-align-content-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -755,7 +533,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ``` 
-```hbs title=align-content-center
+```hbs title=Align-content-center
 {{#> grid grid--modifier="pf-m-align-content-center pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -777,7 +555,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-content-end
+```hbs title=Align-content-end
 {{#> grid grid--modifier="pf-m-align-content-end pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -799,7 +577,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-content-stretch
+```hbs title=Align-content-stretch
 {{#> grid grid--modifier="pf-m-align-content-stretch pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -821,7 +599,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-content-space-around
+```hbs title=Align-content-space-around
 {{#> grid grid--modifier="pf-m-align-content-space-around pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -843,7 +621,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-content-space-between
+```hbs title=Align-content-space-between
 {{#> grid grid--modifier="pf-m-align-content-space-between pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -865,7 +643,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-content-space-evenly
+```hbs title=Align-content-space-evenly
 {{#> grid grid--modifier="pf-m-align-content-space-evenly pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1
@@ -888,28 +666,28 @@ import './Grid.css'
 {{/grid}}
 ```
 #### Justify self
-```hbs title=justify-self-start
+```hbs title=Justify-self-start
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-justify-self-start"}}
     item 1
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-self-center
+```hbs title=Justify-self-center
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-justify-self-center"}}
     item 1
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-self-end
+```hbs title=Justify-self-end
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-justify-self-end"}}
     item 1
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-self-stretch
+```hbs title=Justify-self-stretch
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-justify-self-stretch"}}
     item 1
@@ -917,28 +695,28 @@ import './Grid.css'
 {{/grid}}
 ```
 #### Align self
-```hbs title=align-self-start
+```hbs title=Align-self-start
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-align-self-start pf-m-4-col"}}
     item 1
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-self-center
+```hbs title=Align-self-center
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-align-self-center pf-m-4-col"}}
     item 1
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-self-end
+```hbs title=Align-self-end
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-align-self-end pf-m-4-col"}}
     item 1
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-self-stretch
+```hbs title=Align-self-stretch
 {{#> grid grid--modifier="pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-align-self-stretch pf-m-4-col"}}
     item 1
@@ -947,7 +725,7 @@ import './Grid.css'
 ```
 
 ## Documentation
-### Overiew
+### Overview
 The grid layout is based on CSS Grid’s two-dimensional system of columns and rows. This layout styles the parent element and its children to achieve responsive column and row spans as well as gutters.
 
 ### Usage
@@ -969,13 +747,6 @@ The grid layout is based on CSS Grid’s two-dimensional system of columns and r
 | `.pf-m-align-items-center` | `.pf-l-grid` | Modifies align-items property to center. |
 | `.pf-m-align-items-end` | `.pf-l-grid` | Modifies align-items property to end. |
 | `.pf-m-align-items-stretch` | `.pf-l-grid` | Modifies align-items property to stretch. |
-| `.pf-m-justify-content-start` | `.pf-l-grid` | Modifies justify-content property to start. |
-| `.pf-m-justify-content-center` | `.pf-l-grid` | Modifies justify-content property to center. |
-| `.pf-m-justify-content-end` | `.pf-l-grid` | Modifies justify-content property to end. |
-| `.pf-m-justify-content-stretch` | `.pf-l-grid` | Modifies justify-content property to stretch. |
-| `.pf-m-justify-content-space-around` | `.pf-l-grid` | Modifies justify-content property to space-around. |
-| `.pf-m-justify-content-space-between` | `.pf-l-grid` | Modifies justify-content property to space-between. |
-| `.pf-m-justify-content-space-evenly` | `.pf-l-grid` | Modifies justify-content property to space-evenly. |
 | `.pf-m-align-content-start` | `.pf-l-grid` | Modifies align-content property to start. |
 | `.pf-m-align-content-center` | `.pf-l-grid` | Modifies align-content property to center. |
 | `.pf-m-align-content-end` | `.pf-l-grid` | Modifies align-content property to end. |
@@ -983,9 +754,6 @@ The grid layout is based on CSS Grid’s two-dimensional system of columns and r
 | `.pf-m-align-content-space-around` | `.pf-l-grid` | Modifies align-content property to space-around. |
 | `.pf-m-align-content-space-between` | `.pf-l-grid` | Modifies align-content property to space-between. |
 | `.pf-m-align-content-space-evenly` | `.pf-l-grid` | Modifies align-content property to space-evenly. |
-| `.pf-m-grid-auto-flow-column` | `.pf-l-grid` | Modifies grid-auto-flow property to column. |
-| `.pf-m-grid-auto-flow-row` | `.pf-l-grid` | Modifies grid-auto-flow property to row. |
-| `.pf-m-grid-auto-flow-dense` | `.pf-l-grid` | Modifies grid-auto-flow property to dense. |
 | `.pf-m-justify-self-start` | `.pf-l-grid__item` | Modifies justify-self property to start. |
 | `.pf-m-justify-self-center` | `.pf-l-grid__item` | Modifies justify-self property to center. |
 | `.pf-m-justify-self-end` | `.pf-l-grid__item` | Modifies justify-self property to end. |

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -534,7 +534,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-content-center
+```hbs title=Justify-content-center
 {{#> grid grid--modifier="pf-m-justify-content-center pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -622,7 +622,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-content-space-between
+```hbs title=Justify-content-space-between
 {{#> grid grid--modifier="pf-m-justify-content-space-between pf-m-grid-auto-flow-column pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -377,7 +377,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-items-end
+```hbs title=Justify-items-end
 {{#> grid grid--modifier="pf-m-justify-items-end pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -512,7 +512,7 @@ import './Grid.css'
 ```
 #### Justify content
 #### For all `justify-content` grids `grid-template-columns` is set to initial to allow customization over the column count.
-```hbs title=justify-content-start
+```hbs title=Justify-content-start
 {{#> grid grid--modifier="pf-m-justify-content-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -444,7 +444,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ``` 
-```hbs title=align-items-center
+```hbs title=Align-items-center
 {{#> grid grid--modifier="pf-m-align-items-center pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -578,7 +578,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-content-stretch
+```hbs title=Justify-content-stretch
 {{#> grid grid--modifier="pf-m-justify-content-stretch pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -159,7 +159,7 @@ import './Grid.css'
 {{/grid}}
 ```
 ```hbs title=Row-Gutter
-{{#> grid grid--modifier="pf-m-gutter-row"}}
+{{#> grid grid--modifier="pf-m-gutter-rows"}}
   {{#> grid-item grid-item--modifier="pf-m-12-col"}}
       12 col
   {{/grid-item}}
@@ -184,7 +184,7 @@ import './Grid.css'
 {{/grid}}
 ```
 ```hbs title=Column-Gutter
-{{#> grid grid--modifier="pf-m-gutter-column"}}
+{{#> grid grid--modifier="pf-m-gutter-columns"}}
   {{#> grid-item grid-item--modifier="pf-m-12-col"}}
       12 col
   {{/grid-item}}

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -511,7 +511,7 @@ import './Grid.css'
 {{/grid}}
 ```
 #### Justify content
-#### For all `justify-content` grids `grid-template-columns` is set to initial to allow customization over the column count.
+#### For all `justify-content` grids, `grid-template-columns` is set to `initial` to allow customization over the column count.
 ```hbs title=Justify-content-start
 {{#> grid grid--modifier="pf-m-justify-content-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -556,7 +556,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-content-end
+```hbs title=Justify-content-end
 {{#> grid grid--modifier="pf-m-justify-content-end pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -688,7 +688,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=grid-auto-flow-row
+```hbs title=Grid-auto-flow-row
 {{#> grid grid--modifier="pf-m-grid-auto-flow-row pf-m-justify-content-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -666,7 +666,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=grid-auto-flow-column
+```hbs title=Grid-auto-flow-column
 {{#> grid grid--modifier="pf-m-grid-auto-flow-column pf-m-justify-content-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -511,6 +511,7 @@ import './Grid.css'
 {{/grid}}
 ```
 #### Justify content
+#### For all `justify-content` grids `grid-template-columns` is set to initial to allow customization over the column count.
 ```hbs title=justify-content-start
 {{#> grid grid--modifier="pf-m-justify-content-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
@@ -600,7 +601,7 @@ import './Grid.css'
 {{/grid}}
 ```
 ```hbs title=justify-content-space-around
-{{#> grid grid--modifier="pf-m-justify-content-space-around pf-m-gutter"}}
+{{#> grid grid--modifier="pf-m-justify-content-space-around pf-m-grid-auto-flow-column pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1
   {{/grid-item}}
@@ -622,7 +623,7 @@ import './Grid.css'
 {{/grid}}
 ```
 ```hbs title=justify-content-space-between
-{{#> grid grid--modifier="pf-m-justify-content-space-between pf-m-gutter"}}
+{{#> grid grid--modifier="pf-m-justify-content-space-between pf-m-grid-auto-flow-column pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1
   {{/grid-item}}
@@ -644,7 +645,7 @@ import './Grid.css'
 {{/grid}}
 ```
 ```hbs title=justify-content-space-evenly
-{{#> grid grid--modifier="pf-m-justify-content-space-evenly pf-m-gutter"}}
+{{#> grid grid--modifier="pf-m-justify-content-space-evenly pf-m-grid-auto-flow-column pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1
   {{/grid-item}}
@@ -661,6 +662,72 @@ import './Grid.css'
     item 5
   {{/grid-item}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=grid-auto-flow-column
+{{#> grid grid--modifier="pf-m-grid-auto-flow-column pf-m-justify-content-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=grid-auto-flow-row
+{{#> grid grid--modifier="pf-m-grid-auto-flow-row pf-m-justify-content-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=grid-auto-flow-dense
+{{#> grid grid--modifier="pf-m-grid-auto-flow-dense pf-m-justify-content-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-2-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
     item 6
   {{/grid-item}}
 {{/grid}}
@@ -916,6 +983,9 @@ The grid layout is based on CSS Grid’s two-dimensional system of columns and r
 | `.pf-m-align-content-space-around` | `.pf-l-grid` | Modifies align-content property to space-around. |
 | `.pf-m-align-content-space-between` | `.pf-l-grid` | Modifies align-content property to space-between. |
 | `.pf-m-align-content-space-evenly` | `.pf-l-grid` | Modifies align-content property to space-evenly. |
+| `.pf-m-grid-auto-flow-column` | `.pf-l-grid` | Modifies grid-auto-flow property to column. |
+| `.pf-m-grid-auto-flow-row` | `.pf-l-grid` | Modifies grid-auto-flow property to row. |
+| `.pf-m-grid-auto-flow-dense` | `.pf-l-grid` | Modifies grid-auto-flow property to dense. |
 | `.pf-m-justify-self-start` | `.pf-l-grid__item` | Modifies justify-self property to start. |
 | `.pf-m-justify-self-center` | `.pf-l-grid__item` | Modifies justify-self property to center. |
 | `.pf-m-justify-self-end` | `.pf-l-grid__item` | Modifies justify-self property to end. |

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -422,7 +422,7 @@ import './Grid.css'
 {{/grid}}
 ```
 #### Align items
-```hbs title=align-items-start
+```hbs title=Align-items-start
 {{#> grid grid--modifier="pf-m-align-items-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -183,7 +183,7 @@ import './Grid.css'
   {{/grid-item}}    
 {{/grid}}
 ```
-```hbs title=Column-Gutter
+```hbs title=Column-gutter
 {{#> grid grid--modifier="pf-m-gutter-columns"}}
   {{#> grid-item grid-item--modifier="pf-m-12-col"}}
       12 col

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -331,7 +331,7 @@ import './Grid.css'
 ```
 ### Aligning and justifying
 
-#### Justify-items
+#### Justify items
 ```hbs title=Justify-items-start
 {{#> grid grid--modifier="pf-m-justify-items-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
@@ -727,37 +727,39 @@ import './Grid.css'
 ### Overview
 The grid layout is based on CSS Grid’s two-dimensional system of columns and rows. This layout styles the parent element and its children to achieve responsive column and row spans as well as gutters.
 
+Currently the grid layout does not offer `justify-content` or `grid-auto-flow` options due to the strict 12 column layout. This may change in the future if a more customizable grid is offered.
+
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-l-grid` | `<div>` | Initializes the grid layout. |
 | `.pf-l-grid__item` | `<div>` | Explicitly sets a child of the grid. This class isn't necessary, but it is included to keep inline with BEM convention, and to provide an entity that will later be used for applying modifiers. |
-| `.pf-m-gutter` | `.pf-l-grid` | Adds space between children by using the globally defined gutter value. |
-| `.pf-m-gutter-rows` | `.pf-l-grid` | Adds space between children rows by using the globally defined gutter value. |
-| `.pf-m-gutter-columns` | `.pf-l-grid` | Adds space between children columns by using the globally defined gutter value. |
+| `.pf-m-gutter{-on-[breakpoint]}` | `.pf-l-grid` | Adds space between children by using the globally defined gutter value. |
+| `.pf-m-gutter-rows{-on-[breakpoint]}` | `.pf-l-grid` | Adds space between children rows by using the globally defined gutter value. |
+| `.pf-m-gutter-columns{-on-[breakpoint]}` | `.pf-l-grid` | Adds space between children columns by using the globally defined gutter value. |
 | `.pf-m-all-{1-12}-col{-on-[breakpoint]}` | `.pf-l-grid` | Defines grid item size on grid container. |
 | `.pf-m-{1-12}-col{-on-[breakpoint]}` | `.pf-l-grid__item` | Defines grid item size.  Although not required, they are strongly suggested. If not used, grid item will default to 12 col. |
 | `.pf-m-{2-x}-row{-on-[breakpoint]}` | `.pf-l-grid__item` | Defines grid item row span.  For row spans to function correctly, the value of of the current row plus the grid items to span must be equal to or less than 12. Example: .pf-m-8-col.pf-m-2-row + .pf-m-4-col + .pf-m-4-col. There is no limit to number of spanned rows. |
-| `.pf-m-justify-items-start` | `.pf-l-grid` | Modifies justify-items property to start. |
-| `.pf-m-justify-items-center` | `.pf-l-grid` | Modifies justify-items property to center. |
-| `.pf-m-justify-items-end` | `.pf-l-grid` | Modifies justify-items property to end. |
-| `.pf-m-justify-items-stretch` | `.pf-l-grid` | Modifies justify-items property to stretch. |
-| `.pf-m-align-items-start` | `.pf-l-grid` | Modifies align-items property to start. |
-| `.pf-m-align-items-center` | `.pf-l-grid` | Modifies align-items property to center. |
-| `.pf-m-align-items-end` | `.pf-l-grid` | Modifies align-items property to end. |
-| `.pf-m-align-items-stretch` | `.pf-l-grid` | Modifies align-items property to stretch. |
-| `.pf-m-align-content-start` | `.pf-l-grid` | Modifies align-content property to start. |
-| `.pf-m-align-content-center` | `.pf-l-grid` | Modifies align-content property to center. |
-| `.pf-m-align-content-end` | `.pf-l-grid` | Modifies align-content property to end. |
-| `.pf-m-align-content-stretch` | `.pf-l-grid` | Modifies align-content property to stretch. |
-| `.pf-m-align-content-space-around` | `.pf-l-grid` | Modifies align-content property to space-around. |
-| `.pf-m-align-content-space-between` | `.pf-l-grid` | Modifies align-content property to space-between. |
-| `.pf-m-align-content-space-evenly` | `.pf-l-grid` | Modifies align-content property to space-evenly. |
-| `.pf-m-justify-self-start` | `.pf-l-grid__item` | Modifies justify-self property to start. |
-| `.pf-m-justify-self-center` | `.pf-l-grid__item` | Modifies justify-self property to center. |
-| `.pf-m-justify-self-end` | `.pf-l-grid__item` | Modifies justify-self property to end. |
-| `.pf-m-justify-self-stretch` | `.pf-l-grid__item` | Modifies justify-self property to stretch. |
-| `.pf-m-align-self-start` | `.pf-l-grid__item` | Modifies align-self property to start. |
-| `.pf-m-align-self-center` | `.pf-l-grid__item` | Modifies align-self property to center. |
-| `.pf-m-align-self-end` | `.pf-l-grid__item` | Modifies align-self property to end. |
-| `.pf-m-align-self-stretch` | `.pf-l-grid__item` | Modifies align-self property to stretch. |
+| `.pf-m-justify-items-start{-on-[breakpoint]}` | `.pf-l-grid` | Modifies justify-items property to start. |
+| `.pf-m-justify-items-center{-on-[breakpoint]}` | `.pf-l-grid` | Modifies justify-items property to center. |
+| `.pf-m-justify-items-end{-on-[breakpoint]}` | `.pf-l-grid` | Modifies justify-items property to end. |
+| `.pf-m-justify-items-stretch{-on-[breakpoint]}` | `.pf-l-grid` | Modifies justify-items property to stretch. |
+| `.pf-m-align-items-start{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-items property to start. |
+| `.pf-m-align-items-center{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-items property to center. |
+| `.pf-m-align-items-end{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-items property to end. |
+| `.pf-m-align-items-stretch{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-items property to stretch. |
+| `.pf-m-align-content-start{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to start. |
+| `.pf-m-align-content-center{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to center. |
+| `.pf-m-align-content-end{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to end. |
+| `.pf-m-align-content-stretch{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to stretch. |
+| `.pf-m-align-content-space-around{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to space-around. |
+| `.pf-m-align-content-space-between{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to space-between. |
+| `.pf-m-align-content-space-evenly{-on-[breakpoint]}` | `.pf-l-grid` | Modifies align-content property to space-evenly. |
+| `.pf-m-justify-self-start{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies justify-self property to start. |
+| `.pf-m-justify-self-center{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies justify-self property to center. |
+| `.pf-m-justify-self-end{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies justify-self property to end. |
+| `.pf-m-justify-self-stretch{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies justify-self property to stretch. |
+| `.pf-m-align-self-start{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies align-self property to start. |
+| `.pf-m-align-self-center{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies align-self property to center. |
+| `.pf-m-align-self-end{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies align-self property to end. |
+| `.pf-m-align-self-stretch{-on-[breakpoint]}` | `.pf-l-grid__item` | Modifies align-self property to stretch. |

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -644,7 +644,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-content-space-evenly
+```hbs title=Justify-content-space-evenly
 {{#> grid grid--modifier="pf-m-justify-content-space-evenly pf-m-grid-auto-flow-column pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -732,7 +732,7 @@ Currently the grid layout does not offer `justify-content` or `grid-auto-flow` o
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-l-grid` | `<div>` | Initializes the grid layout. |
+| `.pf-l-grid` | `<div>` | Initializes the grid layout. **Required** |
 | `.pf-l-grid__item` | `<div>` | Explicitly sets a child of the grid. This class isn't necessary, but it is included to keep inline with BEM convention, and to provide an entity that will later be used for applying modifiers. |
 | `.pf-m-gutter{-on-[breakpoint]}` | `.pf-l-grid` | Adds space between children by using the globally defined gutter value. |
 | `.pf-m-gutter-rows{-on-[breakpoint]}` | `.pf-l-grid` | Adds space between children rows by using the globally defined gutter value. |

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -158,6 +158,56 @@ import './Grid.css'
   {{/grid-item}}    
 {{/grid}}
 ```
+```hbs title=Row-Gutter
+{{#> grid grid--modifier="pf-m-gutter-row"}}
+  {{#> grid-item grid-item--modifier="pf-m-12-col"}}
+      12 col
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-11-col"}}
+      11 col 
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+      1 col 
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-10-col"}}
+      10 col 
+  {{/grid-item}}    
+  {{#> grid-item grid-item--modifier="pf-m-2-col"}}
+      2 col 
+  {{/grid-item}}    
+  {{#> grid-item grid-item--modifier="pf-m-9-col"}}
+      9 col 
+  {{/grid-item}}    
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      3 col 
+  {{/grid-item}}    
+{{/grid}}
+```
+```hbs title=Column-Gutter
+{{#> grid grid--modifier="pf-m-gutter-column"}}
+  {{#> grid-item grid-item--modifier="pf-m-12-col"}}
+      12 col
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-11-col"}}
+      11 col 
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+      1 col 
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-10-col"}}
+      10 col 
+  {{/grid-item}}    
+  {{#> grid-item grid-item--modifier="pf-m-2-col"}}
+      2 col 
+  {{/grid-item}}    
+  {{#> grid-item grid-item--modifier="pf-m-9-col"}}
+      9 col 
+  {{/grid-item}}    
+  {{#> grid-item grid-item--modifier="pf-m-3-col"}}
+      3 col 
+  {{/grid-item}}    
+{{/grid}}
+```
 
 ```hbs title=Responsive
 {{#> grid}}
@@ -279,6 +329,555 @@ import './Grid.css'
   {{/grid-item}}  
 {{/grid}}
 ```
+### Aligning and justifying
+
+#### Justify-items
+
+```hbs title=justify-items-start
+{{#> grid grid--modifier="pf-m-justify-items-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-items-center
+{{#> grid grid--modifier="pf-m-justify-items-center pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-items-end
+{{#> grid grid--modifier="pf-m-justify-items-end pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-items-stretch
+{{#> grid grid--modifier="pf-m-justify-items-stretch pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+#### Align items
+```hbs title=align-items-start
+{{#> grid grid--modifier="pf-m-align-items-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+``` 
+```hbs title=align-items-center
+{{#> grid grid--modifier="pf-m-align-items-center pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-items-end
+{{#> grid grid--modifier="pf-m-align-items-end pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-items-stretch
+{{#> grid grid--modifier="pf-m-align-items-stretch pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+#### Justify content
+```hbs title=justify-content-start
+{{#> grid grid--modifier="pf-m-justify-content-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-content-center
+{{#> grid grid--modifier="pf-m-justify-content-center pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-content-end
+{{#> grid grid--modifier="pf-m-justify-content-end pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-content-stretch
+{{#> grid grid--modifier="pf-m-justify-content-stretch pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-content-space-around
+{{#> grid grid--modifier="pf-m-justify-content-space-around pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-content-space-between
+{{#> grid grid--modifier="pf-m-justify-content-space-between pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-content-space-evenly
+{{#> grid grid--modifier="pf-m-justify-content-space-evenly pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-1-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+#### Align content
+```hbs title=align-content-start
+{{#> grid grid--modifier="pf-m-align-content-start pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+``` 
+```hbs title=align-content-center
+{{#> grid grid--modifier="pf-m-align-content-center pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-content-end
+{{#> grid grid--modifier="pf-m-align-content-end pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-content-stretch
+{{#> grid grid--modifier="pf-m-align-content-stretch pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-content-space-around
+{{#> grid grid--modifier="pf-m-align-content-space-around pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-content-space-between
+{{#> grid grid--modifier="pf-m-align-content-space-between pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-content-space-evenly
+{{#> grid grid--modifier="pf-m-align-content-space-evenly pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 2
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 3
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 4
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 5
+  {{/grid-item}}
+  {{#> grid-item grid-item--modifier="pf-m-4-col"}}
+    item 6
+  {{/grid-item}}
+{{/grid}}
+```
+#### Justify self
+```hbs title=justify-self-start
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-justify-self-start"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-self-center
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-justify-self-center"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-self-end
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-justify-self-end"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=justify-self-stretch
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-justify-self-stretch"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+#### Align self
+```hbs title=align-self-start
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-align-self-start pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-self-center
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-align-self-center pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-self-end
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-align-self-end pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
+```hbs title=align-self-stretch
+{{#> grid grid--modifier="pf-m-gutter"}}
+  {{#> grid-item grid-item--modifier="pf-m-align-self-stretch pf-m-4-col"}}
+    item 1
+  {{/grid-item}}
+{{/grid}}
+```
 
 ## Documentation
 ### Overiew
@@ -290,6 +889,38 @@ The grid layout is based on CSS Grid’s two-dimensional system of columns and r
 | `.pf-l-grid` | `<div>` | Initializes the grid layout. |
 | `.pf-l-grid__item` | `<div>` | Explicitly sets a child of the grid. This class isn't necessary, but it is included to keep inline with BEM convention, and to provide an entity that will later be used for applying modifiers. |
 | `.pf-m-gutter` | `.pf-l-grid` | Adds space between children by using the globally defined gutter value. |
+| `.pf-m-gutter-rows` | `.pf-l-grid` | Adds space between children rows by using the globally defined gutter value. |
+| `.pf-m-gutter-columns` | `.pf-l-grid` | Adds space between children columns by using the globally defined gutter value. |
 | `.pf-m-all-{1-12}-col{-on-[breakpoint]}` | `.pf-l-grid` | Defines grid item size on grid container. |
 | `.pf-m-{1-12}-col{-on-[breakpoint]}` | `.pf-l-grid__item` | Defines grid item size.  Although not required, they are strongly suggested. If not used, grid item will default to 12 col. |
 | `.pf-m-{2-x}-row{-on-[breakpoint]}` | `.pf-l-grid__item` | Defines grid item row span.  For row spans to function correctly, the value of of the current row plus the grid items to span must be equal to or less than 12. Example: .pf-m-8-col.pf-m-2-row + .pf-m-4-col + .pf-m-4-col. There is no limit to number of spanned rows. |
+| `.pf-m-justify-items-start` | `.pf-l-grid` | Modifies justify-items property to start. |
+| `.pf-m-justify-items-center` | `.pf-l-grid` | Modifies justify-items property to center. |
+| `.pf-m-justify-items-end` | `.pf-l-grid` | Modifies justify-items property to end. |
+| `.pf-m-justify-items-stretch` | `.pf-l-grid` | Modifies justify-items property to stretch. |
+| `.pf-m-align-items-start` | `.pf-l-grid` | Modifies align-items property to start. |
+| `.pf-m-align-items-center` | `.pf-l-grid` | Modifies align-items property to center. |
+| `.pf-m-align-items-end` | `.pf-l-grid` | Modifies align-items property to end. |
+| `.pf-m-align-items-stretch` | `.pf-l-grid` | Modifies align-items property to stretch. |
+| `.pf-m-justify-content-start` | `.pf-l-grid` | Modifies justify-content property to start. |
+| `.pf-m-justify-content-center` | `.pf-l-grid` | Modifies justify-content property to center. |
+| `.pf-m-justify-content-end` | `.pf-l-grid` | Modifies justify-content property to end. |
+| `.pf-m-justify-content-stretch` | `.pf-l-grid` | Modifies justify-content property to stretch. |
+| `.pf-m-justify-content-space-around` | `.pf-l-grid` | Modifies justify-content property to space-around. |
+| `.pf-m-justify-content-space-between` | `.pf-l-grid` | Modifies justify-content property to space-between. |
+| `.pf-m-justify-content-space-evenly` | `.pf-l-grid` | Modifies justify-content property to space-evenly. |
+| `.pf-m-align-content-start` | `.pf-l-grid` | Modifies align-content property to start. |
+| `.pf-m-align-content-center` | `.pf-l-grid` | Modifies align-content property to center. |
+| `.pf-m-align-content-end` | `.pf-l-grid` | Modifies align-content property to end. |
+| `.pf-m-align-content-stretch` | `.pf-l-grid` | Modifies align-content property to stretch. |
+| `.pf-m-align-content-space-around` | `.pf-l-grid` | Modifies align-content property to space-around. |
+| `.pf-m-align-content-space-between` | `.pf-l-grid` | Modifies align-content property to space-between. |
+| `.pf-m-align-content-space-evenly` | `.pf-l-grid` | Modifies align-content property to space-evenly. |
+| `.pf-m-justify-self-start` | `.pf-l-grid__item` | Modifies justify-self property to start. |
+| `.pf-m-justify-self-center` | `.pf-l-grid__item` | Modifies justify-self property to center. |
+| `.pf-m-justify-self-end` | `.pf-l-grid__item` | Modifies justify-self property to end. |
+| `.pf-m-justify-self-stretch` | `.pf-l-grid__item` | Modifies justify-self property to stretch. |
+| `.pf-m-align-self-start` | `.pf-l-grid__item` | Modifies align-self property to start. |
+| `.pf-m-align-self-center` | `.pf-l-grid__item` | Modifies align-self property to center. |
+| `.pf-m-align-self-end` | `.pf-l-grid__item` | Modifies align-self property to end. |
+| `.pf-m-align-self-stretch` | `.pf-l-grid__item` | Modifies align-self property to stretch. |

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -333,7 +333,7 @@ import './Grid.css'
 
 #### Justify-items
 
-```hbs title=justify-items-start
+```hbs title=Justify-items-start
 {{#> grid grid--modifier="pf-m-justify-items-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -488,7 +488,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-items-stretch
+```hbs title=Align-items-stretch
 {{#> grid grid--modifier="pf-m-align-items-stretch pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -466,7 +466,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=align-items-end
+```hbs title=Align-items-end
 {{#> grid grid--modifier="pf-m-align-items-end pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -600,7 +600,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-content-space-around
+```hbs title=Justify-content-space-around
 {{#> grid grid--modifier="pf-m-justify-content-space-around pf-m-grid-auto-flow-column pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-1-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -158,7 +158,7 @@ import './Grid.css'
   {{/grid-item}}    
 {{/grid}}
 ```
-```hbs title=Row-Gutter
+```hbs title=Row-gutter
 {{#> grid grid--modifier="pf-m-gutter-rows"}}
   {{#> grid-item grid-item--modifier="pf-m-12-col"}}
       12 col

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -355,7 +355,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-items-center
+```hbs title=Justify-items-center
 {{#> grid grid--modifier="pf-m-justify-items-center pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -332,7 +332,6 @@ import './Grid.css'
 ### Aligning and justifying
 
 #### Justify-items
-
 ```hbs title=Justify-items-start
 {{#> grid grid--modifier="pf-m-justify-items-start pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}

--- a/src/patternfly/layouts/Grid/examples/Grid.md
+++ b/src/patternfly/layouts/Grid/examples/Grid.md
@@ -399,7 +399,7 @@ import './Grid.css'
   {{/grid-item}}
 {{/grid}}
 ```
-```hbs title=justify-items-stretch
+```hbs title=Justify-items-stretch
 {{#> grid grid--modifier="pf-m-justify-items-stretch pf-m-gutter"}}
   {{#> grid-item grid-item--modifier="pf-m-4-col"}}
     item 1

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -78,15 +78,15 @@
 
   @each $breakpoint, $value in $pf-global--breakpoint-map {
     @include pf-media-query($breakpoint) {
-      &.pf-m-gutter {
+      &.pf-m-gutter#{$value} {
         grid-gap: var(--pf-l-grid--m-gutter--GridGap);
       }
 
-      &.pf-m-gutter-rows {
+      &.pf-m-gutter-rows#{$value} {
         grid-row-gap: var(--pf-l-grid--m-gutter--GridGap);
       }
 
-      &.pf-m-gutter-columns {
+      &.pf-m-gutter-columns#{$value} {
         grid-column-gap: var(--pf-l-grid--m-gutter--GridGap);
       }
 

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -87,7 +87,7 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
     grid-row-gap: var(--pf-l-grid--m-gutter--GridGap);
   }
 
-  &.pf-m-gutter-column {
+  &.pf-m-gutter-columns {
     grid-column-gap: var(--pf-l-grid--m-gutter--GridGap);
   }
 

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -95,104 +95,102 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
     grid-column-gap: var(--pf-l-grid--m-gutter--GridGap);
   }
 
-  @each $breakpoint, $breakpoint-value in $pf-l-grid--breakpoint-map {
-    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
-
-    @include pf-apply-breakpoint($breakpoint, $pf-l-grid--breakpoint-map) {
+  @each $breakpoint, $value in $pf-global--breakpoint-map {
+    @include pf-media-query($breakpoint) {
       // justify-items
-      &.pf-m-justify-items-start#{$breakpoint-name} {
+      &.pf-m-justify-items-start#{$value} {
         justify-items: start;
       }
 
-      &.pf-m-justify-items-center#{$breakpoint-name} {
+      &.pf-m-justify-items-center#{$value} {
         justify-items: center;
       }
 
-      &.pf-m-justify-items-end#{$breakpoint-name} {
+      &.pf-m-justify-items-end#{$value} {
         justify-items: end;
       }
 
-      &.pf-m-justify-items-stretch#{$breakpoint-name} {
+      &.pf-m-justify-items-stretch#{$value} {
         justify-items: stretch;
       }
 
       // align-items
-      &.pf-m-align-items-start#{$breakpoint-name} {
+      &.pf-m-align-items-start#{$value} {
         align-items: start;
       }
 
-      &.pf-m-align-items-center#{$breakpoint-name} {
+      &.pf-m-align-items-center#{$value} {
         align-items: center;
       }
 
-      &.pf-m-align-items-end#{$breakpoint-name} {
+      &.pf-m-align-items-end#{$value} {
         align-items: end;
       }
 
-      &.pf-m-align-items-stretch#{$breakpoint-name} {
+      &.pf-m-align-items-stretch#{$value} {
         align-items: stretch;
       }
 
       // align-content
-      &.pf-m-align-content-start#{$breakpoint-name} {
+      &.pf-m-align-content-start#{$value} {
         align-content: start;
       }
 
-      &.pf-m-align-content-center#{$breakpoint-name} {
+      &.pf-m-align-content-center#{$value} {
         align-content: center;
       }
 
-      &.pf-m-align-content-end#{$breakpoint-name} {
+      &.pf-m-align-content-end#{$value} {
         align-content: end;
       }
 
-      &.pf-m-align-content-stretch#{$breakpoint-name} {
+      &.pf-m-align-content-stretch#{$value} {
         align-content: stretch;
       }
 
-      &.pf-m-align-content-space-around#{$breakpoint-name} {
+      &.pf-m-align-content-space-around#{$value} {
         align-content: space-around;
       }
 
-      &.pf-m-align-content-space-between#{$breakpoint-name} {
+      &.pf-m-align-content-space-between#{$value} {
         align-content: space-between;
       }
 
-      &.pf-m-align-content-space-evenly#{$breakpoint-name} {
+      &.pf-m-align-content-space-evenly#{$value} {
         align-content: space-evenly;
       }
 
       // justify-self
-      > .pf-m-justify-self-start#{$breakpoint-name} {
+      > .pf-m-justify-self-start#{$value} {
         justify-self: start;
       }
 
-      > .pf-m-justify-self-center#{$breakpoint-name} {
+      > .pf-m-justify-self-center#{$value} {
         justify-self: center;
       }
 
-      > .pf-m-justify-self-end#{$breakpoint-name} {
+      > .pf-m-justify-self-end#{$value} {
         justify-self: end;
       }
 
-      > .pf-m-justify-self-stretch#{$breakpoint-name} {
+      > .pf-m-justify-self-stretch#{$value} {
         justify-self: stretch;
       }
 
       // align-self
-      > .pf-m-align-self-start#{$breakpoint-name} {
+      > .pf-m-align-self-start#{$value} {
         align-self: start;
       }
 
-      > .pf-m-align-self-center#{$breakpoint-name} {
+      > .pf-m-align-self-center#{$value} {
         align-self: center;
       }
 
-      > .pf-m-align-self-end#{$breakpoint-name} {
+      > .pf-m-align-self-end#{$value} {
         align-self: end;
       }
 
-      > .pf-m-align-self-stretch#{$breakpoint-name} {
+      > .pf-m-align-self-stretch#{$value} {
         align-self: stretch;
       }
     }

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -1,9 +1,6 @@
 // Don't remove this magic comment. See gulpfile.js.
 // @import "../../sass-utilities/all";
 
-// Always keep list of spacers and breakpoints up-to-date
-$pf-l-grid--breakpoint-map: build-breakpoint-map();
-
 // URL.com/guidelines#layout
 // Generate smart grid layout
 // @parameter {Suffix} xs, sm, md, lg, xl, null
@@ -57,10 +54,6 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
 
-  &[class*="pf-m-justify-content"] {
-    grid-template-columns: initial;
-  }
-
   > *,
   .pf-l-grid__item {
     grid-column-start: var(--pf-l-grid__item--GridColumnStart);
@@ -83,20 +76,20 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
     }
   }
 
-  &.pf-m-gutter {
-    grid-gap: var(--pf-l-grid--m-gutter--GridGap);
-  }
-
-  &.pf-m-gutter-rows {
-    grid-row-gap: var(--pf-l-grid--m-gutter--GridGap);
-  }
-
-  &.pf-m-gutter-columns {
-    grid-column-gap: var(--pf-l-grid--m-gutter--GridGap);
-  }
-
   @each $breakpoint, $value in $pf-global--breakpoint-map {
     @include pf-media-query($breakpoint) {
+      &.pf-m-gutter {
+        grid-gap: var(--pf-l-grid--m-gutter--GridGap);
+      }
+
+      &.pf-m-gutter-rows {
+        grid-row-gap: var(--pf-l-grid--m-gutter--GridGap);
+      }
+
+      &.pf-m-gutter-columns {
+        grid-column-gap: var(--pf-l-grid--m-gutter--GridGap);
+      }
+
       // justify-items
       &.pf-m-justify-items-start#{$value} {
         justify-items: start;

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -1,6 +1,9 @@
 // Don't remove this magic comment. See gulpfile.js.
 // @import "../../sass-utilities/all";
 
+// Always keep list of spacers and breakpoints up-to-date
+$pf-l-grid--breakpoint-map: build-breakpoint-map();
+
 // URL.com/guidelines#layout
 // Generate smart grid layout
 // @parameter {Suffix} xs, sm, md, lg, xl, null
@@ -78,5 +81,145 @@
 
   &.pf-m-gutter {
     grid-gap: var(--pf-l-grid--m-gutter--GridGap);
+  }
+
+  &.pf-m-gutter-row {
+    grid-row-gap: var(--pf-l-grid--m-gutter--GridGap);
+  }
+
+  &.pf-m-gutter-column {
+    grid-column-gap: var(--pf-l-grid--m-gutter--GridGap);
+  }
+
+  @each $breakpoint, $breakpoint-value in $pf-l-grid--breakpoint-map {
+    $breakpoint-name: if($breakpoint != "base", -on-#{$breakpoint}, "");
+
+    @include pf-apply-breakpoint($breakpoint, $pf-l-grid--breakpoint-map) {
+      // justify-items
+      &.pf-m-justify-items-start#{$breakpoint-name} {
+        justify-items: start;
+      }
+
+      &.pf-m-justify-items-center#{$breakpoint-name} {
+        justify-items: center;
+      }
+
+      &.pf-m-justify-items-end#{$breakpoint-name} {
+        justify-items: end;
+      }
+
+      &.pf-m-justify-items-stretch#{$breakpoint-name} {
+        justify-items: stretch;
+      }
+
+      // align-items
+      &.pf-m-align-items-start#{$breakpoint-name} {
+        align-items: start;
+      }
+
+      &.pf-m-align-items-center#{$breakpoint-name} {
+        align-items: center;
+      }
+
+      &.pf-m-align-items-end#{$breakpoint-name} {
+        align-items: end;
+      }
+
+      &.pf-m-align-items-stretch#{$breakpoint-name} {
+        align-items: stretch;
+      }
+
+      // justify-content
+      &.pf-m-justify-content-start#{$breakpoint-name} {
+        justify-content: start;
+      }
+
+      &.pf-m-justify-content-center#{$breakpoint-name} {
+        justify-content: center;
+      }
+
+      &.pf-m-justify-content-end#{$breakpoint-name} {
+        justify-content: end;
+      }
+
+      &.pf-m-justify-content-stretch#{$breakpoint-name} {
+        justify-content: stretch;
+      }
+
+      &.pf-m-justify-content-space-around#{$breakpoint-name} {
+        justify-content: space-around;
+      }
+
+      &.pf-m-justify-content-space-between#{$breakpoint-name} {
+        justify-content: space-between;
+      }
+
+      &.pf-m-justify-content-space-evenly#{$breakpoint-name} {
+        justify-content: space-evenly;
+      }
+
+      // align-content
+      &.pf-m-align-content-start#{$breakpoint-name} {
+        align-content: start;
+      }
+
+      &.pf-m-align-content-center#{$breakpoint-name} {
+        align-content: center;
+      }
+
+      &.pf-m-align-content-end#{$breakpoint-name} {
+        align-content: end;
+      }
+
+      &.pf-m-align-content-stretch#{$breakpoint-name} {
+        align-content: stretch;
+      }
+
+      &.pf-m-align-content-space-around#{$breakpoint-name} {
+        align-content: space-around;
+      }
+
+      &.pf-m-align-content-space-between#{$breakpoint-name} {
+        align-content: space-between;
+      }
+
+      &.pf-m-align-content-space-evenly#{$breakpoint-name} {
+        align-content: space-evenly;
+      }
+
+      // justify-self
+      .pf-m-justify-self-start#{$breakpoint-name} {
+        justify-self: start;
+      }
+
+      .pf-m-justify-self-center#{$breakpoint-name} {
+        justify-self: center;
+      }
+
+      .pf-m-justify-self-end#{$breakpoint-name} {
+        justify-self: end;
+      }
+
+      .pf-m-justify-self-stretch#{$breakpoint-name} {
+        justify-self: stretch;
+      }
+
+      // align-self
+      .pf-m-align-self-start#{$breakpoint-name} {
+        align-self: start;
+      }
+
+      .pf-m-align-self-end#{$breakpoint-name} {
+        align-self: end;
+      }
+
+      .pf-m-align-self-center#{$breakpoint-name} {
+        align-self: center;
+      }
+
+      .pf-m-align-self-stretch#{$breakpoint-name} {
+        align-self: stretch;
+      }
+    }
   }
 }

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -57,6 +57,10 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
 
+  &[class*="pf-m-justify-content"] {
+    grid-template-columns: initial;
+  }
+
   > *,
   .pf-l-grid__item {
     grid-column-start: var(--pf-l-grid__item--GridColumnStart);
@@ -185,6 +189,18 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
 
       &.pf-m-align-content-space-evenly#{$breakpoint-name} {
         align-content: space-evenly;
+      }
+
+      &.pf-m-grid-auto-flow-column#{$breakpoint-name} {
+        grid-auto-flow: column;
+      }
+
+      &.pf-m-grid-auto-flow-row#{$breakpoint-name} {
+        grid-auto-flow: row;
+      }
+
+      &.pf-m-grid-auto-flow-dense#{$breakpoint-name} {
+        grid-auto-flow: dense;
       }
 
       // justify-self

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -83,7 +83,7 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
     grid-gap: var(--pf-l-grid--m-gutter--GridGap);
   }
 
-  &.pf-m-gutter-row {
+  &.pf-m-gutter-rows {
     grid-row-gap: var(--pf-l-grid--m-gutter--GridGap);
   }
 

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -133,35 +133,6 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
         align-items: stretch;
       }
 
-      // justify-content
-      &.pf-m-justify-content-start#{$breakpoint-name} {
-        justify-content: start;
-      }
-
-      &.pf-m-justify-content-center#{$breakpoint-name} {
-        justify-content: center;
-      }
-
-      &.pf-m-justify-content-end#{$breakpoint-name} {
-        justify-content: end;
-      }
-
-      &.pf-m-justify-content-stretch#{$breakpoint-name} {
-        justify-content: stretch;
-      }
-
-      &.pf-m-justify-content-space-around#{$breakpoint-name} {
-        justify-content: space-around;
-      }
-
-      &.pf-m-justify-content-space-between#{$breakpoint-name} {
-        justify-content: space-between;
-      }
-
-      &.pf-m-justify-content-space-evenly#{$breakpoint-name} {
-        justify-content: space-evenly;
-      }
-
       // align-content
       &.pf-m-align-content-start#{$breakpoint-name} {
         align-content: start;
@@ -191,49 +162,37 @@ $pf-l-grid--breakpoint-map: build-breakpoint-map();
         align-content: space-evenly;
       }
 
-      &.pf-m-grid-auto-flow-column#{$breakpoint-name} {
-        grid-auto-flow: column;
-      }
-
-      &.pf-m-grid-auto-flow-row#{$breakpoint-name} {
-        grid-auto-flow: row;
-      }
-
-      &.pf-m-grid-auto-flow-dense#{$breakpoint-name} {
-        grid-auto-flow: dense;
-      }
-
       // justify-self
-      .pf-m-justify-self-start#{$breakpoint-name} {
+      > .pf-m-justify-self-start#{$breakpoint-name} {
         justify-self: start;
       }
 
-      .pf-m-justify-self-center#{$breakpoint-name} {
+      > .pf-m-justify-self-center#{$breakpoint-name} {
         justify-self: center;
       }
 
-      .pf-m-justify-self-end#{$breakpoint-name} {
+      > .pf-m-justify-self-end#{$breakpoint-name} {
         justify-self: end;
       }
 
-      .pf-m-justify-self-stretch#{$breakpoint-name} {
+      > .pf-m-justify-self-stretch#{$breakpoint-name} {
         justify-self: stretch;
       }
 
       // align-self
-      .pf-m-align-self-start#{$breakpoint-name} {
+      > .pf-m-align-self-start#{$breakpoint-name} {
         align-self: start;
       }
 
-      .pf-m-align-self-end#{$breakpoint-name} {
-        align-self: end;
-      }
-
-      .pf-m-align-self-center#{$breakpoint-name} {
+      > .pf-m-align-self-center#{$breakpoint-name} {
         align-self: center;
       }
 
-      .pf-m-align-self-stretch#{$breakpoint-name} {
+      > .pf-m-align-self-end#{$breakpoint-name} {
+        align-self: end;
+      }
+
+      > .pf-m-align-self-stretch#{$breakpoint-name} {
         align-self: stretch;
       }
     }


### PR DESCRIPTION
closes #2336 
Updates the grid layout to include aligning, justifying grid items. Also adds modifiers for gutter for just rows and columns.

@mattnolting in order to get the justify-content options working I added this for the workspace
```
.ws-core-l-grid div[class*="pf-m-justify-content-"]:not(.pf-m-justify-content-stretch) {
  grid-template-columns: repeat(3, max-content); /*shows placement of items*/ 
}
```
We should either add documentation on this or add a modifier to remove the default 
```
grid-template-columns: repeat(12, [col-start] 1fr);
```

**UPDATE**
Dropped support for justify-content and added docs on the 12 col layout.