### PR TITLE
feat(notification-drawer): added notification drawer component

### DIFF
--- a/experimental-features.js
+++ b/experimental-features.js
@@ -18,5 +18,9 @@ module.exports = [
   {
     name: 'OverflowMenu',
     path: 'components/OverflowMenu/'
+  },
+  {
+    name: 'NotificationDrawer',
+    path: 'components/NotificationDrawer/'
   }
 ];

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,12 +1,3 @@
-import './dist/patternfly.css';
-// Utilities
-import './dist/patternfly-addons.css';
-// Experimental components
-import './dist/components/DataToolbar/data-toolbar.css';
-import './dist/components/Divider/divider.css';
-import './dist/components/Drawer/drawer.css';
-import './dist/components/OverflowMenu/overflow-menu.css';
-import './dist/components/Spinner/spinner.css';
 // React-specific CSS
 import '@patternfly/react-styles/src/css/components/Table/inline-edit.css';
 import '@patternfly/react-styles/src/css/components/Tooltip/tippy.css';
@@ -15,5 +6,20 @@ import '@patternfly/react-styles/src/css/components/Topology/topology-controlbar
 import '@patternfly/react-styles/src/css/components/Topology/topology-side-bar.css';
 import '@patternfly/react-styles/src/css/components/Topology/topology-view.css';
 import '@patternfly/react-styles/src/css/layouts/Toolbar/toolbar.css';
+
 // Global theme CSS
 import 'gatsby-theme-patternfly-org/global.css';
+
+// Patternfly
+import './dist/patternfly.css';
+
+// Utilities
+import './dist/patternfly-addons.css';
+
+// Experimental components
+import './dist/components/DataToolbar/data-toolbar.css';
+import './dist/components/Divider/divider.css';
+import './dist/components/Drawer/drawer.css';
+import './dist/components/OverflowMenu/overflow-menu.css';
+import './dist/components/NotificationDrawer/notification-drawer.css';
+import './dist/components/Spinner/spinner.css';

--- a/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -104,6 +104,7 @@ cssPrefix: pf-c-notification-drawer
 | `aria-expanded="false"` | `.pf-c-notification-drawer__group-toggle` | Indicates that the group notification list is hidden. |
 | `aria-expanded="true"` | `.pf-c-notification-drawer__group-toggle` | Indicates that the group notification list is visible. |
 | `hidden` | `.pf-c-notification-drawer__list` | Indicates that the group notification list is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies. |
+| `tabindex="0"` | `.pf-c-notification-drawer__list-item.pf-m-clickable` | Inserts the clickable list item into the tab order of the page so that it is focusable. |
 | `aria-hidden="true"` | `.pf-c-notification-drawer__group-toggle-icon > *`, `.pf-c-notification-drawer__list-item-header-icon > *` | Hides icon for assistive technologies. |
 
 ### Usage
@@ -128,3 +129,10 @@ cssPrefix: pf-c-notification-drawer
 | `.pf-c-notification-drawer__group-title` | `<div>` | Initiates a notification group toggle title. |
 | `.pf-c-notification-drawer__group-count` | `<div>` | Initiates a notification group toggle count. |
 | `.pf-c-notification-drawer__group-icon` | `<span>` | Initiates a notification group toggle icon. |
+| `.pf-m-info` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the info state. |
+| `.pf-m-warning` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the warning state. |
+| `.pf-m-danger` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the danger state. |
+| `.pf-m-success` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the success state. |
+| `.pf-m-read` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the read state. |
+| `.pf-m-clickable` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item to indicate that it is clickable. |
+| `.pf-m-expanded` | `.pf-c-notification-drawer__group` | Modifies a notification group for the expanded state. |

