### PR TITLE
fix(inline-edit): hide groups by default

### DIFF
--- a/src/patternfly/components/InlineEdit/inline-edit.scss
+++ b/src/patternfly/components/InlineEdit/inline-edit.scss
@@ -74,6 +74,16 @@
 }
 
 // Editable
+.pf-c-inline-edit__group.pf-m-action-group {
+  display: none;
+  visibility: hidden;
+}
+
+.pf-m-inline-editable .pf-c-inline-edit__group {
+  display: flex;
+  visibility: visible;
+}
+
 .pf-c-inline-edit.pf-m-inline-editable,
 .pf-c-inline-edit .pf-m-inline-editable {
   // Expose inputs, input groups, actions and action groups


### PR DESCRIPTION
This PR makes a small change to the inline edit styles, to hide groups by default and then assign display once the activator class (pf-m-inline-editable) is present. This fixes a problem in Firefox where the group container reserves space even when all of its children are hidden, forcing it out of alignment with surrounding elements in table.