### PR TITLE
feat(button): add ability to have icon on left or ride side of text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7438,8 +7438,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -12188,8 +12187,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12210,14 +12208,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12232,20 +12228,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12362,8 +12355,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12375,7 +12367,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12390,7 +12381,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12398,14 +12388,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12424,7 +12412,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -12505,8 +12492,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -12518,7 +12504,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -12604,8 +12589,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -12641,7 +12625,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12661,7 +12644,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12705,14 +12687,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -17098,15 +17078,13 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
           "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -17152,7 +17130,6 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -17161,8 +17138,7 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -17182,8 +17158,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -17242,7 +17217,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }

--- a/src/patternfly/components/Button/button-text.hbs
+++ b/src/patternfly/components/Button/button-text.hbs
@@ -1,0 +1,6 @@
+<span class="pf-c-button__text{{#if button-text--modifier}} {{button-text--modifier}}{{/if}}"
+  {{#if button-text--attribute}}
+    {{{button-text--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</span>

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -110,7 +110,7 @@
 
   // Styles for an icon in button
   --pf-c-button__icon--MarginRight: var(--pf-global--spacer--xs);
-  --pf-c-button__icon--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-button__text--icon--MarginLeft: var(--pf-global--spacer--xs);
 
   position: relative;
   display: inline-block;
@@ -124,12 +124,13 @@
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
 
-  .pf-c-button__text + .pf-c-button__icon {
-    margin-left: var(--pf-c-button__icon--MarginLeft);
+  .pf-c-button__icon {
+    margin-right: var(--pf-c-button__icon--MarginRight);
   }
 
-  .pf-c-button__icon:first-child:not(:only-child) {
-    margin-right: var(--pf-c-button__icon--MarginRight);
+  .pf-c-button__text + .pf-c-button__icon {
+    margin-right: 0;
+    margin-left: var(--pf-c-button__icon--MarginLeft);
   }
 
   &::after {

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -110,6 +110,7 @@
 
   // Styles for an icon in button
   --pf-c-button__icon--MarginRight: var(--pf-global--spacer--xs);
+  --pf-c-button__icon--MarginLeft: var(--pf-global--spacer--xs);
 
   position: relative;
   display: inline-block;
@@ -124,7 +125,13 @@
   border-radius: var(--pf-c-button--BorderRadius);
 
   .pf-c-button__icon {
-    margin-right: var(--pf-c-button__icon--MarginRight);
+    &:first-child {
+      margin-right: var(--pf-c-button__icon--MarginRight);
+    }
+
+    &:last-child {
+      margin-left: var(--pf-c-button__icon--MarginLeft);
+    }
   }
 
 

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -124,16 +124,13 @@
   border: 0;
   border-radius: var(--pf-c-button--BorderRadius);
 
-  .pf-c-button__icon {
-    &:first-child {
-      margin-right: var(--pf-c-button__icon--MarginRight);
-    }
-
-    &:last-child {
-      margin-left: var(--pf-c-button__icon--MarginLeft);
-    }
+  .pf-c-button__text + .pf-c-button__icon {
+    margin-left: var(--pf-c-button__icon--MarginLeft);
   }
 
+  .pf-c-button__icon:first-child:not(:only-child) {
+    margin-right: var(--pf-c-button__icon--MarginRight);
+  }
 
   &::after {
     position: absolute;

--- a/src/patternfly/components/Button/button.scss
+++ b/src/patternfly/components/Button/button.scss
@@ -130,7 +130,7 @@
 
   .pf-c-button__text + .pf-c-button__icon {
     margin-right: 0;
-    margin-left: var(--pf-c-button__icon--MarginLeft);
+    margin-left: var(--pf-c-button__text--icon--MarginLeft);
   }
 
   &::after {

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -265,7 +265,8 @@ Semantic buttons and links are important for usability as well as accessibility.
 | Class | Applied to | Outcome |
 | -- | -- | -- |
 | `.pf-c-button` | `<button>` |  Initiates a button. Always use it with a modifier class. **Required** |
-| `.pf-c-button__icon` | `<span>` |  Applies spacing to an icon inside of the button when the icon is followed by text. |
+| `.pf-c-button__icon` | `<span>` | Applies right spacing to an icon inside of the button when the icon is followed by text. |
+| `.pf-c-button__text` | `<span>` | Applies left spacing to an icon inside of a button when the icon comes after text. |
 | `.pf-m-primary` | `.pf-c-button` | Modifies for primary styles. |
 | `.pf-m-secondary` | `.pf-c-button` | Modifies for secondary styles. |
 | `.pf-m-tertiary` | `.pf-c-button` | Modifies for tertiary styles. |

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -29,7 +29,14 @@ import './Button.css'
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  Link
+  <span>Link</span>
+{{/button}}
+
+{{#> button button--modifier="pf-m-link"}}
+  <span>Link</span>
+  {{#> button-icon}}
+    <i class="fas fa-plus-circle" aria-hidden="true"></i>
+  {{/button-icon}}
 {{/button}}
 
 {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Remove"'}}

--- a/src/patternfly/components/Button/examples/Button.md
+++ b/src/patternfly/components/Button/examples/Button.md
@@ -29,11 +29,15 @@ import './Button.css'
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}
-  <span>Link</span>
+  {{#> button-text}}
+    Link
+  {{/button-text}}
 {{/button}}
 
 {{#> button button--modifier="pf-m-link"}}
-  <span>Link</span>
+  {{#> button-text}}
+    Link
+  {{/button-text}}
   {{#> button-icon}}
     <i class="fas fa-plus-circle" aria-hidden="true"></i>
   {{/button-icon}}

--- a/test-a11y/pf_a11y_violations.json
+++ b/test-a11y/pf_a11y_violations.json
@@ -1,0 +1,2016 @@
+[
+  {
+    "page": "/components/AboutModalBox/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Alert/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Avatar/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Backdrop/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/BackgroundImage/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Badge/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Brand/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Breadcrumb/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Button/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Card/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Check/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Content/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/DataList/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Dropdown/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Form/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/FormControl/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/InputGroup/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Label/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/List/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/LoginBox/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/ModalBox/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Nav/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Popover/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Progress/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Switch/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Table/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Title/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/components/Tooltip/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/demos/AboutModal/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/demos/BasicForms/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/demos/LoginPage/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/demos/Modal/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/demos/PageLayout/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/demos/Toolbar/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Bullseye/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Gallery/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Grid/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Level/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Login/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Page/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Split/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Stack/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/layouts/Toolbar/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/upgrade-examples/AlertUpgradeExamples/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/upgrade-examples/BadgeUpgradeExamples/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/upgrade-examples/CardUpgradeExamples/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/Accessibility/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/Alignment/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/BoxShadow/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/Display/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/Flex/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/Sizing/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  },
+  {
+    "page": "/utilities/Spacing/examples-full/",
+    "violations": [
+      {
+        "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+        "help": "Zooming and scaling must not be disabled",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.0/meta-viewport?application=webdriverjs",
+        "id": "meta-viewport",
+        "impact": "critical",
+        "nodes": [
+          {
+            "all": [],
+            "any": [
+              {
+                "data": null,
+                "id": "meta-viewport",
+                "impact": "critical",
+                "message": "<meta> tag disables zooming on mobile devices",
+                "relatedNodes": []
+              }
+            ],
+            "failureSummary": "Fix any of the following:\n  <meta> tag disables zooming on mobile devices",
+            "html": "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0,\n                                 maximum-scale=1.0, user-scalable=no\">",
+            "impact": "critical",
+            "none": [],
+            "target": [
+              "meta[name=\"viewport\"]"
+            ]
+          }
+        ],
+        "tags": [
+          "cat.sensory-and-visual-cues",
+          "wcag2aa",
+          "wcag144"
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
closes #2507 

@mcoker @mattnolting Instead of making a new class for the text inside of the link button, I just left it as a span. In a future breaking change release I was thinking that we could remove the class around the button, and have a class around the text instead, which can control the margin-left and margin-right. This way we only need one class, rather than two.