### PR TITLE
fix(notification-drawer): fixed flex shorthand bug resulting in 0 height

### DIFF
--- a/src/patternfly/components/NotificationDrawer/notification-drawer.scss
+++ b/src/patternfly/components/NotificationDrawer/notification-drawer.scss
@@ -120,7 +120,7 @@
 }
 
 .pf-c-notification-drawer__body {
-  flex: 1 1 0;
+  flex: 1;
   overflow: auto;
   box-shadow: var(--pf-c-notification-drawer__body--ZIndex);
 }


### PR DESCRIPTION
fixes #2570