### PR TITLE
fix(popover): reduced space between/around elements

### DIFF
--- a/src/patternfly/components/Popover/examples/Popover.md
+++ b/src/patternfly/components/Popover/examples/Popover.md
@@ -11,7 +11,7 @@ cssPrefix: pf-c-popover
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
-    {{#> title titleType="h1" title--modifier="pf-m-xl" title--attribute='id="popover-top-header"'}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-top-header"'}}
       Popover header
     {{/title}}
     {{#> popover-body popover-body--attribute='id="popover-top-body"'}}
@@ -30,7 +30,7 @@ cssPrefix: pf-c-popover
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
-    {{#> title titleType="h1" title--modifier="pf-m-xl" title--attribute='id="popover-right-header"'}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-right-header"'}}
       Popover header
     {{/title}}
     {{#> popover-body popover-body--attribute='id="popover-right-body"'}}
@@ -49,7 +49,7 @@ cssPrefix: pf-c-popover
       {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
         <i class="fas fa-times" aria-hidden="true"></i>
       {{/button}}
-      {{#> title titleType="h1" title--modifier="pf-m-xl" title--attribute='id="popover-bottom-header"'}}
+      {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-bottom-header"'}}
         Popover header
       {{/title}}
     {{#> popover-body popover-body--attribute='id="popover-bottom-body"'}}
@@ -68,7 +68,7 @@ cssPrefix: pf-c-popover
     {{#> button button--modifier="pf-m-plain" button--attribute='aria-label="Close"'}}
       <i class="fas fa-times" aria-hidden="true"></i>
     {{/button}}
-    {{#> title titleType="h1" title--modifier="pf-m-xl" title--attribute='id="popover-left-header"'}}
+    {{#> title titleType="h1" title--modifier="pf-m-md" title--attribute='id="popover-left-header"'}}
         Popover header
     {{/title}}
     {{#> popover-body popover-body--attribute='id="popover-left-body"'}}
@@ -93,7 +93,7 @@ cssPrefix: pf-c-popover
   {{/popover-content}}
 {{/popover}}
 ```
-      
+
 ## Documentation
 ### Overview
 A popover is used to provide contextual information for another component on click.  The popover itself is made up of two main elements: arrow and content. The content element follows the pattern of the popover box component, with a close icon in the top right corner, as well as a header and body.  One of the directional modifiers (`.pf-m-left`, `.pf-m-top`, etc.) is required on the popover component
@@ -122,4 +122,4 @@ A popover is used to provide contextual information for another component on cli
 | `.pf-m-left` | `.pf-c-popover` | Positions the popover to the left of the element. |
 | `.pf-m-right` | `.pf-c-popover` | Positions the popover to the right of the element. |
 | `.pf-m-top` | `.pf-c-popover` | Positions the popover to the top of the element. |
-| `.pf-m-bottom` | `.pf-c-popover` | Positions the popover to the bottom of the element. | 
+| `.pf-m-bottom` | `.pf-c-popover` | Positions the popover to the bottom of the element. |

--- a/src/patternfly/components/Popover/popover-header.hbs
+++ b/src/patternfly/components/Popover/popover-header.hbs
@@ -1,6 +1,6 @@
 <header class="pf-c-popover__header{{#if popover-header--modifier}} {{popover-header--modifier}}{{/if}}"
   {{#if popover-header--attribute}}
-    {{{popover-header--attribute}}} 
+    {{{popover-header--attribute}}}
   {{/if}}>
   {{> @partial-block}}
 </header>

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -1,15 +1,15 @@
 .pf-c-popover {
   // Component
-  --pf-c-popover--MinWidth: calc(var(--pf-c-popover--c-button--sibling--PaddingRight) + #{pf-size-prem(300px)});
-  --pf-c-popover--MaxWidth: calc(var(--pf-c-popover--c-button--sibling--PaddingRight) + #{pf-size-prem(300px)});
+  --pf-c-popover--MinWidth: calc(var(--pf-c-popover__content--PaddingLeft) + var(--pf-c-popover__content--PaddingRight) + #{pf-size-prem(300px)});
+  --pf-c-popover--MaxWidth: calc(var(--pf-c-popover__content--PaddingLeft) + var(--pf-c-popover__content--PaddingRight) + #{pf-size-prem(300px)});
   --pf-c-popover--BoxShadow: var(--pf-global--BoxShadow--md);
 
   // Content
   --pf-c-popover__content--BackgroundColor: var(--pf-global--BackgroundColor--100);
-  --pf-c-popover__content--PaddingTop: var(--pf-global--spacer--xl);
-  --pf-c-popover__content--PaddingRight: var(--pf-global--spacer--xl);
-  --pf-c-popover__content--PaddingBottom: var(--pf-global--spacer--xl);
-  --pf-c-popover__content--PaddingLeft: var(--pf-global--spacer--xl);
+  --pf-c-popover__content--PaddingTop: var(--pf-global--spacer--md);
+  --pf-c-popover__content--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-popover__content--PaddingBottom: var(--pf-global--spacer--md);
+  --pf-c-popover__content--PaddingLeft: var(--pf-global--spacer--md);
 
   // Arrow
   --pf-c-popover__arrow--Width: var(--pf-global--arrow--width-lg);
@@ -25,10 +25,10 @@
   --pf-c-popover--c-button--MarginLeft: var(--pf-global--spacer--sm);
   --pf-c-popover--c-button--Top: calc(var(--pf-c-popover__content--PaddingTop) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
   --pf-c-popover--c-button--Right: var(--pf-global--spacer--md);
-  --pf-c-popover--c-button--sibling--PaddingRight: var(--pf-global--spacer--xl);
+  --pf-c-popover--c-button--sibling--PaddingRight: var(--pf-global--spacer--2xl);
 
   // Header
-  --pf-c-popover--c-title--MarginBottom: var(--pf-global--spacer--md);
+  --pf-c-popover--c-title--MarginBottom: var(--pf-global--spacer--sm);
 
   // Footer
   --pf-c-popover__footer--MarginTop: var(--pf-global--spacer--lg);

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -32,7 +32,7 @@
   --pf-c-popover--c-title--MarginBottom: var(--pf-global--spacer--sm);
 
   // Footer
-  --pf-c-popover__footer--MarginTop: var(--pf-global--spacer--lg);
+  --pf-c-popover__footer--MarginTop: var(--pf-global--spacer--md);
 
   position: relative;
   min-width: var(--pf-c-popover--MinWidth);

--- a/src/patternfly/components/Popover/popover.scss
+++ b/src/patternfly/components/Popover/popover.scss
@@ -1,5 +1,6 @@
 .pf-c-popover {
   // Component
+  --pf-c-popover--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-popover--MinWidth: calc(var(--pf-c-popover__content--PaddingLeft) + var(--pf-c-popover__content--PaddingRight) + #{pf-size-prem(300px)});
   --pf-c-popover--MaxWidth: calc(var(--pf-c-popover__content--PaddingLeft) + var(--pf-c-popover__content--PaddingRight) + #{pf-size-prem(300px)});
   --pf-c-popover--BoxShadow: var(--pf-global--BoxShadow--md);
@@ -23,7 +24,7 @@
 
   // Close
   --pf-c-popover--c-button--MarginLeft: var(--pf-global--spacer--sm);
-  --pf-c-popover--c-button--Top: calc(var(--pf-c-popover__content--PaddingTop) - var(--pf-global--spacer--form-element) + #{pf-size-prem(1px)}); // align top of button with top of text
+  --pf-c-popover--c-button--Top: calc(var(--pf-c-popover__content--PaddingTop) - var(--pf-global--spacer--form-element)); // align top of button with top of text
   --pf-c-popover--c-button--Right: var(--pf-global--spacer--md);
   --pf-c-popover--c-button--sibling--PaddingRight: var(--pf-global--spacer--2xl);
 
@@ -36,6 +37,7 @@
   position: relative;
   min-width: var(--pf-c-popover--MinWidth);
   max-width: var(--pf-c-popover--MaxWidth);
+  font-size: var(--pf-c-popover--FontSize);
   box-shadow: var(--pf-c-popover--BoxShadow);
 
   &.pf-m-top {


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-next/issues/2653. This is a breaking change so shouldn't be merged to master.

## Breaking changes
* Space around popover changed from `--pf-global--spacer--xl` to `--pf-global--spacer--md`
* Increased right padding of element displayed to the left of the close button to make more room for the close button. That padding changed from `--pf-global--spacer--xl` to `--pf-global--spacer--2xl`
* Title component size changes from `pf-m-xl` to `pf-m-md`
* Popover's `font-size` changed to `--pf-global--FontSize--sm`
* Space below title changed from `--pf-global--spacer--md` to `--pf-global--spacer--sm`
* Space above footer changed from `--pf-global--spacer--lg` to `--pf-global--spacer--md`