### PR TITLE
fix(card): add wrapper to img

### DIFF
--- a/src/patternfly/components/Card/card-head-main.hbs
+++ b/src/patternfly/components/Card/card-head-main.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-card__head-main{{#if card-head-main--modifier}} {{card-head-main--modifier}}{{/if}}"
+  {{#if card-head-main--attribute}}
+    {{{card-head-main--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Card/card-image.hbs
+++ b/src/patternfly/components/Card/card-image.hbs
@@ -1,6 +1,0 @@
-<div class="pf-c-card__main{{#if card-main--modifier}} {{card-main--modifier}}{{/if}}"
-  {{#if card-main--attribute}}
-    {{{card-main--attribute}}}
-  {{/if}}>
-  {{> @partial-block}}
-</div>

--- a/src/patternfly/components/Card/card-image.hbs
+++ b/src/patternfly/components/Card/card-image.hbs
@@ -1,6 +1,6 @@
-<div class="pf-c-card__image{{#if card-image--modifier}} {{card-image--modifier}}{{/if}}"
-  {{#if card-image--attribute}}
-    {{{card-image--attribute}}}
+<div class="pf-c-card__main{{#if card-main--modifier}} {{card-main--modifier}}{{/if}}"
+  {{#if card-main--attribute}}
+    {{{card-main--attribute}}}
   {{/if}}>
   {{> @partial-block}}
 </div>

--- a/src/patternfly/components/Card/card-image.hbs
+++ b/src/patternfly/components/Card/card-image.hbs
@@ -1,0 +1,6 @@
+<div class="pf-c-card__image{{#if card-image--modifier}} {{card-image--modifier}}{{/if}}"
+  {{#if card-image--attribute}}
+    {{{card-image--attribute}}}
+  {{/if}}>
+  {{> @partial-block}}
+</div>

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -22,9 +22,9 @@ cssPrefix: pf-c-card
 ```hbs title=With-image-and-action
 {{#> card card--id="card-action-example-1"}}
   {{#> card-head}}
-    {{#> card-image}}
+    {{#> card-main}}
       <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
-    {{/card-image}}
+    {{/card-main}}
     {{#> card-actions}}
       {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
       {{/dropdown}}
@@ -81,9 +81,9 @@ cssPrefix: pf-c-card
 ```hbs title=With-only-image-in-head
 {{#> card}}
   {{#> card-head}}
-    {{#> card-image}}
+    {{#> card-main}}
       <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
-    {{/card-image}}
+    {{/card-main}}
   {{/card-head}}
   {{#> card-header}}
     Header
@@ -241,6 +241,7 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
 | `.pf-c-card__head` | `<div>` | Creates the head of the card where images or actions can go. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
+| `.pf-c-card__main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
 | `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -22,9 +22,9 @@ cssPrefix: pf-c-card
 ```hbs title=With-image-and-action
 {{#> card card--id="card-action-example-1"}}
   {{#> card-head}}
-    {{#> card-main}}
+    {{#> card-head-main}}
       <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
-    {{/card-main}}
+    {{/card-head-main}}
     {{#> card-actions}}
       {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
       {{/dropdown}}
@@ -81,9 +81,9 @@ cssPrefix: pf-c-card
 ```hbs title=With-only-image-in-head
 {{#> card}}
   {{#> card-head}}
-    {{#> card-main}}
+    {{#> card-head-main}}
       <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
-    {{/card-main}}
+    {{/card-head-main}}
   {{/card-head}}
   {{#> card-header}}
     Header
@@ -241,7 +241,7 @@ A card is a generic rectangular container that can be used to build other compon
 | `.pf-c-card__footer` | `<div>` | Creates the footer of a card. |
 | `.pf-c-card__head` | `<div>` | Creates the head of the card where images or actions can go. |
 | `.pf-c-card__actions` | `<div>` | Creates an actions element to be used in the card head. |
-| `.pf-c-card__main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
+| `.pf-c-card__head-main` | `<div>` | Creates a wrapper element to be used in the card head when using an image, logo or text. |
 | `.pf-m-compact` | `.pf-c-card` | Creates a compact variation of the card component that involves smaller font sizes and spacing. |
 | `.pf-m-no-fill` | `.pf-c-card__body` | Sets a `.pf-c-card__body` to not fill the available space in `.pf-c-card`. `.pf-m-no-fill` can be added to multiple card bodies. |
 | `.pf-m-hoverable` | `.pf-c-card` | Modifies the card to include hover styles on `:hover`. |

--- a/src/patternfly/components/Card/examples/Card.md
+++ b/src/patternfly/components/Card/examples/Card.md
@@ -22,7 +22,9 @@ cssPrefix: pf-c-card
 ```hbs title=With-image-and-action
 {{#> card card--id="card-action-example-1"}}
   {{#> card-head}}
-    <span>img goes here</span>
+    {{#> card-image}}
+      <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
+    {{/card-image}}
     {{#> card-actions}}
       {{#> dropdown id=(concat card--id "-dropdown-kebab-right-aligned") dropdown--IsActionMenu="true" dropdown-toggle--modifier="pf-m-plain" dropdown--HasKebabIcon="true" aria-label="Actions"}}
       {{/dropdown}}
@@ -79,7 +81,9 @@ cssPrefix: pf-c-card
 ```hbs title=With-only-image-in-head
 {{#> card}}
   {{#> card-head}}
-    <span>img goes here</span>
+    {{#> card-image}}
+      <img src="/assets/images/pf_logo.svg" width="300px" alt="Logo">
+    {{/card-image}}
   {{/card-head}}
   {{#> card-header}}
     Header


### PR DESCRIPTION
closes #2562 

There may be a few solutions to this problem, I went with the solution of wrapping the image in its own container, because we don't know how the user will give it height/width. So even if width is added to the image in the html or the svg, it will still size proportionally down. But interested to hear what you guys think @mcoker @mattnolting 