### PR TITLE
fix(fileupload): change border for drag hover outside of psuedo selector

### DIFF
--- a/src/patternfly/components/FileUpload/file-upload.scss
+++ b/src/patternfly/components/FileUpload/file-upload.scss
@@ -6,8 +6,8 @@
   --pf-c-file-upload--m-loading__file-details--before--Bottom: var(--pf-global--BorderWidth--sm);
 
   // pf-m-drag-hover
-  --pf-c-file-upload--m-drag-hover--after--BorderWidth: var(--pf-global--BorderWidth--sm);
-  --pf-c-file-upload--m-drag-hover--after--BorderColor: var(--pf-global--primary-color--100);
+  --pf-c-file-upload--m-drag-hover--BorderWidth: var(--pf-global--BorderWidth--sm);
+  --pf-c-file-upload--m-drag-hover--BorderColor: var(--pf-global--primary-color--100);
   --pf-c-file-upload--m-drag-hover--after--BackgroundColor: var(--pf-global--primary-color--100);
   --pf-c-file-upload--m-drag-hover--after--Opacity: .1;
 
@@ -34,6 +34,7 @@
 
   &.pf-m-drag-hover {
     position: relative;
+    border: var(--pf-c-file-upload--m-drag-hover--BorderWidth) solid var(--pf-c-file-upload--m-drag-hover--BorderColor);
 
     &::after {
       position: absolute;
@@ -43,7 +44,6 @@
       left: 0;
       content: "";
       background-color: var(--pf-c-file-upload--m-drag-hover--after--BackgroundColor);
-      border: var(--pf-c-file-upload--m-drag-hover--after--BorderWidth) solid var(--pf-c-file-upload--m-drag-hover--after--BorderColor);
       opacity: var(--pf-c-file-upload--m-drag-hover--after--Opacity);
     }
   }


### PR DESCRIPTION
fixes `.pf-c-file-upload.p-m-drag-hover` so that the border is set on that class rather than the `::after` pseudo selector as that also has opacity of 0.1 set on it, which was affecting the opacity of the border.