### PR TITLE
fix(popover): matched min/max-width so popover has consistent width

### DIFF
--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -1,6 +1,6 @@
 .pf-c-popover {
   // Component
-  --pf-c-popover--MinWidth: calc(var(--pf-c-popover--c-button--sibling--PaddingRight) + #{pf-size-prem(100px)});
+  --pf-c-popover--MinWidth: calc(var(--pf-c-popover--c-button--sibling--PaddingRight) + #{pf-size-prem(300px)});
   --pf-c-popover--MaxWidth: calc(var(--pf-c-popover--c-button--sibling--PaddingRight) + #{pf-size-prem(300px)});
   --pf-c-popover--BoxShadow: var(--pf-global--BoxShadow--md);
 


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2632

@mceledonia can you confirm that you don't consider this a visual breaking change?