### PR TITLE
feat(nothing): try a minor version bump

### DIFF
--- a/.circleci/upload-preview.js
+++ b/.circleci/upload-preview.js
@@ -6,7 +6,7 @@ const surge = require('surge');
 const publishFn = surge().publish();
 
 const owner = process.env.CIRCLE_PROJECT_USERNAME; // patternfly
-const repo = process.env.CIRCLE_PROJECT_REPONAME;
+const repo = process.env.CIRCLE_PROJECT_REPONAME; // patternfly-next
 const prnum = process.env.CIRCLE_PR_NUMBER;
 const prbranch = process.env.CIRCLE_BRANCH;
 


### PR DESCRIPTION
I think this will fix releasing on master. Git tags `2.66.1`, `2.66.2`, and `2.66.3` were accidentally published, so hopefully this will fix that? I'm not sure why semantic-release is not picking those up.