### PR TITLE
fix(chipgroup): modify max width for chip label

### DIFF
--- a/src/patternfly/components/ChipGroup/chip-group.scss
+++ b/src/patternfly/components/ChipGroup/chip-group.scss
@@ -17,7 +17,7 @@
   --pf-c-chip-group__label--PaddingBottom: var(--pf-global--spacer--xs);
   --pf-c-chip-group__label--PaddingLeft: 0;
   --pf-c-chip-group__label--FontSize: var(--pf-global--FontSize--sm);
-  --pf-c-chip-group__label--Maxwidth: #{pf-size-prem(120px)};
+  --pf-c-chip-group__label--Maxwidth: #{pf-size-prem(160px)};
 
   // Chip
   --pf-c-chip-group--c-chip--MarginRight: var(--pf-global--spacer--xs);


### PR DESCRIPTION
fixes #2765 

## Breaking changes
1. Changed max-width for `--pf-c-chip-group__label--Maxwidth` to 160px