### PR TITLE
fix(drawer-panel-tab-focus): added mixin to handle tab focus

### DIFF
--- a/src/patternfly/components/Drawer/drawer.scss
+++ b/src/patternfly/components/Drawer/drawer.scss
@@ -415,3 +415,6 @@ $pf-c-drawer__panel--list--width: (25, 33, 50, 66, 75, 100);
     }
   }
 }
+
+// Include this at EOF to overwrite any previous
+@include pf-hide-tab-focus(".pf-c-drawer__panel");

--- a/src/patternfly/sass-utilities/mixins.scss
+++ b/src/patternfly/sass-utilities/mixins.scss
@@ -192,3 +192,20 @@
     #{$value}: #{$prop};
   }
 }
+
+@mixin pf-hide-tab-focus($element: &, $duration: ".3s") {
+  $element: #{$element}#{"[hidden]"};
+
+  @keyframes out {
+    to {
+      display: none;
+      visibility: hidden;
+    }
+  }
+
+  #{$element} {
+    animation-name: out;
+    animation-delay: #{$duration};
+    animation-fill-mode: forwards;
+  }
+}


### PR DESCRIPTION
closes #2811 