### PR TITLE
chore(fix): should not include "Main" property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "@patternfly/patternfly",
+  "name": "dd-patternfly",
   "description": "Assets, source, tooling, and content for PatternFly 4",
   "version": "0.0.0-development",
   "keywords": [],
   "license": "MIT",
-  "main": "n/a",
   "scripts": {
     "backstop:approve": "node test/approve-conflicts.js",
     "backstop:init": "node test/create-references.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dd-patternfly",
+  "name": "@patternfly/patternfly",
   "description": "Assets, source, tooling, and content for PatternFly 4",
   "version": "0.0.0-development",
   "keywords": [],


### PR DESCRIPTION
if we are not using 'Main' property asn entry point it should be removed, it is not a required property

In the case of the codesandbox it is causing the following error

"Error: Could not fetch dependencies, please try again in a couple seconds: Something went wrong while packaging the
dependency @patternfly/patternfly@2.43.1: ENOENT: no such file or directory, scandir '/tmp/960130286/node_modules/@patternfly/patternfly/n'"