### PR TITLE
fix(nav): only apply focus styles to nav simple list when hovered over it

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -492,8 +492,10 @@
       background-color: var(--pf-c-nav__simple-list-link--hover--BackgroundColor);
     }
 
-    &.pf-m-focus,
-    &:focus {
+    // fix Chrome bug where nav items retain focus after navigation
+    &.pf-m-focus:hover,
+    &:focus:hover,
+    &.pf-m-current:focus {
       --pf-c-nav__simple-list-link--FontWeight: var(--pf-c-nav__simple-list-link--focus--FontWeight);
       --pf-c-nav__simple-list-link--Color: var(--pf-c-nav__simple-list-link--focus--Color);
 


### PR DESCRIPTION
closes #2463 

@mcoker @mattnolting should I be applying this change over all the nav list items that we apply focus styles to?