### PR TITLE
feat(datalist): added selectable/hoverable row variations

### DIFF
--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -16,9 +16,9 @@
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--Top: calc(var(--pf-c-data-list__item-item--BorderTopWidth) * -1);
-  --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm);
+  --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-selectable--hover--ZIndex: var(--pf-global--ZIndex--xs);
-  --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm);
+  --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
   --pf-c-data-list__item-item--BorderTopColor: var(--pf-global--BorderColor--100); // at breaking change switch var to BorderBottom
   --pf-c-data-list__item-item--BorderTopWidth: var(--pf-global--BorderWidth--sm); // at breaking change switch var to BorderBottom

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -14,6 +14,12 @@
 
   // Item
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
+  --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
+  --pf-c-data-list__item--m-selected--before--Top: calc(var(--pf-c-data-list__item-item--BorderTopWidth) * -1);
+  --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-data-list__item--m-selectable--hover--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
   --pf-c-data-list__item-item--BorderTopColor: var(--pf-global--BorderColor--100); // at breaking change switch var to BorderBottom
   --pf-c-data-list__item-item--BorderTopWidth: var(--pf-global--BorderWidth--sm); // at breaking change switch var to BorderBottom
   --pf-c-data-list__item-item--sm--BorderTopWidth: #{pf-size-prem(8px)}; // at breaking change switch var to BorderBottom
@@ -25,6 +31,7 @@
   --pf-c-data-list__item--before--Transition: var(--pf-global--Transition);
   --pf-c-data-list__item--before--ZIndex: var(--pf-global--ZIndex--xl);
   --pf-c-data-list__item--before--Top: 0;
+  --pf-c-data-list__item--before--Bottom: 0;
   --pf-c-data-list__item--before--Height: initial; // remove after breaking change
   --pf-c-data-list__item-item--before--Top: calc(var(--pf-c-data-list__item-item--BorderTopWidth) * -1);
   --pf-c-data-list__item-item--before--Height: initial; // remove after breaking change
@@ -114,30 +121,15 @@
   @include pf-t-light;
 
   list-style-type: disc;
-  background-color: var(--pf-c-data-list--BackgroundColor);
   border-top: var(--pf-c-data-list--BorderTopWidth) solid var(--pf-c-data-list--BorderTopColor);
   border-bottom: var(--pf-c-data-list--BorderBottomWidth) solid var(--pf-c-data-list--BorderBottomColor);
 }
 
 // li
 .pf-c-data-list__item {
-  position: relative;
   display: flex;
   flex-direction: column;
-
-  // left border treatment base
-  // color is transparent by default
-  &::before {
-    position: absolute;
-    top: var(--pf-c-data-list__item--before--Top);
-    bottom: 0;
-    left: 0;
-    width: var(--pf-c-data-list__item--before--Width);
-    height: var(--pf-c-data-list__item--before--Height); // remove after breaking change period
-    content: "";
-    background-color: var(--pf-c-data-list__item--before--BackgroundColor);
-    transition: var(--pf-c-data-list__item--before--Transition);
-  }
+  background-color: var(--pf-c-data-list--BackgroundColor);
 
   // add border top to subsequent li's
   &:not(.pf-m-expanded) {
@@ -148,19 +140,44 @@
       --pf-c-data-list__item-item--BorderTopColor: var(--pf-c-data-list__item-item--sm--BorderTopColor);
     }
 
-    &::before {
-      --pf-c-data-list__item--before--Height: var(--pf-c-data-list__item-item--before--Height); // remove after breaking change
+    + .pf-c-data-list__item.pf-m-selected {
+      --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item--m-selected--before--Top);
     }
   }
 
-  // expanded border treatment color
-  &.pf-m-expanded {
-    &::before {
-      --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
+  &.pf-m-selectable {
+    &:hover {
+      cursor: pointer;
+    }
 
-      @media screen and (min-width: $pf-global--breakpoint--sm) {
-        --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item-item--before--Top);
-      }
+    &:hover,
+    &:focus {
+      position: relative;
+      z-index: var(--pf-c-data-list__item--m-selectable--hover--ZIndex);
+      box-shadow: var(--pf-c-data-list__item--m-selectable--hover--BoxShadow);
+    }
+  }
+
+  &.pf-m-selected {
+    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-selected--before--BackgroundColor);
+
+    position: relative;
+    box-shadow: var(--pf-c-data-list__item--m-selected--BoxShadow);
+
+    &:not(.pf-m-expanded) {
+      --pf-c-data-list__item--before--Bottom: -1px;
+    }
+  }
+
+  &.pf-m-expanded {
+    --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
+
+    @media screen and (min-width: $pf-global--breakpoint--sm) {
+      --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item-item--before--Top);
+    }
+
+    &.pf-m-selectable:not(.pf-m-selected) {
+      --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
     }
   }
 }
@@ -226,6 +243,26 @@
     .pf-c-data-list__item.pf-m-expanded & {
       transform: var(--pf-c-data-list__item--m-expanded__toggle--c-button-icon--Transform);
     }
+  }
+}
+
+.pf-c-data-list__item-row,
+.pf-c-data-list__expandable-content {
+  position: relative;
+
+  // left border treatment base
+  &::before {
+    --pf-c-data-list__item--before--Height: var(--pf-c-data-list__item-item--before--Height); // remove after breaking change
+
+    position: absolute;
+    top: var(--pf-c-data-list__item--before--Top);
+    bottom: var(--pf-c-data-list__item--before--Bottom);
+    left: 0;
+    width: var(--pf-c-data-list__item--before--Width);
+    height: var(--pf-c-data-list__item--before--Height); // remove after breaking change period
+    content: "";
+    background-color: var(--pf-c-data-list__item--before--BackgroundColor); // color is transparent by default
+    transition: var(--pf-c-data-list__item--before--Transition);
   }
 }
 

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -15,15 +15,21 @@
   // Item
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
-  --pf-c-data-list__item--m-selected--before--Top: calc(var(--pf-c-data-list__item-item--BorderTopWidth) * -1);
   --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-selectable--hover--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
   --pf-c-data-list__item-item--BorderTopColor: var(--pf-global--BorderColor--100); // at breaking change switch var to BorderBottom
   --pf-c-data-list__item-item--BorderTopWidth: var(--pf-global--BorderWidth--sm); // at breaking change switch var to BorderBottom
