### PR TITLE
chore(v4): prevent merging in github from triggering release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,4 +133,4 @@ jobs:
         command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
     - run:
         name: Release to NPM
-        command: npx semantic-release@17.0.4
+        command: if [[ -z $CIRCLE_PULL_REQUEST ]]; then npx semantic-release@17.0.4; fi;


### PR DESCRIPTION
Patch CircleCI so when doing this merging `master` into `v4` in Github in the future it won't trigger a release of `v4` to NPM...

Parity to https://github.com/patternfly/patternfly-react/pull/3921