### PR TITLE
fix(chip-group): fixed chip label overflow ellipsis

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -48,7 +48,6 @@
   .pf-c-chip-group__label {
     @include pf-text-overflow;
 
-    display: inline-flex;
     max-width: var(--pf-c-chip-group__label--Maxwidth);
     padding: var(--pf-c-chip-group__label--PaddingTop) var(--pf-c-chip-group__label--PaddingRight) var(--pf-c-chip-group__label--PaddingBottom) var(--pf-c-chip-group__label--PaddingLeft);
     font-size: var(--pf-c-chip-group__label--FontSize);


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2524

@matthewcarleton tagging you since you made this change in https://github.com/patternfly/patternfly-next/pull/1287. Here's the commit - https://github.com/patternfly/patternfly-next/pull/1287/commits/967855b2ba3545fc5ff2758137ddf453f1c8f16d

As far as I can tell, that isn't needed as we don't apply any flex properties to children in it. If it was to make it an inline element regardless the element used for the label, we could use `inline-block` instead.