--- a/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -38,62 +38,64 @@ cssPrefix: pf-c-notification-drawer
     {{/notification-drawer-header-action}}
   {{/notification-drawer-header}}
   {{#> notification-drawer-body}}
-    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group1')}}
-      <h1>
-        {{#> notification-drawer-group-toggle}}
-          {{#> notification-drawer-group-toggle-title}}
-            First notification group
-          {{/notification-drawer-group-toggle-title}}
-          {{#> notification-drawer-group-toggle-count}}
-            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
-          {{/notification-drawer-group-toggle-count}}
-          {{> notification-drawer-group-toggle-icon}}
-        {{/notification-drawer-group-toggle}}
-      </h1>
-      {{> notification-drawer-basic-list}}
-    {{/notification-drawer-group}}
-    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group2') notification-drawer-group--IsExpanded="true"}}
-      <h1>
-        {{#> notification-drawer-group-toggle}}
-          {{#> notification-drawer-group-toggle-title}}
-            Second notification group
-          {{/notification-drawer-group-toggle-title}}
-          {{#> notification-drawer-group-toggle-count}}
-            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
-          {{/notification-drawer-group-toggle-count}}
-          {{> notification-drawer-group-toggle-icon}}
-        {{/notification-drawer-group-toggle}}
-      </h1>
-      {{> notification-drawer-basic-list}}
-    {{/notification-drawer-group}}
-    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group3')}}
-      <h1>
-        {{#> notification-drawer-group-toggle}}
-          {{#> notification-drawer-group-toggle-title}}
-            Third notification group
-          {{/notification-drawer-group-toggle-title}}
-          {{#> notification-drawer-group-toggle-count}}
-            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
-          {{/notification-drawer-group-toggle-count}}
-          {{> notification-drawer-group-toggle-icon}}
-        {{/notification-drawer-group-toggle}}
-      </h1>
-      {{> notification-drawer-basic-list}}
-    {{/notification-drawer-group}}
-    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group4')}}
-      <h1>
-        {{#> notification-drawer-group-toggle}}
-          {{#> notification-drawer-group-toggle-title}}
-            Fourth notification group
-          {{/notification-drawer-group-toggle-title}}
-          {{#> notification-drawer-group-toggle-count}}
-            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
-          {{/notification-drawer-group-toggle-count}}
-          {{> notification-drawer-group-toggle-icon}}
-        {{/notification-drawer-group-toggle}}
-      </h1>
-      {{> notification-drawer-basic-list}}
-    {{/notification-drawer-group}}
+    {{#> notification-drawer-group-list}}
+      {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group1')}}
+        <h1>
+          {{#> notification-drawer-group-toggle}}
+            {{#> notification-drawer-group-toggle-title}}
+              First notification group
+            {{/notification-drawer-group-toggle-title}}
+            {{#> notification-drawer-group-toggle-count}}
+              {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+            {{/notification-drawer-group-toggle-count}}
+            {{> notification-drawer-group-toggle-icon}}
+          {{/notification-drawer-group-toggle}}
+        </h1>
+        {{> notification-drawer-basic-list}}
+      {{/notification-drawer-group}}
+      {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group2') notification-drawer-group--IsExpanded="true"}}
+        <h1>
+          {{#> notification-drawer-group-toggle}}
+            {{#> notification-drawer-group-toggle-title}}
+              Second notification group
+            {{/notification-drawer-group-toggle-title}}
+            {{#> notification-drawer-group-toggle-count}}
+              {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+            {{/notification-drawer-group-toggle-count}}
+            {{> notification-drawer-group-toggle-icon}}
+          {{/notification-drawer-group-toggle}}
+        </h1>
+        {{> notification-drawer-basic-list}}
+      {{/notification-drawer-group}}
+      {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group3')}}
+        <h1>
+          {{#> notification-drawer-group-toggle}}
+            {{#> notification-drawer-group-toggle-title}}
+              Third notification group
+            {{/notification-drawer-group-toggle-title}}
+            {{#> notification-drawer-group-toggle-count}}
+              {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+            {{/notification-drawer-group-toggle-count}}
+            {{> notification-drawer-group-toggle-icon}}
+          {{/notification-drawer-group-toggle}}
+        </h1>
+        {{> notification-drawer-basic-list}}
+      {{/notification-drawer-group}}
+      {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group4')}}
+        <h1>
+          {{#> notification-drawer-group-toggle}}
+            {{#> notification-drawer-group-toggle-title}}
+              Fourth notification group
+            {{/notification-drawer-group-toggle-title}}
+            {{#> notification-drawer-group-toggle-count}}
+              {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+            {{/notification-drawer-group-toggle-count}}
+            {{> notification-drawer-group-toggle-icon}}
+          {{/notification-drawer-group-toggle}}
+        </h1>
+        {{> notification-drawer-basic-list}}
+      {{/notification-drawer-group}}
+    {{/notification-drawer-group-list}}
   {{/notification-drawer-body}}
 {{/notification-drawer}}
 ```
@@ -110,25 +112,26 @@ cssPrefix: pf-c-notification-drawer
 ### Usage
 | Class | Applied to | Outcome |
 | -- | -- | -- |
-| `.pf-c-notification-drawer` | `<div>` | Initiates the notification drawer. |
-| `.pf-c-notification-drawer__header` | `<div>` | Initiates the notification drawer header. |
-| `.pf-c-notification-drawer__header-title` | `<h1>` | Initiates the notification drawer header title. |
+| `.pf-c-notification-drawer` | `<div>` | Initiates the notification drawer. **Required** |
+| `.pf-c-notification-drawer__header` | `<div>` | Initiates the notification drawer header. **Required** |
+| `.pf-c-notification-drawer__header-title` | `<h1>` | Initiates the notification drawer header title. **Required** |
 | `.pf-c-notification-drawer__header-status` | `<span>` | Initiates the notification drawer header status. |
 | `.pf-c-notification-drawer__header-action` | `<div>` | Initiates the notification drawer header action. |
-| `.pf-c-notification-drawer__body` | `<div>` | Initiates the notification drawer body. |
-| `.pf-c-notification-drawer__list` | `<ul>` | Initiates a notification list. |
-| `.pf-c-notification-drawer__list-item` | `<li>` | Initiates a notification list item. |
-| `.pf-c-notification-drawer__list-item-header` | `<div>` | Initiates a notification list item header. |
-| `.pf-c-notification-drawer__list-item-header-icon` | `<span>` | Initiates a notification list item header icon. |
-| `.pf-c-notification-drawer__list-item-header-title` | `<h2>` | Initiates a notification list item header title. |
+| `.pf-c-notification-drawer__body` | `<div>` | Initiates the notification drawer body. **Required** |
+| `.pf-c-notification-drawer__list` | `<ul>` | Initiates a notification list. **Required** |
+| `.pf-c-notification-drawer__list-item` | `<li>` | Initiates a notification list item. **Always use with a state modifier - one of `.pf-m-info`, `.pf-m-warning`, `.pf-m-danger`, `.pf-m-success`.** **Required** |
+| `.pf-c-notification-drawer__list-item-header` | `<div>` | Initiates a notification list item header. **Required** |
+| `.pf-c-notification-drawer__list-item-header-icon` | `<span>` | Initiates a notification list item header icon. **Required** |
+| `.pf-c-notification-drawer__list-item-header-title` | `<h2>` | Initiates a notification list item header title. **Required** |
 | `.pf-c-notification-drawer__list-item-action` | `<div>` | Initiates a notification list item action. |
-| `.pf-c-notification-drawer__list-item-description` | `<div>` | Initiates a notification list item description. |
-| `.pf-c-notification-drawer__list-item-timestamp` | `<div>` | Initiates a notification list item timestamp. |
-| `.pf-c-notification-drawer__group` | `<section>` | Initiates a notification group. |
-| `.pf-c-notification-drawer__group-toggle` | `<button>` | Initiates a notification group toggle. |
-| `.pf-c-notification-drawer__group-title` | `<div>` | Initiates a notification group toggle title. |
+| `.pf-c-notification-drawer__list-item-description` | `<div>` | Initiates a notification list item description. **Required** |
+| `.pf-c-notification-drawer__list-item-timestamp` | `<div>` | Initiates a notification list item timestamp. **Required** |
+| `.pf-c-notification-drawer__group-list` | `<div>` | Initiates a notification group list. **Required when notifications are grouped** |
+| `.pf-c-notification-drawer__group` | `<section>` | Initiates a notification group. **Required** |
+| `.pf-c-notification-drawer__group-toggle` | `<button>` | Initiates a notification group toggle. **Required** |
+| `.pf-c-notification-drawer__group-title` | `<div>` | Initiates a notification group toggle title. **Required** |
 | `.pf-c-notification-drawer__group-count` | `<div>` | Initiates a notification group toggle count. |
-| `.pf-c-notification-drawer__group-icon` | `<span>` | Initiates a notification group toggle icon. |
+| `.pf-c-notification-drawer__group-icon` | `<span>` | Initiates a notification group toggle icon. **Required** |
 | `.pf-m-info` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the info state. |
 | `.pf-m-warning` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the warning state. |
 | `.pf-m-danger` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the danger state. |

--- a/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -1,0 +1,130 @@
+---
+title: Notification drawer
+section: experimental
+cssPrefix: pf-c-notification-drawer
+---
+
+## Examples
+```hbs title=Basic
+{{#> notification-drawer notification-drawer--id="notification-drawer-basic"}}
+  {{#> notification-drawer-header}}
+    {{#> notification-drawer-header-title}}
+      Notifications
+    {{/notification-drawer-header-title}}
+    {{#> notification-drawer-header-status}}
+      3 unread
+    {{/notification-drawer-header-status}}
+    {{#> notification-drawer-header-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-header-action") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-header-action}}
+  {{/notification-drawer-header}}
+  {{#> notification-drawer-body}}
+    {{> notification-drawer-basic-list}}
+  {{/notification-drawer-body}}
+{{/notification-drawer}}
+```
+
+```hbs title=Groups
+{{#> notification-drawer notification-drawer--id="notification-drawer-groups"}}
+  {{#> notification-drawer-header}}
+    {{#> notification-drawer-header-title}}
+      Notifications
+    {{/notification-drawer-header-title}}
+    {{#> notification-drawer-header-status}}
+      3 unread
+    {{/notification-drawer-header-status}}
+    {{#> notification-drawer-header-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-header-action") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-header-action}}
+  {{/notification-drawer-header}}
+  {{#> notification-drawer-body}}
+    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group1')}}
+      <h1>
+        {{#> notification-drawer-group-toggle}}
+          {{#> notification-drawer-group-toggle-title}}
+            First notification group
+          {{/notification-drawer-group-toggle-title}}
+          {{#> notification-drawer-group-toggle-count}}
+            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+          {{/notification-drawer-group-toggle-count}}
+          {{> notification-drawer-group-toggle-icon}}
+        {{/notification-drawer-group-toggle}}
+      </h1>
+      {{> notification-drawer-basic-list}}
+    {{/notification-drawer-group}}
+    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group2') notification-drawer-group--IsExpanded="true"}}
+      <h1>
+        {{#> notification-drawer-group-toggle}}
+          {{#> notification-drawer-group-toggle-title}}
+            Second notification group
+          {{/notification-drawer-group-toggle-title}}
+          {{#> notification-drawer-group-toggle-count}}
+            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+          {{/notification-drawer-group-toggle-count}}
+          {{> notification-drawer-group-toggle-icon}}
+        {{/notification-drawer-group-toggle}}
+      </h1>
+      {{> notification-drawer-basic-list}}
+    {{/notification-drawer-group}}
+    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group3')}}
+      <h1>
+        {{#> notification-drawer-group-toggle}}
+          {{#> notification-drawer-group-toggle-title}}
+            Third notification group
+          {{/notification-drawer-group-toggle-title}}
+          {{#> notification-drawer-group-toggle-count}}
+            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+          {{/notification-drawer-group-toggle-count}}
+          {{> notification-drawer-group-toggle-icon}}
+        {{/notification-drawer-group-toggle}}
+      </h1>
+      {{> notification-drawer-basic-list}}
+    {{/notification-drawer-group}}
+    {{#> notification-drawer-group notification-drawer--id=(concat notification-drawer--id '-group4')}}
+      <h1>
+        {{#> notification-drawer-group-toggle}}
+          {{#> notification-drawer-group-toggle-title}}
+            Fourth notification group
+          {{/notification-drawer-group-toggle-title}}
+          {{#> notification-drawer-group-toggle-count}}
+            {{#> badge badge--modifier="pf-m-unread"}}2{{/badge}}
+          {{/notification-drawer-group-toggle-count}}
+          {{> notification-drawer-group-toggle-icon}}
+        {{/notification-drawer-group-toggle}}
+      </h1>
+      {{> notification-drawer-basic-list}}
+    {{/notification-drawer-group}}
+  {{/notification-drawer-body}}
+{{/notification-drawer}}
+```
+
+### Accessibility
+| Attribute | Applied to | Outcome |
+| -- | -- | -- |
+| `aria-expanded="false"` | `.pf-c-notification-drawer__group-toggle` | Indicates that the group notification list is hidden. |
+| `aria-expanded="true"` | `.pf-c-notification-drawer__group-toggle` | Indicates that the group notification list is visible. |
+| `hidden` | `.pf-c-notification-drawer__list` | Indicates that the group notification list is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies. |
+| `aria-hidden="true"` | `.pf-c-notification-drawer__group-toggle-icon > *`, `.pf-c-notification-drawer__list-item-header-icon > *` | Hides icon for assistive technologies. |
+
+### Usage
+| Class | Applied to | Outcome |
+| -- | -- | -- |
+| `.pf-c-notification-drawer` | `<div>` | Initiates the notification drawer. |
+| `.pf-c-notification-drawer__header` | `<div>` | Initiates the notification drawer header. |
+| `.pf-c-notification-drawer__header-title` | `<h1>` | Initiates the notification drawer header title. |
+| `.pf-c-notification-drawer__header-status` | `<span>` | Initiates the notification drawer header status. |
+| `.pf-c-notification-drawer__header-action` | `<div>` | Initiates the notification drawer header action. |
+| `.pf-c-notification-drawer__body` | `<div>` | Initiates the notification drawer body. |
+| `.pf-c-notification-drawer__list` | `<ul>` | Initiates a notification list. |
+| `.pf-c-notification-drawer__list-item` | `<li>` | Initiates a notification list item. |
+| `.pf-c-notification-drawer__list-item-header` | `<div>` | Initiates a notification list item header. |
+| `.pf-c-notification-drawer__list-item-header-icon` | `<span>` | Initiates a notification list item header icon. |
+| `.pf-c-notification-drawer__list-item-header-title` | `<h2>` | Initiates a notification list item header title. |
+| `.pf-c-notification-drawer__list-item-action` | `<div>` | Initiates a notification list item action. |
+| `.pf-c-notification-drawer__list-item-description` | `<div>` | Initiates a notification list item description. |
+| `.pf-c-notification-drawer__list-item-timestamp` | `<div>` | Initiates a notification list item timestamp. |
+| `.pf-c-notification-drawer__group` | `<section>` | Initiates a notification group. |
+| `.pf-c-notification-drawer__group-toggle` | `<button>` | Initiates a notification group toggle. |
+| `.pf-c-notification-drawer__group-title` | `<div>` | Initiates a notification group toggle title. |
+| `.pf-c-notification-drawer__group-count` | `<div>` | Initiates a notification group toggle count. |
+| `.pf-c-notification-drawer__group-icon` | `<span>` | Initiates a notification group toggle icon. |

--- a/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/src/patternfly/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -104,7 +104,7 @@ cssPrefix: pf-c-notification-drawer
 | `aria-expanded="false"` | `.pf-c-notification-drawer__group-toggle` | Indicates that the group notification list is hidden. |
 | `aria-expanded="true"` | `.pf-c-notification-drawer__group-toggle` | Indicates that the group notification list is visible. |
 | `hidden` | `.pf-c-notification-drawer__list` | Indicates that the group notification list is hidden so that it isn't visible in the UI and isn't accessed by assistive technologies. |
-| `tabindex="0"` | `.pf-c-notification-drawer__list-item.pf-m-clickable` | Inserts the clickable list item into the tab order of the page so that it is focusable. |
+| `tabindex="0"` | `.pf-c-notification-drawer__list-item.pf-m-hoverable` | Inserts the hoverable list item into the tab order of the page so that it is focusable. |
 | `aria-hidden="true"` | `.pf-c-notification-drawer__group-toggle-icon > *`, `.pf-c-notification-drawer__list-item-header-icon > *` | Hides icon for assistive technologies. |
 
 ### Usage
@@ -134,5 +134,5 @@ cssPrefix: pf-c-notification-drawer
 | `.pf-m-danger` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the danger state. |
 | `.pf-m-success` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the success state. |
 | `.pf-m-read` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item for the read state. |
-| `.pf-m-clickable` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item to indicate that it is clickable. |
+| `.pf-m-hoverable` | `.pf-c-notification-drawer__list-item` | Modifies a notification list item hover states to inidicate it is clickable. |
 | `.pf-m-expanded` | `.pf-c-notification-drawer__group` | Modifies a notification group for the expanded state. |

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
@@ -1,0 +1,70 @@
+{{#> notification-drawer-list}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsInfo="true"}}
+    {{#> notification-drawer-list-item-header}}
+      {{> notification-drawer-list-item-header-icon}}
+      {{#> notification-drawer-list-item-header-title}}
+        Unread info notification title
+      {{/notification-drawer-list-item-header-title}}
+    {{/notification-drawer-list-item-header}}
+    {{#> notification-drawer-list-item-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-action1") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-list-item-action}}
+    {{#> notification-drawer-list-item-description}}
+      This is an info notification description.
+    {{/notification-drawer-list-item-description}}
+    {{#> notification-drawer-list-item-timestamp}}
+      5 minutes ago
+    {{/notification-drawer-list-item-timestamp}}
+  {{/notification-drawer-list-item}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsDanger="true"}}
+    {{#> notification-drawer-list-item-header}}
+      {{> notification-drawer-list-item-header-icon}}
+      {{#> notification-drawer-list-item-header-title}}
+        Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines.
+      {{/notification-drawer-list-item-header-title}}
+    {{/notification-drawer-list-item-header}}
+    {{#> notification-drawer-list-item-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-action2") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-list-item-action}}
+    {{#> notification-drawer-list-item-description}}
+      This is a danger notification description. This is a long description to show how the title will wrap if it is long and wraps to multiple lines.
+    {{/notification-drawer-list-item-description}}
+    {{#> notification-drawer-list-item-timestamp}}
+      10 minutes ago
+    {{/notification-drawer-list-item-timestamp}}
+  {{/notification-drawer-list-item}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsWarning="true" notification-drawer-list-item--IsRead="true"}}
+    {{#> notification-drawer-list-item-header}}
+      {{> notification-drawer-list-item-header-icon}}
+      {{#> notification-drawer-list-item-header-title}}
+        Unread warning notification title
+      {{/notification-drawer-list-item-header-title}}
+    {{/notification-drawer-list-item-header}}
+    {{#> notification-drawer-list-item-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-action3") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-list-item-action}}
+    {{#> notification-drawer-list-item-description}}
+      This is a warning notification description.
+    {{/notification-drawer-list-item-description}}
+    {{#> notification-drawer-list-item-timestamp}}
+      20 minutes ago
+    {{/notification-drawer-list-item-timestamp}}
+  {{/notification-drawer-list-item}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--IsSuccess="true" notification-drawer-list-item--IsRead="true"}}
+    {{#> notification-drawer-list-item-header}}
+      {{> notification-drawer-list-item-header-icon}}
+      {{#> notification-drawer-list-item-header-title}}
+        Unread success notification title
+      {{/notification-drawer-list-item-header-title}}
+    {{/notification-drawer-list-item-header}}
+    {{#> notification-drawer-list-item-action}}
+      {{#> dropdown id=(concat notification-drawer--id "-action1") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+    {{/notification-drawer-list-item-action}}
+    {{#> notification-drawer-list-item-description}}
+      This is a success notification description.
+    {{/notification-drawer-list-item-description}}
+    {{#> notification-drawer-list-item-timestamp}}
+      30 minutes ago
+    {{/notification-drawer-list-item-timestamp}}
+  {{/notification-drawer-list-item}}
+{{/notification-drawer-list}}

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
@@ -33,11 +33,11 @@
       10 minutes ago
     {{/notification-drawer-list-item-timestamp}}
   {{/notification-drawer-list-item}}
-  {{#> notification-drawer-list-item notification-drawer-list-item--IsWarning="true" notification-drawer-list-item--IsRead="true"}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--modifier="pf-m-hoverable" notification-drawer-list-item--IsWarning="true" notification-drawer-list-item--IsRead="true"}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
       {{#> notification-drawer-list-item-header-title}}
-        Unread warning notification title
+        Read warning notification title
       {{/notification-drawer-list-item-header-title}}
     {{/notification-drawer-list-item-header}}
     {{#> notification-drawer-list-item-action}}
@@ -50,11 +50,11 @@
       20 minutes ago
     {{/notification-drawer-list-item-timestamp}}
   {{/notification-drawer-list-item}}
-  {{#> notification-drawer-list-item notification-drawer-list-item--IsSuccess="true" notification-drawer-list-item--IsRead="true"}}
+  {{#> notification-drawer-list-item notification-drawer-list-item--modifier="pf-m-hoverable" notification-drawer-list-item--IsSuccess="true" notification-drawer-list-item--IsRead="true"}}
     {{#> notification-drawer-list-item-header}}
       {{> notification-drawer-list-item-header-icon}}
       {{#> notification-drawer-list-item-header-title}}
-        Unread success notification title
+        Read success notification title
       {{/notification-drawer-list-item-header-title}}
     {{/notification-drawer-list-item-header}}
     {{#> notification-drawer-list-item-action}}

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-basic-list.hbs
@@ -58,7 +58,7 @@
       {{/notification-drawer-list-item-header-title}}
     {{/notification-drawer-list-item-header}}
     {{#> notification-drawer-list-item-action}}
-      {{#> dropdown id=(concat notification-drawer--id "-action1") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
+      {{#> dropdown id=(concat notification-drawer--id "-action4") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}{{/dropdown}}
     {{/notification-drawer-list-item-action}}
     {{#> notification-drawer-list-item-description}}
       This is a success notification description.

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-body.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-body.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__body{{#if notification-drawer-body--modifier}} {{notification-drawer-body--modifier}}{{/if}}"
+  {{#if notification-drawer-body--attribute}}
+    {{{notification-drawer-body--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-group-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-group-list.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__group-list{{#if notification-drawer-group-list--modifier}} {{notification-drawer-group-list--modifier}}{{/if}}"
+  {{#if notification-drawer-group-list--attribute}}
+    {{{notification-drawer-group-list--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle-count.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle-count.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__group-toggle-count{{#if notification-drawer-group-toggle-count--modifier}} {{notification-drawer-group-toggle-count--modifier}}{{/if}}"
+  {{#if notification-drawer-group-toggle-count--attribute}}
+    {{{notification-drawer-group-toggle-count--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle-icon.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle-icon.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-notification-drawer__group-toggle-icon{{#if notification-drawer-group-toggle-icon--modifier}} {{notification-drawer-group-toggle-icon--modifier}}{{/if}}"
+  {{#if notification-drawer-group-toggle-icon--attribute}}
+    {{{notification-drawer-group-toggle-icon--attribute}}}
+  {{/if}}>
+  <i class="fas fa-angle-right" aria-hidden="true"></i>
+</span>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle-title.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle-title.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__group-toggle-title{{#if notification-drawer-group-toggle-title--modifier}} {{notification-drawer-group-toggle-title--modifier}}{{/if}}"
+  {{#if notification-drawer-group-toggle-title--attribute}}
+    {{{notification-drawer-group-toggle-title--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-group-toggle.hbs
@@ -1,0 +1,11 @@
+<button class="pf-c-notification-drawer__group-toggle{{#if notification-drawer-group-toggle--modifier}} {{notification-drawer-group-toggle--modifier}}{{/if}}"
+  {{#if notification-drawer-group--IsExpanded}}
+    aria-expanded="true"
+  {{else}}
+    aria-expanded="false"
+  {{/if}}
+  {{#if notification-drawer-group-toggle--attribute}}
+    {{{notification-drawer-group-toggle--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</button>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-group.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-group.hbs
@@ -1,0 +1,6 @@
+<section class="pf-c-notification-drawer__group{{#if notification-drawer-group--IsExpanded}} pf-m-expanded{{/if}}{{#if notification-drawer-group--modifier}} {{notification-drawer-group--modifier}}{{/if}}"
+  {{#if notification-drawer-group--attribute}}
+    {{{notification-drawer-group--attribute}}}
+  {{/if}}>
+  {{> @partial-block notification-drawer-group--IsGroup="true"}}
+</section>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-header-action.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-header-action.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__header-action{{#if notification-drawer-header-action--modifier}} {{notification-drawer-header-action--modifier}}{{/if}}"
+  {{#if notification-drawer-header-action--attribute}}
+    {{{notification-drawer-header-action--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-header-status.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-header-status.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-notification-drawer__header-status{{#if notification-drawer-header-status--modifier}} {{notification-drawer-header-status--modifier}}{{/if}}"
+  {{#if notification-drawer-header-status--attribute}}
+    {{{notification-drawer-header-status--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-header-title.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-header-title.hbs
@@ -1,0 +1,6 @@
+<h1 class="pf-c-notification-drawer__header-title{{#if notification-drawer-header-title--modifier}} {{notification-drawer-header-title--modifier}}{{/if}}"
+  {{#if notification-drawer-header-title--attribute}}
+    {{{notification-drawer-header-title--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</h1>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-header.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-header.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__header{{#if notification-drawer-header--modifier}} {{notification-drawer-header--modifier}}{{/if}}"
+  {{#if notification-drawer-header--attribute}}
+    {{{notification-drawer-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-action.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-action.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__list-item-action{{#if notification-drawer-list-item-action--modifier}} {{notification-drawer-list-item-action--modifier}}{{/if}}"
+  {{#if notification-drawer-list-item-action--attribute}}
+    {{{notification-drawer-list-item-action--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-description.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-description.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__list-item-description{{#if notification-drawer-list-item-description--modifier}} {{notification-drawer-list-item-description--modifier}}{{/if}}"
+  {{#if notification-drawer-list-item-description--attribute}}
+    {{{notification-drawer-list-item-description--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-header-icon.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-header-icon.hbs
@@ -1,0 +1,14 @@
+<span class="pf-c-notification-drawer__list-item-header-icon{{#if notification-drawer-list-item-header-icon--modifier}} {{notification-drawer-list-item-header-icon--modifier}}{{/if}}"
+  {{#if notification-drawer-list-item-header-icon--attribute}}
+    {{{notification-drawer-list-item-header-icon--attribute}}}
+  {{/if}}>
+  {{#if notification-drawer-list-item--IsInfo}}
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  {{else if notification-drawer-list-item--IsWarning}}
+    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+  {{else if notification-drawer-list-item--IsDanger}}
+    <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+  {{else if notification-drawer-list-item--IsSuccess}}
+    <i class="fas fa-check-circle" aria-hidden="true"></i>
+  {{/if}}
+</span>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-header-title.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-header-title.hbs
@@ -1,0 +1,17 @@
+<h2 class="pf-c-notification-drawer__list-item-header-title{{#if notification-drawer-list-item-header-title--modifier}} {{notification-drawer-list-item-header-title--modifier}}{{/if}}"
+  {{#if notification-drawer-list-item-header-title--attribute}}
+    {{{notification-drawer-list-item-header-title--attribute}}}
+  {{/if}}>
+  <span class="pf-screen-reader">
+    {{#if notification-drawer-list-item--IsInfo}}
+      Info notification:
+    {{else if notification-drawer-list-item--IsWarning}}
+      Warning notification:
+    {{else if notification-drawer-list-item--IsDanger}}
+      Danger notification:
+    {{else if notification-drawer-list-item--IsSuccess}}
+      Success notification:
+    {{/if}}
+  </span>
+  {{> @partial-block}}
+</h2>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-header.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-header.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__list-item-header{{#if notification-drawer-list-item-header--modifier}} {{notification-drawer-list-item-header--modifier}}{{/if}}"
+  {{#if notification-drawer-list-item-header--attribute}}
+    {{{notification-drawer-list-item-header--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-timestamp.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item-timestamp.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer__list-item-timestamp{{#if notification-drawer-list-item-timestamp--modifier}} {{notification-drawer-list-item-timestamp--modifier}}{{/if}}"
+  {{#if notification-drawer-list-item-timestamp--attribute}}
+    {{{notification-drawer-list-item-timestamp--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item.hbs
@@ -1,0 +1,19 @@
+<li class="pf-c-notification-drawer__list-item{{#if notification-drawer-list-item--IsRead}} pf-m-read{{/if}}
+  {{#if notification-drawer-list-item--IsInfo}}
+    pf-m-info
+  {{else if notification-drawer-list-item--IsWarning}}
+    pf-m-warning
+  {{else if notification-drawer-list-item--IsDanger}}
+    pf-m-danger
+  {{else if notification-drawer-list-item--IsSuccess}}
+    pf-m-success
+  {{/if}}
+  {{#if notification-drawer-list-item--modifier}} {{notification-drawer-list-item--modifier}}{{/if}}"
+  {{#unless notification-drawer-list-item--IsRead}}
+    tabindex="0"
+  {{/unless}}
+  {{#if notification-drawer-list-item--attribute}}
+    {{{notification-drawer-list-item--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</li>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item.hbs
@@ -1,4 +1,9 @@
-<li class="pf-c-notification-drawer__list-item{{#if notification-drawer-list-item--IsRead}} pf-m-read{{/if}}
+<li class="pf-c-notification-drawer__list-item
+  {{#if notification-drawer-list-item--IsRead}}
+    pf-m-read
+  {{else}}
+    pf-m-clickable
+  {{/if}}
   {{#if notification-drawer-list-item--IsInfo}}
     pf-m-info
   {{else if notification-drawer-list-item--IsWarning}}

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list-item.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list-item.hbs
@@ -2,7 +2,7 @@
   {{#if notification-drawer-list-item--IsRead}}
     pf-m-read
   {{else}}
-    pf-m-clickable
+    pf-m-hoverable
   {{/if}}
   {{#if notification-drawer-list-item--IsInfo}}
     pf-m-info

--- a/src/patternfly/components/NotificationDrawer/notification-drawer-list.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer-list.hbs
@@ -1,0 +1,11 @@
+<ul class="pf-c-notification-drawer__list{{#if notification-drawer-list--modifier}} {{notification-drawer-list--modifier}}{{/if}}"
+  {{#if notification-drawer-group--IsGroup}}
+    {{#unless notification-drawer-group--IsExpanded}}
+      hidden
+    {{/unless}}
+  {{/if}}
+  {{#if notification-drawer-list--attribute}}
+    {{{notification-drawer-list--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</ul>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.hbs
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-notification-drawer{{#if notification-drawer--modifier}} {{notification-drawer--modifier}}{{/if}}"
+  {{#if notification-drawer--attribute}}
+    {{{notification-drawer--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -45,6 +45,8 @@
   --pf-c-notification-drawer__list-item--m-read--before--BackgroundColor: transparent;
   --pf-c-notification-drawer__list-item--list-item--m-read--before--Top: 0;
   --pf-c-notification-drawer__list-item--list-item--m-read--BoxShadow: inset var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-notification-drawer__list-item--m-hoverable--hover--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-notification-drawer__list-item--m-hoverable--hover--BoxShadow: var(--pf-global--BoxShadow--md-top), var(--pf-global--BoxShadow--md-bottom);
 
   // List item header
   --pf-c-notification-drawer__list-item-header--MarginBottom: var(--pf-global--spacer--xs);
@@ -191,8 +193,8 @@
     cursor: pointer;
 
     &:hover {
-      z-index: 100;
-      box-shadow: var(--pf-global--BoxShadow--md-top), var(--pf-global--BoxShadow--md-bottom);
+      z-index: var(--pf-c-notification-drawer__list-item--m-hoverable--hover--ZIndex);
+      box-shadow: var(--pf-c-notification-drawer__list-item--m-hoverable--hover--BoxShadow);
     }
   }
 }

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -131,7 +131,6 @@
   grid-template-columns: 1fr max-content;
   grid-template-rows: repeat(3, auto);
   padding: var(--pf-c-notification-drawer__list-item--PaddingTop) var(--pf-c-notification-drawer__list-item--PaddingRight) var(--pf-c-notification-drawer__list-item--PaddingBottom) var(--pf-c-notification-drawer__list-item--PaddingLeft);
-  cursor: pointer;
   background-color: var(--pf-c-notification-drawer__list-item--BackgroundColor);
   border-bottom: var(--pf-c-notification-drawer__list-item--BorderBottomWidth) solid var(--pf-c-notification-drawer__list-item--BorderBottomColor);
   outline-offset: var(--pf-c-notification-drawer__list-item--OutlineOffset);
@@ -185,7 +184,10 @@
     --pf-c-notification-drawer__list-item-header-title--FontWeight: var(--pf-c-notification-drawer__list-item--m-read__list-item-header-title--FontWeight);
 
     position: relative;
-    cursor: auto;
+  }
+
+  &.pf-m-clickable {
+    cursor: pointer;
   }
 }
 

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -1,0 +1,260 @@
+.pf-c-notification-drawer {
+  --pf-c-notification-drawer--BackgroundColor: var(--pf-global--BackgroundColor--200);
+
+  // Header
+  --pf-c-notification-drawer__header--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__header--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__header--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__header--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__header--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-notification-drawer__header--BoxShadow: var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-notification-drawer__header--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-notification-drawer__header-title--FontSize: var(--pf-global--FontSize--xl);
+  --pf-c-notification-drawer__header-status--MarginLeft: var(--pf-global--spacer--md);
+
+  // List item
+  --pf-c-notification-drawer__list-item--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__list-item--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__list-item--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__list-item--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__list-item--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-notification-drawer__list-item--BoxShadow: inset var(--pf-global--BoxShadow--sm-bottom);
+  --pf-c-notification-drawer__list-item--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-notification-drawer__list-item--BorderBottomColor: transparent;
+  --pf-c-notification-drawer__list-item--OutlineOffset: #{pf-size-prem(-4px)};
+  --pf-c-notification-drawer__list-item--before--Width: var(--pf-global--BorderWidth--lg);
+  --pf-c-notification-drawer__list-item--before--Top: 0;
+  --pf-c-notification-drawer__list-item--before--Bottom: calc(var(--pf-c-notification-drawer__list-item--BorderBottomWidth) * -1);
+
+  // List item modifiers
+  --pf-c-notification-drawer__list-item--m-info__list-item-header-icon--Color: var(--pf-global--info-color--100);
+  --pf-c-notification-drawer__list-item--m-info__list-item--before--BackgroundColor: var(--pf-global--info-color--100);
+  --pf-c-notification-drawer__list-item--m-warning__list-item-header-icon--Color: var(--pf-global--warning-color--100);
+  --pf-c-notification-drawer__list-item--m-warning__list-item--before--BackgroundColor: var(--pf-global--warning-color--100);
+  --pf-c-notification-drawer__list-item--m-danger__list-item-header-icon--Color: var(--pf-global--danger-color--100);
+  --pf-c-notification-drawer__list-item--m-danger__list-item--before--BackgroundColor: var(--pf-global--danger-color--100);
+  --pf-c-notification-drawer__list-item--m-success__list-item-header-icon--Color: var(--pf-global--success-color--100);
+  --pf-c-notification-drawer__list-item--m-success__list-item--before--BackgroundColor: var(--pf-global--success-color--100);
+  --pf-c-notification-drawer__list-item--m-read--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  --pf-c-notification-drawer__list-item--m-read--BorderBottomColor: var(--pf-global--BorderColor--100);
+  --pf-c-notification-drawer__list-item--m-read--before--Top: calc(var(--pf-c-notification-drawer__list-item--BorderBottomWidth) * -1);
+  --pf-c-notification-drawer__list-item--m-read--before--Bottom: 0;
+  --pf-c-notification-drawer__list-item--m-read--before--BackgroundColor: transparent;
+  --pf-c-notification-drawer__list-item--list-item--m-read--before--Top: 0;
+  --pf-c-notification-drawer__list-item--list-item--m-read--BoxShadow: inset var(--pf-global--BoxShadow--sm-bottom);
+
+  // List item header
+  --pf-c-notification-drawer__list-item-header--MarginBottom: var(--pf-global--spacer--xs);
+
+  // List item header icon
+  --pf-c-notification-drawer__list-item-header-icon--Color: inherit;
+  --pf-c-notification-drawer__list-item-header-icon--MarginRight: var(--pf-global--spacer--sm);
+
+  // List item header title
+  --pf-c-notification-drawer__list-item-header-title--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-notification-drawer__list-item--m-read__list-item-header-title--FontWeight: var(--pf-global--FontWeight--normal);
+
+  // List item description
+  --pf-c-notification-drawer__list-item-description--MarginBottom: var(--pf-global--spacer--sm);
+
+  // List item timestamp
+  --pf-c-notification-drawer__list-item-timestamp--Color: var(--pf-global--Color--200);
+  --pf-c-notification-drawer__list-item-timestamp--FontSize: var(--pf-global--FontSize--sm);
+
+  // Group
+  --pf-c-notification-drawer__group--m-expanded--group--BorderTopWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-notification-drawer__group--m-expanded--group--BorderTopColor: var(--pf-global--BorderColor--100);
+  --pf-c-notification-drawer__group--m-expanded--MinHeight: #{pf-size-prem(300px)};
+
+  // Group toggle
+  --pf-c-notification-drawer__group-toggle--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__group-toggle--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__group-toggle--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__group-toggle--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__group-toggle--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  --pf-c-notification-drawer__group-toggle--BorderColor: var(--pf-global--BorderColor--100);
+  --pf-c-notification-drawer__group-toggle--BorderBottomWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-notification-drawer__group-toggle--OutlineOffset: #{pf-size-prem(-4px)};
+
+  // Group toggle count
+  --pf-c-notification-drawer__group-toggle-count--MarginRight: var(--pf-global--spacer--md);
+
+  // Group toggle icon
+  --pf-c-notification-drawer__group-toggle-icon--MarginRight: var(--pf-global--spacer--md);
+  --pf-c-notification-drawer__group-toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-notification-drawer__group--m-expanded__group-toggle-icon--Transform: rotate(90deg);
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--pf-c-notification-drawer--BackgroundColor);
+}
+
+.pf-c-notification-drawer__header {
+  position: relative;
+  z-index: var(--pf-c-notification-drawer__header--ZIndex);
+  display: flex;
+  flex-shrink: 0;
+  align-items: baseline;
+  padding: var(--pf-c-notification-drawer__header--PaddingTop) var(--pf-c-notification-drawer__header--PaddingRight) var(--pf-c-notification-drawer__header--PaddingBottom) var(--pf-c-notification-drawer__header--PaddingLeft);
+  background-color: var(--pf-c-notification-drawer__header--BackgroundColor);
+  box-shadow: var(--pf-c-notification-drawer__header--BoxShadow);
+}
+
+.pf-c-notification-drawer__header-title {
+  font-size: var(--pf-c-notification-drawer__header-title--FontSize);
+}
+
+.pf-c-notification-drawer__header-status {
+  margin-left: var(--pf-c-notification-drawer__header-status--MarginLeft);
+}
+
+.pf-c-notification-drawer__header-action {
+  margin-left: auto;
+}
+
+.pf-c-notification-drawer__body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pf-c-notification-drawer__list {
+  overflow: auto;
+}
+
+.pf-c-notification-drawer__list-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-template-rows: repeat(3, auto);
+  padding: var(--pf-c-notification-drawer__list-item--PaddingTop) var(--pf-c-notification-drawer__list-item--PaddingRight) var(--pf-c-notification-drawer__list-item--PaddingBottom) var(--pf-c-notification-drawer__list-item--PaddingLeft);
+  cursor: pointer;
+  background-color: var(--pf-c-notification-drawer__list-item--BackgroundColor);
+  border-bottom: var(--pf-c-notification-drawer__list-item--BorderBottomWidth) solid var(--pf-c-notification-drawer__list-item--BorderBottomColor);
+  outline-offset: var(--pf-c-notification-drawer__list-item--OutlineOffset);
+  box-shadow: var(--pf-c-notification-drawer__list-item--BoxShadow);
+
+  &.pf-m-read,
+  &:first-child {
+    --pf-c-notification-drawer__list-item--BoxShadow: none;
+  }
+
+  &:not(.pf-m-read) + &.pf-m-read {
+    --pf-c-notification-drawer__list-item--BoxShadow: var(--pf-c-notification-drawer__list-item--list-item--m-read--BoxShadow);
+    --pf-c-notification-drawer__list-item--before--Top: var(--pf-c-notification-drawer__list-item--list-item--m-read--before--Top);
+  }
+
+  &::before {
+    position: absolute;
+    top: var(--pf-c-notification-drawer__list-item--before--Top);
+    bottom: var(--pf-c-notification-drawer__list-item--before--Bottom);
+    width: var(--pf-c-notification-drawer__list-item--before--Width);
+    content: "";
+    background-color: var(--pf-c-notification-drawer__list-item--before--BackgroundColor);
+  }
+
+  &.pf-m-info {
+    --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-c-notification-drawer__list-item--m-info__list-item--before--BackgroundColor);
+    --pf-c-notification-drawer__list-item-header-icon--Color: var(--pf-c-notification-drawer__list-item--m-info__list-item-header-icon--Color);
+  }
+
+  &.pf-m-warning {
+    --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-c-notification-drawer__list-item--m-warning__list-item--before--BackgroundColor);
+    --pf-c-notification-drawer__list-item-header-icon--Color: var(--pf-c-notification-drawer__list-item--m-warning__list-item-header-icon--Color);
+  }
+
+  &.pf-m-danger {
+    --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-c-notification-drawer__list-item--m-danger__list-item--before--BackgroundColor);
+    --pf-c-notification-drawer__list-item-header-icon--Color: var(--pf-c-notification-drawer__list-item--m-danger__list-item-header-icon--Color);
+  }
+
+  &.pf-m-success {
+    --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-c-notification-drawer__list-item--m-success__list-item--before--BackgroundColor);
+    --pf-c-notification-drawer__list-item-header-icon--Color: var(--pf-c-notification-drawer__list-item--m-success__list-item-header-icon--Color);
+  }
+
+  &.pf-m-read {
+    --pf-c-notification-drawer__list-item--BorderBottomColor: var(--pf-c-notification-drawer__list-item--m-read--BorderBottomColor);
+    --pf-c-notification-drawer__list-item--BackgroundColor: var(--pf-c-notification-drawer__list-item--m-read--BackgroundColor);
+    --pf-c-notification-drawer__list-item--before--Top: var(--pf-c-notification-drawer__list-item--m-read--before--Top);
+    --pf-c-notification-drawer__list-item--before--Bottom: var(--pf-c-notification-drawer__list-item--m-read--before--Bottom);
+    --pf-c-notification-drawer__list-item--before--BackgroundColor: var(--pf-c-notification-drawer__list-item--m-read--before--BackgroundColor);
+    --pf-c-notification-drawer__list-item-header-title--FontWeight: var(--pf-c-notification-drawer__list-item--m-read__list-item-header-title--FontWeight);
+
+    position: relative;
+    cursor: auto;
+  }
+}
+
+.pf-c-notification-drawer__list-item-header {
+  display: flex;
+  margin-bottom: var(--pf-c-notification-drawer__list-item-header--MarginBottom);
+}
+
+.pf-c-notification-drawer__list-item-header-icon {
+  margin-right: var(--pf-c-notification-drawer__list-item-header-icon--MarginRight);
+  color: var(--pf-c-notification-drawer__list-item-header-icon--Color);
+}
+
+.pf-c-notification-drawer__list-item-header-title {
+  font-weight: var(--pf-c-notification-drawer__list-item-header-title--FontWeight);
+}
+
+.pf-c-notification-drawer__list-item-action {
+  grid-column: 2;
+  grid-row: 1 / -1;
+}
+
+.pf-c-notification-drawer__list-item-description {
+  margin-bottom: var(--pf-c-notification-drawer__list-item-description--MarginBottom);
+}
+
+.pf-c-notification-drawer__list-item-timestamp {
+  font-size: var(--pf-c-notification-drawer__list-item-timestamp--FontSize);
+  color: var(--pf-c-notification-drawer__list-item-timestamp--Color);
+}
+
+.pf-c-notification-drawer__group {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+
+  &.pf-m-expanded {
+    flex: 1;
+    min-height: var(--pf-c-notification-drawer__group--m-expanded--MinHeight);
+
+    + .pf-c-notification-drawer__group {
+      border-top: var(--pf-c-notification-drawer__group--m-expanded--group--BorderTopWidth) solid var(--pf-c-notification-drawer__group--m-expanded--group--BorderTopColor);
+    }
+  }
+
+  .pf-c-notification-drawer__list-item:last-child {
+    --pf-c-notification-drawer__list-item--BorderBottomWidth: 0;
+  }
+}
+
+.pf-c-notification-drawer__group-toggle {
+  display: flex;
+  align-items: baseline;
+  width: 100%;
+  padding: var(--pf-c-notification-drawer__group-toggle--PaddingTop) var(--pf-c-notification-drawer__group-toggle--PaddingRight) var(--pf-c-notification-drawer__group-toggle--PaddingBottom) var(--pf-c-notification-drawer__group-toggle--PaddingLeft);
+  background-color: var(--pf-c-notification-drawer__group-toggle--BackgroundColor);
+  border: solid var(--pf-c-notification-drawer__group-toggle--BorderColor);
+  border-width: 0 0 var(--pf-c-notification-drawer__group-toggle--BorderBottomWidth) 0;
+  outline-offset: var(--pf-c-notification-drawer__group-toggle--OutlineOffset);
+}
+
+.pf-c-notification-drawer__group-toggle-count {
+  margin-right: var(--pf-c-notification-drawer__group-toggle-count--MarginRight);
+  margin-left: auto;
+}
+
+.pf-c-notification-drawer__group-toggle-icon {
+  margin-right: var(--pf-c-notification-drawer__group-toggle-icon--MarginRight);
+  color: var(--pf-c-notification-drawer__group-toggle-icon--Color);
+
+  .pf-c-notification-drawer__group.pf-m-expanded & {
+    transform: var(--pf-c-notification-drawer__group--m-expanded__group-toggle-icon--Transform);
+  }
+}

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -8,9 +8,12 @@
   --pf-c-notification-drawer__header--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-notification-drawer__header--BackgroundColor: var(--pf-global--BackgroundColor--100);
   --pf-c-notification-drawer__header--BoxShadow: var(--pf-global--BoxShadow--sm-bottom);
-  --pf-c-notification-drawer__header--ZIndex: var(--pf-global--ZIndex--xs);
+  --pf-c-notification-drawer__header--ZIndex: var(--pf-global--ZIndex--sm);
   --pf-c-notification-drawer__header-title--FontSize: var(--pf-global--FontSize--xl);
   --pf-c-notification-drawer__header-status--MarginLeft: var(--pf-global--spacer--md);
+
+  // Body
+  --pf-c-notification-drawer__body--ZIndex: var(--pf-global--ZIndex--xs);
 
   // List item
   --pf-c-notification-drawer__list-item--PaddingTop: var(--pf-global--spacer--md);
@@ -115,14 +118,13 @@
 }
 
 .pf-c-notification-drawer__body {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+  flex: 1 1 0;
   overflow: auto;
+  box-shadow: var(--pf-c-notification-drawer__body--ZIndex);
 }
 
 .pf-c-notification-drawer__list {
-  overflow: auto;
+  flex-grow: 1;
 }
 
 .pf-c-notification-drawer__list-item {
@@ -187,6 +189,11 @@
 
   &.pf-m-hoverable {
     cursor: pointer;
+
+    &:hover {
+      z-index: 100;
+      box-shadow: var(--pf-global--BoxShadow--md-top), var(--pf-global--BoxShadow--md-bottom);
+    }
   }
 }
 
@@ -221,6 +228,13 @@
   color: var(--pf-c-notification-drawer__list-item-timestamp--Color);
 }
 
+.pf-c-notification-drawer__group-list {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: 100%;
+}
+
 .pf-c-notification-drawer__group {
   display: flex;
   flex-shrink: 0;
@@ -233,6 +247,10 @@
     + .pf-c-notification-drawer__group {
       border-top: var(--pf-c-notification-drawer__group--m-expanded--group--BorderTopWidth) solid var(--pf-c-notification-drawer__group--m-expanded--group--BorderTopColor);
     }
+  }
+
+  .pf-c-notification-drawer__list {
+    overflow: auto;
   }
 
   .pf-c-notification-drawer__list-item:last-child {

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -82,6 +82,7 @@
   // Group toggle icon
   --pf-c-notification-drawer__group-toggle-icon--MarginRight: var(--pf-global--spacer--md);
   --pf-c-notification-drawer__group-toggle-icon--Color: var(--pf-global--Color--200);
+  --pf-c-notification-drawer__group-toggle-icon--Transition: .2s ease-in 0s;
   --pf-c-notification-drawer__group--m-expanded__group-toggle-icon--Transform: rotate(90deg);
 
   display: flex;
@@ -253,6 +254,7 @@
 .pf-c-notification-drawer__group-toggle-icon {
   margin-right: var(--pf-c-notification-drawer__group-toggle-icon--MarginRight);
   color: var(--pf-c-notification-drawer__group-toggle-icon--Color);
+  transition: var(--pf-c-notification-drawer__group-toggle-icon--Transition);
 
   .pf-c-notification-drawer__group.pf-m-expanded & {
     transform: var(--pf-c-notification-drawer__group--m-expanded__group-toggle-icon--Transform);

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -129,7 +129,6 @@
   position: relative;
   display: grid;
   grid-template-columns: 1fr max-content;
-  grid-template-rows: repeat(3, auto);
   padding: var(--pf-c-notification-drawer__list-item--PaddingTop) var(--pf-c-notification-drawer__list-item--PaddingRight) var(--pf-c-notification-drawer__list-item--PaddingBottom) var(--pf-c-notification-drawer__list-item--PaddingLeft);
   background-color: var(--pf-c-notification-drawer__list-item--BackgroundColor);
   border-bottom: var(--pf-c-notification-drawer__list-item--BorderBottomWidth) solid var(--pf-c-notification-drawer__list-item--BorderBottomColor);
@@ -193,6 +192,7 @@
 
 .pf-c-notification-drawer__list-item-header {
   display: flex;
+  grid-row: 1 / 2;
   margin-bottom: var(--pf-c-notification-drawer__list-item-header--MarginBottom);
 }
 
@@ -211,10 +211,12 @@
 }
 
 .pf-c-notification-drawer__list-item-description {
+  grid-row: 2 / 3;
   margin-bottom: var(--pf-c-notification-drawer__list-item-description--MarginBottom);
 }
 
 .pf-c-notification-drawer__list-item-timestamp {
+  grid-row: 3 / 4;
   font-size: var(--pf-c-notification-drawer__list-item-timestamp--FontSize);
   color: var(--pf-c-notification-drawer__list-item-timestamp--Color);
 }

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -118,6 +118,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: auto;
 }
 
 .pf-c-notification-drawer__list {

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -186,7 +186,7 @@
     position: relative;
   }
 
-  &.pf-m-clickable {
+  &.pf-m-hoverable {
     cursor: pointer;
   }
 }

--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -201,6 +201,7 @@
 
 .pf-c-notification-drawer__list-item-header {
   display: flex;
+  align-items: baseline;
   grid-row: 1 / 2;
   margin-bottom: var(--pf-c-notification-drawer__list-item-header--MarginBottom);
 }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/1787

Given the number of overrides that would be needed to fit the accordion to this component, I opted just to create a unique element in this component. That may change in the future.

* The notification drawer should fill the height of its container.
* Unread notifications should be clickable to mark them as read.
* Expanded groups should push all of the other groups underneath it down until 1) all of the items in the group are visible, or 2) the groups underneath hit the bottom of the container at which point the list of notifications should scroll within the group. A couple of visuals showing this:

<img width="662" alt="Screen Shot 2019-12-12 at 3 21 41 PM" src="https://user-images.githubusercontent.com/35148959/70750081-4a747c00-1cf3-11ea-9d60-3ff5800d52a1.png">
<img width="662" alt="Screen Shot 2019-12-12 at 3 21 47 PM" src="https://user-images.githubusercontent.com/35148959/70750084-4cd6d600-1cf3-11ea-9d92-6e9c0c788fd8.png">

* Expanded groups have a min-height of 300px, so if the viewport shrinks in height and there isn't enough space to display the expanded group and all of the additional groups, an outer scrollbar will appear, creating 2 scrollbars and a scroll treadmill trap. This isn't ideal, but it should be a rare occurrence as there will likely only be a few groups in a notification drawer. We will likely iterate more on this interaction. Here's a screengrab of that.

<img width="662" alt="Screen Shot 2019-12-12 at 3 22 02 PM" src="https://user-images.githubusercontent.com/35148959/70750623-5ad92680-1cf4-11ea-975f-e11d9165c947.png">

* I deviated from the `__el-nested-nested` BEM naming in a couple of places because the classnames were getting really long and it didn't seem necessary to follow that structure re: avoiding class name conflicts in the future. I'm open to changing this.
