### PR TITLE
fix(components): always auto-import patternfly-utilities.sass

### DIFF
--- a/src/patternfly/components/AboutModalBox/about-modal-box.scss
+++ b/src/patternfly/components/AboutModalBox/about-modal-box.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-about-modal-box {
   // Component variables
   --pf-c-about-modal-box--BackgroundColor: #{$pf-color-black-1000}; // Modal uses a non-standard background color

--- a/src/patternfly/components/Accordion/accordion.scss
+++ b/src/patternfly/components/Accordion/accordion.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-accordion {
   // accordion
   --pf-c-accordion--BackgroundColor: var(--pf-global--BackgroundColor--100);

--- a/src/patternfly/components/Alert/alert.scss
+++ b/src/patternfly/components/Alert/alert.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-alert {
   // Component variables
   --pf-c-alert--BoxShadow: var(--pf-global--BoxShadow--lg);

--- a/src/patternfly/components/BackgroundImage/background-image.scss
+++ b/src/patternfly/components/BackgroundImage/background-image.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-background-image {
   --pf-c-background-image--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
   --pf-c-background-image--BackgroundImage: url("#{$pf-global--image-path}/pfbg_576.jpg");

--- a/src/patternfly/components/Breadcrumb/breadcrumb.scss
+++ b/src/patternfly/components/Breadcrumb/breadcrumb.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-breadcrumb {
   // Breadcrumb item
   --pf-c-breadcrumb__item--FontSize: var(--pf-global--FontSize--sm);

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-button {
   // Component
   --pf-c-button--PaddingTop: var(--pf-global--spacer--form-element);

--- a/src/patternfly/components/Card/card.scss
+++ b/src/patternfly/components/Card/card.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-card {
   // Component variables
   --pf-c-card--BackgroundColor: var(--pf-global--BackgroundColor--100);

--- a/src/patternfly/components/Chip/chip.scss
+++ b/src/patternfly/components/Chip/chip.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-chip {
   --pf-c-chip--PaddingLeft: var(--pf-global--spacer--sm);
   --pf-c-chip--BackgroundColor: var(--pf-global--Color--light-100);

--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-chip-group {
   @include pf-t-light; // force the container follow the light theme
 

--- a/src/patternfly/components/Content/content.scss
+++ b/src/patternfly/components/Content/content.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-content {
   // Body
   --pf-c-content--MarginBottom: var(--pf-global--spacer--md);

--- a/src/patternfly/components/ContextSelector/context-selector.scss
+++ b/src/patternfly/components/ContextSelector/context-selector.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-context-selector {
   // Context selector
   --pf-c-context-selector--Width: #{pf-size-prem(250px)};

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-data-list {
   --pf-c-data-list--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-data-list--BorderTopColor: var(--pf-global--BorderColor--100);

--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-drawer {
   --pf-c-drawer__content--MarginRight: calc(var(--pf-c-drawer__panel--Width) * -1);
   --pf-c-drawer--m-expanded--m-inline__content--MarginRight: 0;

--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-dropdown {
   // Toggle
   --pf-c-dropdown__toggle--PaddingTop: var(--pf-global--spacer--form-element);

--- a/src/patternfly/components/EmptyState/empty-state.scss
+++ b/src/patternfly/components/EmptyState/empty-state.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-empty-state {
   --pf-c-empty-state--Padding: var(--pf-global--spacer--xl);
   --pf-c-empty-state__icon--MarginBottom: var(--pf-global--spacer--lg);

--- a/src/patternfly/components/Expandable/expandable.scss
+++ b/src/patternfly/components/Expandable/expandable.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-expandable {
   // Expandable toggle
   --pf-c-expandable__toggle--PaddingTop: var(--pf-global--spacer--form-element);

--- a/src/patternfly/components/Form/form.scss
+++ b/src/patternfly/components/Form/form.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-form {
   --pf-c-form--GridGap: var(--pf-global--gutter);
 

--- a/src/patternfly/components/FormControl/form-control.scss
+++ b/src/patternfly/components/FormControl/form-control.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 // Input - error
 $pf-c-form-control--invalid--Color: $pf-global--danger-color--100 !default;
 $pf-c-form-control--invalid--Coordinates: "M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" !default;

--- a/src/patternfly/components/InputGroup/input-group.scss
+++ b/src/patternfly/components/InputGroup/input-group.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-input-group {
   // Input group
   --pf-c-input-group--BackgroundColor: var(--pf-global--BackgroundColor--100);

--- a/src/patternfly/components/Login/login.scss
+++ b/src/patternfly/components/Login/login.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-login {
   --pf-c-login--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-login--PaddingBottom: var(--pf-global--spacer--lg);

--- a/src/patternfly/components/ModalBox/modal-box.scss
+++ b/src/patternfly/components/ModalBox/modal-box.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-modal-box {
   --pf-c-modal-box--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-modal-box--BorderColor: transparent;

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-nav {
   --pf-c-nav--Width: #{pf-size-prem(290px)};
   --pf-c-nav--Transition: var(--pf-global--Transition);

--- a/src/patternfly/components/OptionsMenu/options-menu.scss
+++ b/src/patternfly/components/OptionsMenu/options-menu.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-options-menu {
   // Toggle
   --pf-c-options-menu__toggle--Background: transparent;

--- a/src/patternfly/components/OverflowMenu/overflow-menu.scss
+++ b/src/patternfly/components/OverflowMenu/overflow-menu.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-overflow-menu {
   // Base spacer - shared value
   --pf-c-overflow-menu--spacer--base: var(--pf-global--spacer--md);

--- a/src/patternfly/components/Page/page.scss
+++ b/src/patternfly/components/Page/page.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 // URL.com/guidelines#layout
 .pf-c-page {
   --pf-c-page--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);

--- a/src/patternfly/components/Pagination/pagination.scss
+++ b/src/patternfly/components/Pagination/pagination.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-pagination {
   // Base
   --pf-c-pagination--child--MarginRight: var(--pf-global--spacer--lg);

--- a/src/patternfly/components/Select/select.scss
+++ b/src/patternfly/components/Select/select.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-select {
   @include pf-t-light; // force the container follow the light theme
 

--- a/src/patternfly/components/SkipToContent/skip-to-content.scss
+++ b/src/patternfly/components/SkipToContent/skip-to-content.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-skip-to-content {
   --pf-c-skip-to-content--Top: var(--pf-global--spacer--md);
   --pf-c-skip-to-content--ZIndex: var(--pf-global--ZIndex--2xl);

--- a/src/patternfly/components/Table/table-grid.scss
+++ b/src/patternfly/components/Table/table-grid.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 @mixin pf-mobile-layout {
   .pf-m-grid.pf-c-table {

--- a/src/patternfly/components/Table/table.scss
+++ b/src/patternfly/components/Table/table.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-table {
 
   /* stylelint-disable */

--- a/src/patternfly/components/Tabs/tabs.scss
+++ b/src/patternfly/components/Tabs/tabs.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-tabs {
   // Primary tab items
   --pf-c-tabs__item--BackgroundColor: var(--pf-global--BackgroundColor--100);

--- a/src/patternfly/components/Title/title.scss
+++ b/src/patternfly/components/Title/title.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-title {
   --pf-c-title--FontFamily: var(--pf-global--FontFamily--heading--sans-serif);
 

--- a/src/patternfly/components/Toolbar/toolbar.scss
+++ b/src/patternfly/components/Toolbar/toolbar.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 // The value of component scoped variables is always defined by a global variable:
 .pf-c-toolbar {
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--md);

--- a/src/patternfly/components/Wizard/wizard.scss
+++ b/src/patternfly/components/Wizard/wizard.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-c-wizard {
   --pf-c-wizard--BoxShadow: var(--pf-global--BoxShadow--lg);
   --pf-c-wizard--Height: 100%;

--- a/src/patternfly/layouts/Flex/flex.scss
+++ b/src/patternfly/layouts/Flex/flex.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 // Always keep list of spacers and breakpoints up-to-date
 $pf-l-flex--breakpoint-map: build-breakpoint-map();
 $pf-l-flex--spacer-map: build-spacer-map();

--- a/src/patternfly/layouts/Gallery/gallery.scss
+++ b/src/patternfly/layouts/Gallery/gallery.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-l-gallery {
   --pf-l-gallery--m-gutter--GridGap: var(--pf-global--gutter);
   --pf-l-gallery--m-gutter--md--GridGap: var(--pf-global--gutter--md);

--- a/src/patternfly/layouts/Grid/grid.scss
+++ b/src/patternfly/layouts/Grid/grid.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 // URL.com/guidelines#layout
 // Generate smart grid layout
 // @parameter {Suffix} xs, sm, md, lg, xl, null

--- a/src/patternfly/layouts/Level/level.scss
+++ b/src/patternfly/layouts/Level/level.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-l-level {
   --pf-l-level--m-gutter--MarginRight: var(--pf-global--gutter);
   --pf-l-level--m-gutter--md--MarginRight: var(--pf-global--gutter--md);

--- a/src/patternfly/layouts/Split/split.scss
+++ b/src/patternfly/layouts/Split/split.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-l-split {
   --pf-l-split--m-gutter--MarginRight: var(--pf-global--gutter);
   --pf-l-split--m-gutter--md--MarginRight: var(--pf-global--gutter--md);

--- a/src/patternfly/layouts/Stack/stack.scss
+++ b/src/patternfly/layouts/Stack/stack.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 .pf-l-stack {
   --pf-l-stack--m-gutter--MarginBottom: var(--pf-global--gutter);
   --pf-l-stack--m-gutter--md--MarginBottom: var(--pf-global--gutter--md);

--- a/src/patternfly/utilities/Accessibility/accessibility.scss
+++ b/src/patternfly/utilities/Accessibility/accessibility.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 // screen-reader - visually hide, but expose to screen readers
 @each $breakpoint, $breakpoint-value in $pf-global--breakpoint-map {
   .pf-u-screen-reader#{$breakpoint-value} {

--- a/src/patternfly/utilities/Alignment/alignment.scss
+++ b/src/patternfly/utilities/Alignment/alignment.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 $pf-u-alignment-options: (
   text-align-left:    (text-align left),

--- a/src/patternfly/utilities/BoxShadow/box-shadow.scss
+++ b/src/patternfly/utilities/BoxShadow/box-shadow.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 
 $pf-u-box-shadow-options: (

--- a/src/patternfly/utilities/Display/display.scss
+++ b/src/patternfly/utilities/Display/display.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 
 // Display options

--- a/src/patternfly/utilities/Flex/flex.scss
+++ b/src/patternfly/utilities/Flex/flex.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 
 // Flex direction options

--- a/src/patternfly/utilities/Float/float.scss
+++ b/src/patternfly/utilities/Float/float.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 
 $pf-u-alignment-options: (

--- a/src/patternfly/utilities/Sizing/sizing.scss
+++ b/src/patternfly/utilities/Sizing/sizing.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 
 // Width options

--- a/src/patternfly/utilities/Spacing/spacing.scss
+++ b/src/patternfly/utilities/Spacing/spacing.scss
@@ -1,6 +1,3 @@
-// Don't remove this magic comment. See gulpfile.js.
-// @import "../../sass-utilities/all";
-
 /* stylelint-disable */
 
 // Build spacing values


### PR DESCRIPTION
We should probably find a cleaner way to do this. Maybe a custom importer that works like a `#pragma once` in C and only imports once? No one else will be able to compile component SASS files individually but us.

Also, it's not very clear to devs that each `src/patternfly/**` file is actually importing the utilities in the build while `src/patternfly/*` files are not.