### PR TITLE
fix(dropdown): fixed bottom border for split button w/ action expanded

### DIFF
--- a/src/patternfly/components/Dropdown/dropdown.scss
+++ b/src/patternfly/components/Dropdown/dropdown.scss
@@ -241,7 +241,8 @@
     }
   }
 
-  .pf-m-expanded > & {
+  .pf-m-expanded > &:not(.pf-m-action),
+  .pf-m-expanded > &.pf-m-action .pf-c-dropdown__toggle-button {
     &::before {
       --pf-c-dropdown__toggle--BorderBottomColor: var(--pf-c-dropdown__toggle--expanded--BorderBottomColor);
 

--- a/src/patternfly/components/Dropdown/examples/Dropdown.css
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.css
@@ -24,7 +24,8 @@
   min-height: 440px;
 }
 
-#ws-core-c-dropdown-split-button-checkbox {
+#ws-core-c-dropdown-split-button-checkbox,
+#ws-core-c-dropdown-split-button-action {
   min-height: 210px;
 }
 

--- a/src/patternfly/components/Dropdown/examples/Dropdown.md
+++ b/src/patternfly/components/Dropdown/examples/Dropdown.md
@@ -101,6 +101,13 @@ import './Dropdown.css'
   {{/dropdown-toggle-button}}
   {{> dropdown-toggle-button dropdown--IsToggleButton="true" aria-label="Select"}}
 {{/dropdown}}
+
+{{#> dropdown id="dropdown-split-button-action-icon-expanded" dropdown--IsExpanded="true" dropdown--IsSplitButton="true" dropdown-toggle--type="div" dropdown-toggle--modifier="pf-m-split-button pf-m-action"}}
+  {{#> dropdown-toggle-button aria-label="Settings"}}
+    <i class="fas fa-cog" aria-hidden="true"></i>
+  {{/dropdown-toggle-button}}
+  {{> dropdown-toggle-button dropdown--IsToggleButton="true" aria-label="Select"}}
+{{/dropdown}}
 ```
 
 ```hbs title=With-groups


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2448