+  --pf-c-data-list__item--hover--item--BorderTopColor: var(--pf-c-data-list__item-item--BorderTopColor);
+  --pf-c-data-list__item--hover--item--BorderTopWidth: var(--pf-c-data-list__item-item--BorderTopWidth);
   --pf-c-data-list__item-item--sm--BorderTopWidth: #{pf-size-prem(8px)}; // at breaking change switch var to BorderBottom
   --pf-c-data-list__item-item--sm--BorderTopColor: var(--pf-global--BorderColor--300); // at breaking change switch var to BorderBottom
+
+  @media screen and (max-width: $pf-global--breakpoint--sm) {
+    --pf-c-data-list__item-item--BorderTopWidth: var(--pf-c-data-list__item-item--sm--BorderTopWidth);
+    --pf-c-data-list__item-item--BorderTopColor: var(--pf-c-data-list__item-item--sm--BorderTopColor);
+  }
 
   // List item border left
   --pf-c-data-list__item--before--BackgroundColor: transparent;
@@ -101,6 +107,7 @@
   --pf-c-data-list__expandable-content--MarginLeft: calc(var(--pf-c-data-list__expandable-content-body--PaddingLeft) * -1);
   --pf-c-data-list__expandable-content--BoxShadow: var(--pf-global--BoxShadow--md-bottom);
   --pf-c-data-list__expandable-content--md--MaxHeight: #{pf-size-prem(600px)};
+  --pf-c-data-list__expandable-content--before--Top: calc(var(--pf-c-data-list__item-item--BorderTopWidth) * -1);
   --pf-c-data-list__item--m-expanded__expandable-content--BorderTopWidth: var(--pf-global--BorderWidth--sm);
   --pf-c-data-list__expandable-content-body--PaddingTop: var(--pf-global--spacer--lg);
   --pf-c-data-list__expandable-content-body--PaddingRight: var(--pf-global--spacer--lg);
@@ -131,17 +138,20 @@
   flex-direction: column;
   background-color: var(--pf-c-data-list--BackgroundColor);
 
+  @media (min-width: $pf-global--breakpoint--sm) {
+    --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item-item--before--Top);
+  }
+
   // add border top to subsequent li's
   &:not(.pf-m-expanded) {
     border-bottom: var(--pf-c-data-list__item-item--BorderTopWidth) solid var(--pf-c-data-list__item-item--BorderTopColor);
 
-    @media screen and (max-width: $pf-global--breakpoint--sm) {
-      --pf-c-data-list__item-item--BorderTopWidth: var(--pf-c-data-list__item-item--sm--BorderTopWidth);
-      --pf-c-data-list__item-item--BorderTopColor: var(--pf-c-data-list__item-item--sm--BorderTopColor);
-    }
+    &:not(.pf-m-selected):not(:last-child).pf-m-selectable:hover {
+      --pf-c-data-list__item-item--BorderTopWidth: 0;
 
-    + .pf-c-data-list__item.pf-m-selected {
-      --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item--m-selected--before--Top);
+      + .pf-c-data-list__item {
+        border-top: var(--pf-c-data-list__item--hover--item--BorderTopWidth) solid var(--pf-c-data-list__item--hover--item--BorderTopColor);
+      }
     }
   }
 
@@ -163,18 +173,10 @@
 
     position: relative;
     box-shadow: var(--pf-c-data-list__item--m-selected--BoxShadow);
-
-    &:not(.pf-m-expanded) {
-      --pf-c-data-list__item--before--Bottom: -1px;
-    }
   }
 
   &.pf-m-expanded {
     --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--before--BackgroundColor);
