### PR TITLE
fix(background-image): removed empty width attribute

### DIFF
--- a/src/patternfly/components/BackgroundImage/background-image.hbs
+++ b/src/patternfly/components/BackgroundImage/background-image.hbs
@@ -4,7 +4,7 @@
   {{/if}}>
   {{> @partial-block}}
   <svg xmlns="http://www.w3.org/2000/svg" class="pf-c-background-image__filter" width="0" height="0">
-  <filter id="image_overlay" width="">
+  <filter id="image_overlay">
     <feColorMatrix type="matrix"
       values="1 0 0 0 0
               1 0 0 0 0


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-next/issues/2738

note - there is a bug in safari where relative paths to files in `url()` that are used in a custom property aren't evaluated correctly. To get around that, just take whatever the `url()` is in the custom property value and assign it directly to `background-image` in the CSS (you can do it in dev tools).

So for the background-image component, get the value of `--pf-c-background-image--BackgroundImage--lg` (or whatever image path you want to test) and assign that value directly to the `.pf-c-babckground-image::before` element's `background-image` property.