### PR TITLE
fix(tooltip): reduced space around component

### DIFF
--- a/src/patternfly/components/Tooltip/tooltip.scss
+++ b/src/patternfly/components/Tooltip/tooltip.scss
@@ -3,10 +3,10 @@
   --pf-c-tooltip--MaxWidth: #{pf-size-prem(300px)};
 
   // Content variables
-  --pf-c-tooltip__content--PaddingTop: var(--pf-global--spacer--md);
-  --pf-c-tooltip__content--PaddingRight: var(--pf-global--spacer--lg);
-  --pf-c-tooltip__content--PaddingBottom: var(--pf-global--spacer--md);
-  --pf-c-tooltip__content--PaddingLeft: var(--pf-global--spacer--lg);
+  --pf-c-tooltip__content--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-tooltip__content--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-tooltip__content--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-tooltip__content--PaddingLeft: var(--pf-global--spacer--md);
   --pf-c-tooltip__content--Color: var(--pf-global--Color--light-100);
   --pf-c-tooltip__content--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
   --pf-c-tooltip__content--FontSize: var(--pf-global--FontSize--sm);


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-next/issues/2653. Breaking change, don't merge to master. 

## Breaking changes
* Reduces spacers around tooltip