-
-    @media screen and (min-width: $pf-global--breakpoint--sm) {
-      --pf-c-data-list__item--before--Top: var(--pf-c-data-list__item-item--before--Top);
-    }
 
     &.pf-m-selectable:not(.pf-m-selected) {
       --pf-c-data-list__item--before--BackgroundColor: var(--pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor);
@@ -336,15 +338,11 @@
 
 // Expandable content
 .pf-c-data-list__expandable-content {
-  border-top: 0 solid var(--pf-c-data-list__expandable-content--BorderTopColor);
   box-shadow: var(--pf-c-data-list__expandable-content--BoxShadow);
-
-  .pf-c-data-list__item.pf-m-expanded & {
-    border-top-width: var(--pf-c-data-list__item--m-expanded__expandable-content--BorderTopWidth);
-  }
 
   .pf-c-data-list__expandable-content-body {
     padding: var(--pf-c-data-list__expandable-content-body--PaddingTop) var(--pf-c-data-list__expandable-content-body--PaddingRight) var(--pf-c-data-list__expandable-content-body--PaddingBottom) var(--pf-c-data-list__expandable-content-body--PaddingLeft);
+    border-top: var(--pf-c-data-list__item--m-expanded__expandable-content--BorderTopWidth) solid var(--pf-c-data-list__expandable-content--BorderTopColor);
 
     &.pf-m-no-padding {
       padding: 0;

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -16,9 +16,9 @@
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--Top: calc(var(--pf-c-data-list__item-item--BorderTopWidth) * -1);
-  --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm);
   --pf-c-data-list__item--m-selectable--hover--ZIndex: var(--pf-global--ZIndex--xs);
-  --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--lg);
+  --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm);
   --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
   --pf-c-data-list__item-item--BorderTopColor: var(--pf-global--BorderColor--100); // at breaking change switch var to BorderBottom
   --pf-c-data-list__item-item--BorderTopWidth: var(--pf-global--BorderWidth--sm); // at breaking change switch var to BorderBottom

--- a/src/patternfly/components/DataList/data-list.scss
+++ b/src/patternfly/components/DataList/data-list.scss
@@ -16,6 +16,7 @@
   --pf-c-data-list__item--m-expanded--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--before--BackgroundColor: var(--pf-global--active-color--100);
   --pf-c-data-list__item--m-selected--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-data-list__item--m-selectable--OutlineOffset: #{pf-size-prem(-4px)};
   --pf-c-data-list__item--m-selectable--hover--ZIndex: var(--pf-global--ZIndex--xs);
   --pf-c-data-list__item--m-selectable--hover--BoxShadow: var(--pf-global--BoxShadow--sm-top), var(--pf-global--BoxShadow--sm-bottom);
   --pf-c-data-list__item--m-expanded--m-selectable--before--BackgroundColor: var(--pf-global--active-color--300);
@@ -156,6 +157,8 @@
   }
 
   &.pf-m-selectable {
+    outline-offset: var(--pf-c-data-list__item--m-selectable--OutlineOffset);
+
     &:hover {
       cursor: pointer;
     }

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -527,7 +527,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item4" tabindex="0"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item4" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -7,12 +7,12 @@ cssPrefix: pf-c-data-list
 ## Examples
 
 ```hbs title=Basic
-{{#> data-list id="data-list-basic" data-list--attribute='aria-label="Basic data list example"'}}
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-basic" data-list--attribute='aria-label="Basic data list example"'}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content</span>
+          <span id="{{data-list--id}}-item1">Primary content</span>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content
@@ -21,11 +21,11 @@ cssPrefix: pf-c-data-list
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
-          <span id="{{id}}-item2">Secondary content (pf-m-no-fill)</span>
+          <span id="{{data-list--id}}-item2">Secondary content (pf-m-no-fill)</span>
         {{/data-list-cell}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill pf-m-align-right"}}
           Secondary content (pf-m-align-right pf-m-no-fill)
@@ -55,12 +55,12 @@ cssPrefix: pf-c-data-list
 | `.pf-m-align-right` | `.pf-c-data-list__cell` | Modifies a data list cell to align-right. |
 
 ```hbs title=With-headings
-{{#> data-list id="data-list-with-headings" data-list--attribute='aria-label="With headings data list example"'}}
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-with-headings" data-list--attribute='aria-label="With headings data list example"'}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <h2 id="{{id}}-item1">Primary content</h2>
+          <h2 id="{{data-list--id}}-item1">Primary content</h2>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content
@@ -69,11 +69,11 @@ cssPrefix: pf-c-data-list
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
-          <h2 id="{{id}}-item2">Secondary content (pf-m-no-fill)</h2>
+          <h2 id="{{data-list--id}}-item2">Secondary content (pf-m-no-fill)</h2>
         {{/data-list-cell}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill pf-m-align-right"}}
           Secondary content (pf-m-align-right pf-m-no-fill)
@@ -87,15 +87,15 @@ cssPrefix: pf-c-data-list
 When a list item includes more than one block of content, it can be difficult for some screen reader users to discern where one list item ends and the next one begins. A simple way to provide better separation of list items is to define the primary content section as a heading. Headings are useful for indicating a new section of contents, but also provide an easy way for screen reader users to navigate to specific sections on the page. The heading level should be based on the context in which the DataList component is being used. For example, if the heading for the section that contains the DataList is a level 3, then `h4` elements should be used in the DataList list items.
 
 ```hbs title=Checkboxes,-actions,-and-additional-cells
-{{#> data-list id="data-list-checkboxes-actions-addl-cells" data-list--attribute='aria-label="Checkbox and action data list example"'}}
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-checkboxes-actions-addl-cells" data-list--attribute='aria-label="Checkbox and action data list example"'}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=(concat 'name="' id '-check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' data-list--id '-check-action-check1" aria-labelledby="' data-list--id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content</span> Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
+          <span id="{{data-list--id}}-item1">Primary content</span> Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content. Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
@@ -111,26 +111,26 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action1')}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=(concat 'name="' id '-check-action-check2" aria-labelledby="' id '-item2"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' data-list--id '-check-action-check2" aria-labelledby="' data-list--id '-item2"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item2">Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
+          <span id="{{data-list--id}}-item2">Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content. Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden-on-lg"}}
-        {{#> data-list-action id="{{id}}-action2"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action2')}}{{/data-list-action}}
       {{/data-list-item-action}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden pf-m-visible-on-lg"}}
         {{#> button button--modifier="pf-m-primary"}}
@@ -143,21 +143,21 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=(concat 'name="' id '-check-action-check3" aria-labelledby="' id '-item3"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' data-list--id '-check-action-check3" aria-labelledby="' data-list--id '-item3"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item3">Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
+          <span id="{{data-list--id}}-item3">Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content. Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden-on-xl"}}
-        {{#> data-list-action id="{{id}}-action3"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action3')}}{{/data-list-action}}
       {{/data-list-item-action}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden pf-m-visible-on-xl"}}
         {{#> button button--modifier="pf-m-primary"}}
@@ -194,18 +194,18 @@ When a list item includes more than one block of content, it can be difficult fo
 | `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-data-list__item-action` | Shows an actions container at a given breakpoint. |
 
 ```hbs title=Expandable
-{{#> data-list id="data-list-expandable" data-list--attribute='aria-label="Expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-expandable" data-list--attribute='aria-label="Expandable data list example"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle1 ' data-list--id '-item1" id="' data-list--id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content1"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
         {{/data-list-cell}}
         {{#> data-list-cell}}
-          <div id="{{id}}-item1">Primary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+          <div id="{{data-list--id}}-item1">Primary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
           <a href="#">link</a>
         {{/data-list-cell}}
         {{#> data-list-cell}}
@@ -216,27 +216,27 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action1')}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content1" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle2 ' data-list--id '-item2" id="' data-list--id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' data-list--id '-content2"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
         {{/data-list-cell}}
         {{#> data-list-cell}}
-          <div id="{{id}}-item2">Secondary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+          <div id="{{data-list--id}}-item2">Secondary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           <span>Lorem ipsum dolor sit amet.</span>
@@ -246,27 +246,27 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="{{id}}-action2"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action2')}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content2" aria-label="Secondary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content2" aria-label="Secondary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle3 ' data-list--id '-item3" id="' data-list--id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content3"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
         {{/data-list-cell}}
         {{#> data-list-cell}}
-          <div id="{{id}}-item3">Tertiary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+          <div id="{{data-list--id}}-item3">Tertiary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           <span>Lorem ipsum dolor sit amet.</span>
@@ -276,10 +276,10 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="{{id}}-action3"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action3')}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content3" aria-label="Tertiary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content3" aria-label="Tertiary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
@@ -312,16 +312,16 @@ When a list item includes more than one block of content, it can be difficult fo
 ```hbs title=Modifiers
 {{!-- Example 1 --}}
 <h2 class="Preview__section-title">Default fitting - example 1</h2>
-{{#> data-list id="data-list-default-fitting" data-list--attribute='aria-label="Width modifier data list example 1"'}}
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-default-fitting" data-list--attribute='aria-label="Width modifier data list example 1"'}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=(concat 'name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' data-list--id 'check-action-check1" aria-labelledby="' data-list--id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
           <div class="Preview__placeholder">
-            <b id="{{id}}-item1">default</b>
+            <b id="{{data-list--id}}-item1">default</b>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
           </div>
         {{/data-list-cell}}
@@ -338,16 +338,16 @@ When a list item includes more than one block of content, it can be difficult fo
 
 {{!-- Example 2 --}}
 <h2 class="Preview__section-title">Flex modifiers - example 2</h2>
-{{#> data-list id="data-list-flex-modifiers" data-list--attribute='aria-label="Width modifier data list example 2"'}}
-  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-flex-modifiers" data-list--attribute='aria-label="Width modifier data list example 2"'}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=(concat 'name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' data-list--id 'check-action-check1" aria-labelledby="' data-list--id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-flex-2"}}
           <div class="Preview__placeholder">
-            <b id="{{id}}-item1">.pf-m-flex-2</b>
+            <b id="{{data-list--id}}-item1">.pf-m-flex-2</b>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt.</p>
           </div>
         {{/data-list-cell}}
@@ -365,7 +365,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action1')}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
@@ -373,17 +373,17 @@ When a list item includes more than one block of content, it can be difficult fo
 
 {{!-- Example 3 --}}
 <h2 class="Preview__section-title">Flex modifiers - example 3</h2>
-{{#> data-list id="data-list-flex-modifiers-2" data-list--attribute='aria-label="Width modifier data list example 3"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+{{#> data-list data-list--id="data-list-flex-modifiers-2" data-list--attribute='aria-label="Width modifier data list example 3"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
-        {{#> data-list-check checkbox--attribute=(concat 'name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle1 ' data-list--id '-item1" id="' data-list--id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content1"')}}{{/data-list-toggle}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' data-list--id 'check-action-check1" aria-labelledby="' data-list--id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-flex-5"}}
           <div class="Preview__placeholder">
-            <b id="{{id}}-item1">.pf-m-flex-5</b>
+            <b id="{{data-list--id}}-item1">.pf-m-flex-5</b>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
           </div>
         {{/data-list-cell}}
@@ -407,10 +407,10 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
+        {{#> data-list-action id=(concat data-list--id '-action1')}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content1" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
@@ -428,32 +428,32 @@ When a list item includes more than one block of content, it can be difficult fo
 | `.pf-m-flex-{1, 2, 3, 4, 5}` | `.pf-c-data-list__cell` | Percentage based modifier for `.pf-c-data-list__cell` widths. |
 
 ```hbs title=Selectable-rows
-{{#> data-list id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1" tabindex="0"')}}
+{{#> data-list data-list--id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content</span>
+          <span id="{{data-list--id}}-item1">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2" tabindex="0"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item2" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item2">Secondary content (selected)</span>
+          <span id="{{data-list--id}}-item2">Secondary content (selected)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3" tabindex="0"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item3" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item3">Tertiary content</span>
+          <span id="{{data-list--id}}-item3">Tertiary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
@@ -472,74 +472,74 @@ When a list item includes more than one block of content, it can be difficult fo
 | `.pf-m-selected` | `.pf-c-data-list__item` | Modifies a data list item for the selected state. |
 
 ```hbs title=Selectable-expandable-rows
-{{#> data-list id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1" tabindex="0"')}}
+{{#> data-list data-list--id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item1" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle1 ' data-list--id '-item1" id="' data-list--id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content1"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content (selected, expanded)</span>
+          <span id="{{data-list--id}}-item1">Primary content (selected, expanded)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content1" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2" tabindex="0"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item2" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle2 ' data-list--id '-item2" id="' data-list--id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' data-list--id '-content2"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item2">Secondary content</span>
+          <span id="{{data-list--id}}-item2">Secondary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content2" aria-label="Secondary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content2" aria-label="Secondary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3" tabindex="0"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item3" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle3 ' data-list--id '-item3" id="' data-list--id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' data-list--id '-content3"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item3">Tertiary content (not selected, expanded)</span>
+          <span id="{{data-list--id}}-item3">Tertiary content (not selected, expanded)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content3" aria-label="Tertiary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content3" aria-label="Tertiary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item4" tabindex="0"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' data-list--id '-item4" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' data-list--id '-toggle4 ' data-list--id '-item4" id="' data-list--id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' data-list--id '-content4"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item4">Quaternary content (selected)</span>
+          <span id="{{data-list--id}}-item4">Quaternary content (selected)</span>
         {{/data-list-cell}}
 
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content4" aria-label="Quaternary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' data-list--id '-content4" aria-label="Quaternary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -6,42 +6,42 @@ cssPrefix: pf-c-data-list
 
 ## Examples
 ```hbs title=Selectable-rows
-{{#> data-list data-list--attribute='aria-label="Simple data list example"'}}
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="simple-item1"'}}
+{{#> data-list id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="simple-item1">Primary content</span>
+          <span id="{{id}}-item1">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute='aria-labelledby="simple-item2"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="simple-item2">Primary content (selected)</span>
+          <span id="{{id}}-item2">Primary content (selected)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="simple-item3"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="simple-item3">Primary content</span>
+          <span id="{{id}}-item3">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="simple-item4"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="simple-item4">Primary content</span>
+          <span id="{{id}}-item4">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
@@ -50,74 +50,72 @@ cssPrefix: pf-c-data-list
 ```
 
 ```hbs title=Selectable-expandable-rows
-{{#> data-list data-list--attribute='aria-label="Expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute='aria-labelledby="ex-item1"'}}
+{{#> data-list id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle1 ex-item1" id="ex-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-1"'}}{{/data-list-toggle}}
-      {{/data-list-item-control}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="ex-item1">Primary content</span>
+          <span id="{{id}}-item1">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-1" aria-label="Primary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="ex-item2"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle2 ex-item2" id="ex-toggle2" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-2"'}}{{/data-list-toggle}}
-      {{/data-list-item-control}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="ex-item2">Primary content</span>
+          <span id="{{id}}-item2">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Secondary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content2" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute='aria-labelledby="ex-item3"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle3 ex-item3" id="ex-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-3"'}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="ex-item3">Primary content</span>
+          <span id="{{id}}-item3">Primary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-3" aria-label="Tertiary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content3" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute='aria-labelledby="ex-item2"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle4 ex-item4" id="ex-toggle4" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-4"'}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="ex-item4">Primary content</span>
+          <span id="{{id}}-item4">Primary content</span>
         {{/data-list-cell}}
 
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-4" aria-label="Secondary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content4" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
@@ -127,12 +125,12 @@ cssPrefix: pf-c-data-list
 ```
 
 ```hbs title=Basic
-{{#> data-list data-list--attribute='aria-label="Simple data list example"'}}
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="simple-item1"'}}
+{{#> data-list id="data-list-basic" data-list--attribute='aria-label="Basic data list example"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="simple-item1">Primary content</span>
+          <span id="{{id}}-item1">Primary content</span>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content
@@ -141,11 +139,11 @@ cssPrefix: pf-c-data-list
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="simple-item2"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
-          <span id="simple-item2">Secondary content (pf-m-no-fill)</span>
+          <span id="{{id}}-item2">Secondary content (pf-m-no-fill)</span>
         {{/data-list-cell}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill pf-m-align-right"}}
           Secondary content (pf-m-align-right pf-m-no-fill)
@@ -175,47 +173,47 @@ cssPrefix: pf-c-data-list
 | `.pf-m-align-right` | `.pf-c-data-list__cell` | Modifies a data list cell to align-right. |
 
 ```hbs title=With-headings
-{{#> data-list data-list--attribute='aria-label="Simple data list example"'}}
-    {{#> data-list-item data-list-item--attribute='aria-labelledby="simple-h2-item1"'}}
-        {{#> data-list-item-row}}
-            {{#> data-list-item-content}}
-                {{#> data-list-cell}}
-                    <h2 id="simple-h2-item1">Primary content</h2>
-                {{/data-list-cell}}
-                {{#> data-list-cell}}
-                    Secondary content
-                {{/data-list-cell}}
-            {{/data-list-item-content}}
-        {{/data-list-item-row}}
-    {{/data-list-item}}
+{{#> data-list id="data-list-with-headings" data-list--attribute='aria-label="With headings data list example"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <h2 id="{{id}}-item1">Primary content</h2>
+        {{/data-list-cell}}
+        {{#> data-list-cell}}
+          Secondary content
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
 
-    {{#> data-list-item data-list-item--attribute='aria-labelledby="simple-h2-item2"'}}
-        {{#> data-list-item-row}}
-            {{#> data-list-item-content}}
-                {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
-                    <h2 id="simple-h2-item2">Secondary content (pf-m-no-fill)</h2>
-                {{/data-list-cell}}
-                {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill pf-m-align-right"}}
-                    Secondary content (pf-m-align-right pf-m-no-fill)
-                {{/data-list-cell}}
-            {{/data-list-item-content}}
-        {{/data-list-item-row}}
-    {{/data-list-item}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
+          <h2 id="{{id}}-item2">Secondary content (pf-m-no-fill)</h2>
+        {{/data-list-cell}}
+        {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill pf-m-align-right"}}
+          Secondary content (pf-m-align-right pf-m-no-fill)
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
 {{/data-list}}
 ```
 ### Usage
 When a list item includes more than one block of content, it can be difficult for some screen reader users to discern where one list item ends and the next one begins. A simple way to provide better separation of list items is to define the primary content section as a heading. Headings are useful for indicating a new section of contents, but also provide an easy way for screen reader users to navigate to specific sections on the page. The heading level should be based on the context in which the DataList component is being used. For example, if the heading for the section that contains the DataList is a level 3, then `h4` elements should be used in the DataList list items.
 
 ```hbs title=Checkboxes,-actions,-and-additional-cells
-{{#> data-list data-list--attribute='aria-label="Checkbox and action data list example"'}}
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="check-action-item1"'}}
+{{#> data-list id="data-list-checkboxes-actions-addl-cells" data-list--attribute='aria-label="Checkbox and action data list example"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute='name="check-action-check1" aria-labelledby="check-action-item1"'}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=concat('name="' id '-check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id='check-action-item1'>Primary content</span> Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
+          <span id="{{id}}-item1">Primary content</span> Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content. Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
@@ -231,26 +229,26 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="check-action-dropdown-kebab-right-action-1"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="check-action-item2"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute='name="check-action-check2" aria-labelledby="check-action-item2"'}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=concat('name="' id '-check-action-check2" aria-labelledby="' id '-item2"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id='check-action-item2'>Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
+          <span id="{{id}}-item2">Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content. Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden-on-lg"}}
-        {{#> data-list-action id="check-action-dropdown-kebab-right-action-2"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action2"}}{{/data-list-action}}
       {{/data-list-item-action}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden pf-m-visible-on-lg"}}
         {{#> button button--modifier="pf-m-primary"}}
@@ -263,21 +261,21 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="check-action-item2"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute='name="check-action-check3" aria-labelledby="check-action-item2"'}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=concat('name="' id '-check-action-check3" aria-labelledby="' id '-item3"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id='check-action-item3'>Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
+          <span id="{{id}}-item3">Primary content - lorem ipsum</span> dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
         {{#> data-list-cell}}
           Secondary content. Dolor sit amet, consectetur adipisicing elit, sed do eiusmod.
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden-on-xl"}}
-        {{#> data-list-action id="check-action-dropdown-kebab-right-action-3"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action3"}}{{/data-list-action}}
       {{/data-list-item-action}}
       {{#> data-list-item-action data-list-item-action--modifier="pf-m-hidden pf-m-visible-on-xl"}}
         {{#> button button--modifier="pf-m-primary"}}
@@ -314,18 +312,18 @@ When a list item includes more than one block of content, it can be difficult fo
 | `.pf-m-visible{-on-[breakpoint]}` | `.pf-c-data-list__item-action` | Shows an actions container at a given breakpoint. |
 
 ```hbs title=Expandable
-{{#> data-list data-list--attribute='aria-label="Expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute='aria-labelledby="ex-item1"'}}
+{{#> data-list id="data-list-expandable" data-list--attribute='aria-label="Expandable data list example"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle1 ex-item1" id="ex-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-1"'}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
         {{/data-list-cell}}
         {{#> data-list-cell}}
-          <div id="ex-item1">Primary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+          <div id="{{id}}-item1">Primary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
           <a href="#">link</a>
         {{/data-list-cell}}
         {{#> data-list-cell}}
@@ -336,27 +334,27 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="dropdown-kebab-right-action-3"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-1" aria-label="Primary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="ex-item2"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle2 ex-item2" id="ex-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="content-2"'}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
         {{/data-list-cell}}
         {{#> data-list-cell}}
-          <div id="ex-item2">Secondary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+          <div id="{{id}}-item2">Secondary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           <span>Lorem ipsum dolor sit amet.</span>
@@ -366,27 +364,27 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="dropdown-kebab-right-action-4"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action2"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Secondary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content2" aria-label="Secondary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute='aria-labelledby="ex-item3"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle3 ex-item3" id="ex-toggle3" aria-label="Toggle details for" aria-expanded="false" aria-controls="content-3"'}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
         {{/data-list-cell}}
         {{#> data-list-cell}}
-          <div id="ex-item3">Tertiary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+          <div id="{{id}}-item3">Tertiary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
         {{/data-list-cell}}
         {{#> data-list-cell}}
           <span>Lorem ipsum dolor sit amet.</span>
@@ -396,10 +394,10 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="dropdown-kebab-right-action-5"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action3"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-3" aria-label="Tertiary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content3" aria-label="Tertiary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
@@ -432,16 +430,16 @@ When a list item includes more than one block of content, it can be difficult fo
 ```hbs title=Modifiers
 {{!-- Example 1 --}}
 <h2 class="Preview__section-title">Default fitting - example 1</h2>
-{{#> data-list data-list--attribute='aria-label="Width modifier data list example 1"'}}
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="width-ex1-item1"'}}
+{{#> data-list id="data-list-default-fitting" data-list--attribute='aria-label="Width modifier data list example 1"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute='name="width-ex1-check1" aria-labelledby="width-ex1-item1"'}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=concat('name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
           <div class="Preview__placeholder">
-            <b id="width-ex1-item1">default</b>
+            <b id="{{id}}-item1">default</b>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
           </div>
         {{/data-list-cell}}
@@ -458,16 +456,16 @@ When a list item includes more than one block of content, it can be difficult fo
 
 {{!-- Example 2 --}}
 <h2 class="Preview__section-title">Flex modifiers - example 2</h2>
-{{#> data-list data-list--attribute='aria-label="Width modifier data list example 2"'}}
-  {{#> data-list-item data-list-item--attribute='aria-labelledby="width-ex2-item1"'}}
+{{#> data-list id="data-list-flex-modifiers" data-list--attribute='aria-label="Width modifier data list example 2"'}}
+  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute='name="width-ex2-check1" aria-labelledby="width-ex2-item1"'}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=concat('name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-flex-2"}}
           <div class="Preview__placeholder">
-            <b id="width-ex2-item1">.pf-m-flex-2</b>
+            <b id="{{id}}-item1">.pf-m-flex-2</b>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt.</p>
           </div>
         {{/data-list-cell}}
@@ -485,7 +483,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="dropdown-kebab-right-action-6"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
   {{/data-list-item}}
@@ -493,17 +491,17 @@ When a list item includes more than one block of content, it can be difficult fo
 
 {{!-- Example 3 --}}
 <h2 class="Preview__section-title">Flex modifiers - example 3</h2>
-{{#> data-list data-list--attribute='aria-label="Width modifier data list example 3"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute='aria-labelledby="width-ex3-item1"'}}
+{{#> data-list id="data-list-flex-modifiers-2" data-list--attribute='aria-label="Width modifier data list example 3"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute='aria-labelledby="width-ex3-toggle1 width-ex3-item1" id="width-ex3-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-4"'}}{{/data-list-toggle}}
-        {{#> data-list-check checkbox--attribute='name="width-ex3-check1" aria-labelledby="width-ex3-item1"'}}{{/data-list-check}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
+        {{#> data-list-check checkbox--attribute=concat('name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-flex-5"}}
           <div class="Preview__placeholder">
-            <b id="width-ex3-item1">.pf-m-flex-5</b>
+            <b id="{{id}}-item1">.pf-m-flex-5</b>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
           </div>
         {{/data-list-cell}}
@@ -527,10 +525,10 @@ When a list item includes more than one block of content, it can be difficult fo
         {{/data-list-cell}}
       {{/data-list-item-content}}
       {{#> data-list-item-action}}
-        {{#> data-list-action id="dropdown-kebab-right-action-7"}}{{/data-list-action}}
+        {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-4" aria-label="Primary content details"'}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -5,6 +5,127 @@ cssPrefix: pf-c-data-list
 ---
 
 ## Examples
+```hbs title=Selectable-rows
+{{#> data-list data-list--attribute='aria-label="Simple data list example"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="simple-item1"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="simple-item1">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute='aria-labelledby="simple-item2"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="simple-item2">Primary content (selected)</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="simple-item3"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="simple-item3">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="simple-item4"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="simple-item4">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+{{/data-list}}
+```
+
+```hbs title=Selectable-expandable-rows
+{{#> data-list data-list--attribute='aria-label="Expandable data list example"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute='aria-labelledby="ex-item1"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle1 ex-item1" id="ex-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-1"'}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="ex-item1">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-1" aria-label="Primary content details"'}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute='aria-labelledby="ex-item2"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle2 ex-item2" id="ex-toggle2" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-2"'}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="ex-item2">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Secondary content details"'}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute='aria-labelledby="ex-item3"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle3 ex-item3" id="ex-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-3"'}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="ex-item3">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-3" aria-label="Tertiary content details"'}}
+      {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
+        This expanded section has no padding.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute='aria-labelledby="ex-item2"'}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute='aria-labelledby="ex-toggle4 ex-item4" id="ex-toggle4" aria-label="Toggle details for" aria-expanded="true" aria-controls="content-4"'}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="ex-item4">Primary content</span>
+        {{/data-list-cell}}
+
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-4" aria-label="Secondary content details"'}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+{{/data-list}}
+```
+
 ```hbs title=Basic
 {{#> data-list data-list--attribute='aria-label="Simple data list example"'}}
   {{#> data-list-item data-list-item--attribute='aria-labelledby="simple-item1"'}}
@@ -233,7 +354,7 @@ When a list item includes more than one block of content, it can be difficult fo
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
-        {{/data-list-cell}}        
+        {{/data-list-cell}}
         {{#> data-list-cell}}
           <div id="ex-item2">Secondary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
         {{/data-list-cell}}
@@ -251,7 +372,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-2" aria-label="Secondary content details"'}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      {{/data-list-expandable-content-body}}    
+      {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
@@ -263,7 +384,7 @@ When a list item includes more than one block of content, it can be difficult fo
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
           {{#> data-list-icon data-list-icon--type="code-branch"}}{{/data-list-icon}}
-        {{/data-list-cell}}        
+        {{/data-list-cell}}
         {{#> data-list-cell}}
           <div id="ex-item3">Tertiary content</div><span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
         {{/data-list-cell}}
@@ -281,7 +402,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{#> data-list-expandable-content data-list-expandable-content--attribute='id="content-3" aria-label="Tertiary content details"'}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
-      {{/data-list-expandable-content-body}}    
+      {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 {{/data-list}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -5,124 +5,6 @@ cssPrefix: pf-c-data-list
 ---
 
 ## Examples
-```hbs title=Selectable-rows
-{{#> data-list id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item2">Primary content (selected)</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item3">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item4">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-  {{/data-list-item}}
-{{/data-list}}
-```
-
-```hbs title=Selectable-expandable-rows
-{{#> data-list id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
-      {{#> data-list-expandable-content-body}}
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      {{/data-list-expandable-content-body}}
-    {{/data-list-expandable-content}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item2">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content2" aria-label="Primary content details"')}}
-      {{#> data-list-expandable-content-body}}
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      {{/data-list-expandable-content-body}}
-    {{/data-list-expandable-content}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
-      {{/data-list-item-control}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item3">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content3" aria-label="Primary content details"')}}
-      {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
-        This expanded section has no padding.
-      {{/data-list-expandable-content-body}}
-    {{/data-list-expandable-content}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}
-      {{/data-list-item-control}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item4">Primary content</span>
-        {{/data-list-cell}}
-
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content4" aria-label="Primary content details"')}}
-      {{#> data-list-expandable-content-body}}
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      {{/data-list-expandable-content-body}}
-    {{/data-list-expandable-content}}
-  {{/data-list-item}}
-{{/data-list}}
-```
 
 ```hbs title=Basic
 {{#> data-list id="data-list-basic" data-list--attribute='aria-label="Basic data list example"'}}
@@ -545,6 +427,132 @@ When a list item includes more than one block of content, it can be difficult fo
 | -- | -- | -- |
 | `.pf-m-flex-{1, 2, 3, 4, 5}` | `.pf-c-data-list__cell` | Percentage based modifier for `.pf-c-data-list__cell` widths. |
 
+```hbs title=Selectable-rows
+{{#> data-list id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item1">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item2">Primary content (selected)</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item3">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item4">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+  {{/data-list-item}}
+{{/data-list}}
+```
+
+### Usage
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-m-selectable` | `.pf-c-data-list__item` | Modifies a data list item so that it is selectable. |
+| `.pf-m-selected` | `.pf-c-data-list__item` | Modifies a data list item for the selected state. |
+
+```hbs title=Selectable-expandable-rows
+{{#> data-list id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item1">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item2">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content2" aria-label="Primary content details"')}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item3">Primary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content3" aria-label="Primary content details"')}}
+      {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
+        This expanded section has no padding.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item4">Primary content</span>
+        {{/data-list-cell}}
+
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content4" aria-label="Primary content details"')}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+{{/data-list}}
+```
+
 ## Documentation
 ### Overiew
 The DataList component provides a flexible alternative to the Table component, wherein individual data points may or may not exist within each row. DataList relies upon PatternFly layouts to achieve desired presentation within `pf-c-data-list__cell`s. DataLists do not have headers. If headers are required, use the [table component](/documentation/core/components/table).
+

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -429,7 +429,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ```hbs title=Selectable-rows
 {{#> data-list id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -439,7 +439,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -449,7 +449,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -461,6 +461,10 @@ When a list item includes more than one block of content, it can be difficult fo
 {{/data-list}}
 ```
 
+### Accessibility
+| Attribute | Applied to | Outcome |
+| -- | -- | -- |
+| `tabindex="0"` | `.pf-c-data-list__item.pf-m-selectable` | Inserts the selectable row into the tab order of the page so that it is focusable. **Required** |
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
@@ -469,7 +473,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ```hbs title=Selectable-expandable-rows
 {{#> data-list id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
@@ -487,7 +491,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
@@ -505,7 +509,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
@@ -523,7 +527,7 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item4"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item4" tabindex="0"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
         {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}

--- a/src/patternfly/components/DataList/examples/DataList.md
+++ b/src/patternfly/components/DataList/examples/DataList.md
@@ -8,7 +8,7 @@ cssPrefix: pf-c-data-list
 
 ```hbs title=Basic
 {{#> data-list id="data-list-basic" data-list--attribute='aria-label="Basic data list example"'}}
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -21,7 +21,7 @@ cssPrefix: pf-c-data-list
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
@@ -56,7 +56,7 @@ cssPrefix: pf-c-data-list
 
 ```hbs title=With-headings
 {{#> data-list id="data-list-with-headings" data-list--attribute='aria-label="With headings data list example"'}}
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -69,7 +69,7 @@ cssPrefix: pf-c-data-list
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-no-fill"}}
@@ -88,10 +88,10 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ```hbs title=Checkboxes,-actions,-and-additional-cells
 {{#> data-list id="data-list-checkboxes-actions-addl-cells" data-list--attribute='aria-label="Checkbox and action data list example"'}}
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=concat('name="' id '-check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' id '-check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -116,10 +116,10 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=concat('name="' id '-check-action-check2" aria-labelledby="' id '-item2"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' id '-check-action-check2" aria-labelledby="' id '-item2"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -143,10 +143,10 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=concat('name="' id '-check-action-check3" aria-labelledby="' id '-item3"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' id '-check-action-check3" aria-labelledby="' id '-item3"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -195,10 +195,10 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ```hbs title=Expandable
 {{#> data-list id="data-list-expandable" data-list--attribute='aria-label="Expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
@@ -219,17 +219,17 @@ When a list item includes more than one block of content, it can be difficult fo
         {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
@@ -249,17 +249,17 @@ When a list item includes more than one block of content, it can be difficult fo
         {{#> data-list-action id="{{id}}-action2"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content2" aria-label="Secondary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content2" aria-label="Secondary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-icon"}}
@@ -279,7 +279,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{#> data-list-action id="{{id}}-action3"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content3" aria-label="Tertiary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content3" aria-label="Tertiary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
@@ -313,10 +313,10 @@ When a list item includes more than one block of content, it can be difficult fo
 {{!-- Example 1 --}}
 <h2 class="Preview__section-title">Default fitting - example 1</h2>
 {{#> data-list id="data-list-default-fitting" data-list--attribute='aria-label="Width modifier data list example 1"'}}
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=concat('name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -339,10 +339,10 @@ When a list item includes more than one block of content, it can be difficult fo
 {{!-- Example 2 --}}
 <h2 class="Preview__section-title">Flex modifiers - example 2</h2>
 {{#> data-list id="data-list-flex-modifiers" data-list--attribute='aria-label="Width modifier data list example 2"'}}
-  {{#> data-list-item data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-check checkbox--attribute=concat('name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-flex-2"}}
@@ -374,11 +374,11 @@ When a list item includes more than one block of content, it can be difficult fo
 {{!-- Example 3 --}}
 <h2 class="Preview__section-title">Flex modifiers - example 3</h2>
 {{#> data-list id="data-list-flex-modifiers-2" data-list--attribute='aria-label="Width modifier data list example 3"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
-        {{#> data-list-check checkbox--attribute=concat('name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
+        {{#> data-list-check checkbox--attribute=(concat 'name="' id 'check-action-check1" aria-labelledby="' id '-item1"')}}{{/data-list-check}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell data-list-cell--modifier="pf-m-flex-5"}}
@@ -410,7 +410,7 @@ When a list item includes more than one block of content, it can be difficult fo
         {{#> data-list-action id="{{id}}-action1"}}{{/data-list-action}}
       {{/data-list-item-action}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content1" aria-label="Primary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}
@@ -429,7 +429,7 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ```hbs title=Selectable-rows
 {{#> data-list id="data-list-selectable-rows" data-list--attribute='aria-label="Selectable rows data list example"'}}
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
@@ -439,31 +439,21 @@ When a list item includes more than one block of content, it can be difficult fo
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item2">Primary content (selected)</span>
+          <span id="{{id}}-item2">Secondary content (selected)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item3">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item4">Primary content</span>
+          <span id="{{id}}-item3">Tertiary content</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
@@ -479,71 +469,73 @@ When a list item includes more than one block of content, it can be difficult fo
 
 ```hbs title=Selectable-expandable-rows
 {{#> data-list id="data-list-selectable-expandable-rows" data-list--attribute='aria-label="Selectable, expandable data list example"'}}
-  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item1"')}}
+  {{#> data-list-item data-list-item--expanded="true" data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item1"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item1">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content1" aria-label="Primary content details"')}}
-      {{#> data-list-expandable-content-body}}
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      {{/data-list-expandable-content-body}}
-    {{/data-list-expandable-content}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=concat('aria-labelledby="' id '-item2"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
-      {{#> data-list-item-content}}
-        {{#> data-list-cell}}
-          <span id="{{id}}-item2">Primary content</span>
-        {{/data-list-cell}}
-      {{/data-list-item-content}}
-    {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content2" aria-label="Primary content details"')}}
-      {{#> data-list-expandable-content-body}}
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-      {{/data-list-expandable-content-body}}
-    {{/data-list-expandable-content}}
-  {{/data-list-item}}
-
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=concat('aria-labelledby="' id '-item3"')}}
-    {{#> data-list-item-row}}
-      {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle1 ' id '-item1" id="' id '-toggle1" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content1"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item3">Primary content</span>
+          <span id="{{id}}-item1">Primary content (selected, expanded)</span>
         {{/data-list-cell}}
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content3" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content1" aria-label="Primary content details"')}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--attribute=(concat 'aria-labelledby="' id '-item2"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle2 ' id '-item2" id="' id '-toggle2" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content2"')}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item2">Secondary content</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content2" aria-label="Secondary content details"')}}
+      {{#> data-list-expandable-content-body}}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      {{/data-list-expandable-content-body}}
+    {{/data-list-expandable-content}}
+  {{/data-list-item}}
+
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable" data-list-item--expanded="true" data-list-item--attribute=(concat 'aria-labelledby="' id '-item3"')}}
+    {{#> data-list-item-row}}
+      {{#> data-list-item-control}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle3 ' id '-item3" id="' id '-toggle3" aria-label="Toggle details for" aria-expanded="true" aria-controls="' id '-content3"')}}{{/data-list-toggle}}
+      {{/data-list-item-control}}
+      {{#> data-list-item-content}}
+        {{#> data-list-cell}}
+          <span id="{{id}}-item3">Tertiary content (not selected, expanded)</span>
+        {{/data-list-cell}}
+      {{/data-list-item-content}}
+    {{/data-list-item-row}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content3" aria-label="Tertiary content details"')}}
       {{#> data-list-expandable-content-body data-list-expandable-content-body--modifier="pf-m-no-padding"}}
         This expanded section has no padding.
       {{/data-list-expandable-content-body}}
     {{/data-list-expandable-content}}
   {{/data-list-item}}
 
-  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=concat('aria-labelledby="' id '-item4"')}}
+  {{#> data-list-item data-list-item--modifier="pf-m-selectable pf-m-selected" data-list-item--attribute=(concat 'aria-labelledby="' id '-item4"')}}
     {{#> data-list-item-row}}
       {{#> data-list-item-control}}
-        {{#> data-list-toggle button--attribute=concat('aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}
+        {{#> data-list-toggle button--attribute=(concat 'aria-labelledby="' id '-toggle4 ' id '-item4" id="' id '-toggle4" aria-label="Toggle details for" aria-expanded="false" aria-controls="' id '-content4"')}}{{/data-list-toggle}}
       {{/data-list-item-control}}
       {{#> data-list-item-content}}
         {{#> data-list-cell}}
-          <span id="{{id}}-item4">Primary content</span>
+          <span id="{{id}}-item4">Quaternary content (selected)</span>
         {{/data-list-cell}}
 
       {{/data-list-item-content}}
     {{/data-list-item-row}}
-    {{#> data-list-expandable-content data-list-expandable-content--attribute=concat('id="' id '-content4" aria-label="Primary content details"')}}
+    {{#> data-list-expandable-content data-list-expandable-content--attribute=(concat 'id="' id '-content4" aria-label="Quaternary content details"')}}
       {{#> data-list-expandable-content-body}}
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       {{/data-list-expandable-content-body}}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2370

Notes:
* We removed the ability to select multiple rows in a data-list. Selecting multiple rows should be via checkbox select, not this kind of select.
* I refactored the way we draw the left border on expanded/selected rows to be able to remove `position: relative` from list items, so that I can use `position` to create a stacking context for selected rows, then only have to assign a single `z-index` to hovered rows to get the shadow stacking order correct.
* Moved the background from the data list to the items as that's needed so the shadows on a row don't show up behind adjacent rows.
* The [first commit](https://github.com/patternfly/patternfly-next/pull/2491/commits/f6f08c3714706a23b08e52a4b1ffb4eb5bb71096) has the majority of the feature work in it if you want to review that separately. The subsequent commits were to redo the hbs for data lists to make the a11y easier, plus a few minor feature tweaks.
